### PR TITLE
removed unnecessary init methods. Everything in them moved to constructors

### DIFF
--- a/src/Models/ConverterModel.cpp
+++ b/src/Models/ConverterModel.cpp
@@ -5,7 +5,6 @@
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ConverterModel::ConverterModel() {
-  init();
   setModelType("Converter");
 }
 

--- a/src/Models/ConverterModel.h
+++ b/src/Models/ConverterModel.h
@@ -58,12 +58,6 @@ class ConverterModel : public Model {
   virtual ~ConverterModel() {};
 
   /**
-     Initalize members of ConverterModel and any other non-input
-     related parameters
-   */
-  void init() {};
-
-  /**
      A method to initialize the model 
       
      @param cur the pointer to the xml input for the model to initialize 

--- a/src/Models/Facility/BatchReactor/BatchReactor.cpp
+++ b/src/Models/Facility/BatchReactor/BatchReactor.cpp
@@ -23,11 +23,6 @@ using namespace std;
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -    
 BatchReactor::BatchReactor() {
-  init();
-}
-
-//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -    
-void BatchReactor::init() { 
   preCore_.makeUnlimited();
   inCore_.makeUnlimited();
   postCore_.makeUnlimited();

--- a/src/Models/Facility/BatchReactor/BatchReactor.h
+++ b/src/Models/Facility/BatchReactor/BatchReactor.h
@@ -44,11 +44,6 @@ class BatchReactor : public FacilityModel  {
   virtual ~BatchReactor() {};
 
   /**
-     Initialize all members during construction
-   */
-  void init();
-    
-  /**
      initialize an object from XML input 
    */
   virtual void init(xmlNodePtr cur);

--- a/src/Models/FacilityModel.cpp
+++ b/src/Models/FacilityModel.cpp
@@ -12,7 +12,6 @@
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 FacilityModel::FacilityModel() {
-  init();
   setModelType("Facility");
 };
 

--- a/src/Models/FacilityModel.h
+++ b/src/Models/FacilityModel.h
@@ -74,12 +74,6 @@ class FacilityModel : public TimeAgent, public Communicator {
   FacilityModel();
   
   virtual ~FacilityModel();
-  
-  /**
-     Initalize members of FacilityModel and any other non-input
-     related parameters
-   */
-  void init() {};
 
   /**
      Initalize the FacilityModel from xml. Calls the init function. 

--- a/src/Models/Inst/BuildInst/BuildInst.cpp
+++ b/src/Models/Inst/BuildInst/BuildInst.cpp
@@ -16,7 +16,7 @@
 using namespace std;
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-void BuildInst::init() {
+BuildInst::BuildInst() {
   totalBuildCount_ = 0;
 }
 

--- a/src/Models/Inst/BuildInst/BuildInst.h
+++ b/src/Models/Inst/BuildInst/BuildInst.h
@@ -49,18 +49,12 @@ public:
   /**
      Default constructor for the build inst 
    */
-  BuildInst() { init(); }
+  BuildInst();
     
   /**
      Default destructor for the build inst 
    */
   virtual ~BuildInst() {};
-  
-  /**
-     Initalize members of BuildInst and any other non-input
-     related parameters
-   */
-  void init();
   
   /**
      Initalize the BuildInst from xml. Calls the init function. 

--- a/src/Models/InstModel.cpp
+++ b/src/Models/InstModel.cpp
@@ -17,20 +17,12 @@ using namespace std;
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -    
 InstModel::InstModel() {
-  init();
   setModelType("Inst");
-}
-
-//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -    
-void InstModel::init() {
   prototypes_ = new PrototypeSet();
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -    
 void InstModel::init(xmlNodePtr cur) {
-  // non xml inits
-  InstModel::init();
-  // xml inits
   Model::init(cur);
 }
 

--- a/src/Models/InstModel.h
+++ b/src/Models/InstModel.h
@@ -62,12 +62,6 @@ class InstModel : public TimeAgent, public Communicator {
   virtual ~InstModel() {};
       
   /**
-     Initalize members of InstModel and any other non-input
-     related parameters
-   */
-  void init();
-
-  /**
      Initalize the InstModel from xml. Calls the init function. 
      
      @param cur the current xml node pointer 

--- a/src/Models/MarketModel.cpp
+++ b/src/Models/MarketModel.cpp
@@ -16,7 +16,6 @@ list<MarketModel*> MarketModel::markets_;
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -    
 MarketModel::MarketModel() {
-  init();
   setModelType("Market"); 
 }
 

--- a/src/Models/MarketModel.h
+++ b/src/Models/MarketModel.h
@@ -73,12 +73,6 @@ class MarketModel : public Model, public Communicator {
   static MarketModel* marketForCommod(std::string commod);
 
   /**
-     Initalize members of MarketModel and any other non-input
-     related parameters
-   */
-  void init() {};
-
-  /**
      set the parameters necessary for MarketModel to interact
      with the simulation
      

--- a/src/Models/Model.cpp
+++ b/src/Models/Model.cpp
@@ -206,7 +206,6 @@ void Model::copy(Model* model_orig) {
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Model::Model() {
-  Model::init();
   ID_ = next_id_++;
   is_template_ = true;
   born_ = false;

--- a/src/Models/Model.h
+++ b/src/Models/Model.h
@@ -115,12 +115,6 @@ class Model {
   Model();
 
   /**
-     Initalize members of Model and any other non-input
-     related parameters
-   */
-  void init() {};
-
-  /**
      A method to initialize the model 
       
      @param cur the pointer to the xml input for the model to initialize 

--- a/src/Models/Region/BuildRegion/BuildRegion.cpp
+++ b/src/Models/Region/BuildRegion/BuildRegion.cpp
@@ -19,6 +19,7 @@ using namespace std;
  * Comparison Functors
  * --------------------
  */
+
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 bool compare_order_times(PrototypeBuildOrder* o1, PrototypeBuildOrder* o2) {
   return (o1->first < o2->first); // sort by time
@@ -32,7 +33,7 @@ bool compare_order_times(PrototypeBuildOrder* o1, PrototypeBuildOrder* o2) {
  * --------------------
  */
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-void BuildRegion::init() {
+BuildRegion::BuildRegion() {
   prototypeOrders_ = new PrototypeOrders();
   builders_ = new map<Model*, std::list<Model*>*>();
 }

--- a/src/Models/Region/BuildRegion/BuildRegion.h
+++ b/src/Models/Region/BuildRegion/BuildRegion.h
@@ -109,19 +109,13 @@ class BuildRegion : public RegionModel
   /**
      The default constructor for the BuildRegion 
    */
-  BuildRegion() { init(); }
+  BuildRegion();
 
   /**
      The default destructor for the BuildRegion 
    */
   virtual ~BuildRegion() {};
 
-  /**
-     Initalize members of BuildRegion and any other non-input
-     related parameters
-   */
-  void init();
-   
   /**
      Initalize the BuildRegion from xml. Calls the init function. 
      

--- a/src/Models/RegionModel.cpp
+++ b/src/Models/RegionModel.cpp
@@ -16,7 +16,6 @@ using namespace std;
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 RegionModel::RegionModel() { 
-  init();
   setModelType("Region");
 }
 

--- a/src/Models/RegionModel.h
+++ b/src/Models/RegionModel.h
@@ -77,12 +77,6 @@ class RegionModel : public TimeAgent, public Communicator {
   virtual ~RegionModel() {};
     
   /**
-     Initalize members of RegionModel and any other non-input
-     related parameters
-   */
-  void init() {};
-
-  /**
      Initalize the InstModel from xml. Calls the init function. 
      
      @param cur the current xml node pointer 

--- a/src/Models/StubCommModel.h
+++ b/src/Models/StubCommModel.h
@@ -36,12 +36,6 @@ class StubCommModel : public Model, public Communicator {
   virtual ~StubCommModel();
 
   /**
-     Initalize members of StubCommModel and any other non-input
-     related parameters
-   */
-  void init() { Model::init(); }
-    
-  /**
      every model needs a method to initialize from XML 
       
      @param cur is the pointer to the model's xml node 

--- a/src/Models/StubModel.h
+++ b/src/Models/StubModel.h
@@ -37,12 +37,6 @@ class StubModel : public Model {
   virtual ~StubModel();
 
   /**
-     Initalize members of StubModel and any other non-input
-     related parameters
-   */
-  void init() { Model::init(); }
-
-  /**
      every model needs a method to initialize from XML 
       
      @param cur is the pointer to the model's xml node 

--- a/src/Models/StubTimeAgent.h
+++ b/src/Models/StubTimeAgent.h
@@ -36,12 +36,6 @@ class StubTimeAgent : public TimeAgent {
   virtual ~StubTimeAgent();
 
   /**
-     Initalize members of StubTimeAgent and any other non-input
-     related parameters
-   */
-  void init() { Model::init(); }
-    
-  /**
      every model needs a method to initialize from XML 
       
      @param cur is the pointer to the model's xml node 

--- a/src/Testing/ConverterModelTests.h
+++ b/src/Testing/ConverterModelTests.h
@@ -19,7 +19,6 @@ class ConverterModelTests : public TestWithParam<ConverterModelConstructor*> {
   public:
     virtual void SetUp() { 
       converter_model_ = (*GetParam())();
-      converter_model_->init();
     }
     virtual void TearDown(){ 
       delete converter_model_;

--- a/src/Testing/FacilityModelTests.h
+++ b/src/Testing/FacilityModelTests.h
@@ -21,7 +21,6 @@ class FacilityModelTests : public TestWithParam<FacilityModelConstructor*> {
  public:
   virtual void SetUp() { 
     facility_model_ = (*GetParam())();
-    facility_model_->init();
     test_inst_ = new TestInst();
     facility_model_->setParent(test_inst_);
     test_out_market_ = new TestMarket("out-commod");

--- a/src/Testing/InstModelTests.h
+++ b/src/Testing/InstModelTests.h
@@ -39,7 +39,6 @@ class InstModelTests : public TestWithParam<InstModelConstructor*> {
  public:
   virtual void SetUp() { 
     inst_model_ = new FakeInstModel();
-    inst_model_->init();
     test_facility_ = new TestFacility();
     test_region_ = new TestRegion();
     inst_model_->setParent(test_region_);

--- a/src/Testing/MarketModelTests.h
+++ b/src/Testing/MarketModelTests.h
@@ -21,7 +21,6 @@ class MarketModelTests : public TestWithParam<MarketModelConstructor*> {
   public:
     virtual void SetUp() { 
       market_model_ = (*GetParam())();
-      market_model_->init();
     }
     virtual void TearDown(){ 
       delete market_model_;

--- a/src/Testing/ModelTests.h
+++ b/src/Testing/ModelTests.h
@@ -19,7 +19,6 @@ class ModelTests : public TestWithParam<ModelConstructor*> {
   public:
     virtual void SetUp() { 
       model_ = (*GetParam())();
-      model_->init();
     }
     virtual void TearDown(){ 
       delete model_;

--- a/src/Testing/RegionModelTests.h
+++ b/src/Testing/RegionModelTests.h
@@ -20,7 +20,6 @@ class RegionModelTests : public TestWithParam<RegionModelConstructor*> {
   public:
     virtual void SetUp() { 
       region_model_ = (*GetParam())();
-      region_model_->init();
     }
     virtual void TearDown(){ 
       delete region_model_;

--- a/src/Testing/StubModelTests.h
+++ b/src/Testing/StubModelTests.h
@@ -19,7 +19,6 @@ class StubModelTests : public TestWithParam<StubModelConstructor*> {
   public:
     virtual void SetUp() { 
       stub_model_ = (*GetParam())();
-      stub_model_->init();
     }
     virtual void TearDown(){ 
       delete stub_model_;

--- a/src/Testing/TestMarket.h
+++ b/src/Testing/TestMarket.h
@@ -18,7 +18,6 @@ class TestMarket : public MarketModel {
     }
     virtual void copy(TestMarket* src){
       commodity_ = src->commodity_;
-      MarketModel::init();
     }
     void copyFreshModel(Model* src){
       copy(dynamic_cast<TestMarket*>(src));


### PR DESCRIPTION
This simplifies the public interface of models and should help to make the initialization phase easier to understand.  If specialized initialization is required (e.g. for testing), public getters and setters should be used.  Addresses #102.  
