### PR TITLE
Issue 116

### DIFF
--- a/src/App.cpp
+++ b/src/App.cpp
@@ -96,7 +96,7 @@ int main(int argc, char* argv[]) {
     BI->createDB();
   } catch (CycException ge) {
     CLOG(LEV_ERROR) << ge.what();
-  };
+  }
 
   // read input file and setup simulation
   try {
@@ -104,7 +104,9 @@ int main(int argc, char* argv[]) {
   } catch (CycIOException ge) {
     CLOG(LEV_ERROR) << ge.what();
     return 0;
-  };
+  } catch (CycException e) {
+    CLOG(LEV_ERROR) << e.what();
+  }
 
   Model::printModelList();
   IsoVector::printRecipes();
@@ -121,7 +123,7 @@ int main(int argc, char* argv[]) {
     BI->closeDB();
   } catch (CycException ge) {
     CLOG(LEV_ERROR) << ge.what();
-  };
+  }
 
   return 0;
 }


### PR DESCRIPTION
This adds another catch statement that catchs any type of CycException that is raised during file loading. CycIOExceptions are not the only kind that can be raised. In issue #116, I didn't notice that this step was only catching CycIOExceptions (the name is too similar looking to CycException, and I missed it visually). This fixes #116 .
