### PR TITLE
Adds a script that runs all xml files in the input directory

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,7 +51,7 @@ COPYONLY
 
 set(input_path ${CYCLUS_SOURCE_DIR}/../input)
 set(cyclus_path ${CMAKE_CURRENT_BINARY_DIR})
-CONFIGURE_FILE(${CYCLUS_SRC_DIR}/Config/run_all_inputs.py.in ${PROJECT_BINARY_DIR}/Testing/run_all_inputs.py @ONLY)
+CONFIGURE_FILE(${CYCLUS_SRC_DIR}/Config/run_inputs.py.in ${PROJECT_BINARY_DIR}/Testing/run_inputs.py @ONLY)
 
 
 # ----- Cyclus Unit Test Driver ------

--- a/src/Config/run_inputs.py.in
+++ b/src/Config/run_inputs.py.in
@@ -38,7 +38,7 @@ def check_inputs():
 
 def print_usage() :
     """This prints the proper way to treat the command line interface"""
-    print 'Usage: python run_all_inputs.py\n' + \
+    print 'Usage: python run_inputs.py\n' + \
             'Allowed Options : \n' + \
             '-v arg                    output log verbosity. \n' + \
             '                    \


### PR DESCRIPTION
This is a python script which is configured during the configure step to update the paths to your cyclus executable directory and your input directory. It is placed in the build directory under Testing, the same directory as the CyclusUnitTestDriver. You can run the python script from anywhere, and it accepts a verbosity variable, just like cyclus.

When you run this python script, it searches through the directory tree of the input directory (one level above the cyclus source directory) and finds all xml files. If the file is a recipebook or a facilitycatalog, it is copied into the executable directory, to be cleaned up later. Otherwise, it is assumed to be an input file and runs that file.

If during the run it encounters an ERROR message, a Segmentation fault, or a missing file, the full output from that run will be printed to the screen and summarized as a failure at the end of the script run.

You may need to do a clean build and reconfigure. 

```
Usage: python run_all_inputs.py
Allowed Options : 
-v arg                    output log verbosity. 
                                Can be text: 
                                  LEV_ERROR (least verbose, default), LEV_WARN,
                                  LEV_INFO1 (through 5), and LEV_DEBUG1 (through 5).
                                Or an integer:
                                  0 (LEV_ERROR equiv) through 11 (LEV_DEBUG5 equiv)
```

Please note that this is intended to fix #118 .
