### PR TITLE
Fixes null simulation ERROR logs caused by null facility

### DIFF
--- a/src/Models/Facility/NullFacility/NullFacility.cpp
+++ b/src/Models/Facility/NullFacility/NullFacility.cpp
@@ -171,6 +171,10 @@ void NullFacility::makeOffers() {
     offer_amt = inventory_.capacity(); 
   }
 
+  if (offer_amt < EPS_KG) {
+    return;
+  }
+
   // there is no minimum amount a null facility may send
   double min_amt = 0;
   // and it's free


### PR DESCRIPTION
Null facility was generating offers of quantity 0 when its stocks+inventory were empty.  Naughy NullFacility.  Simple fix.  Fixes #117.
