### PR TITLE
Remove human-modified date stamp from README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,6 @@ _______________________________________________________________________
 Cyclus Core
 _______________________________________________________________________
 
-**Last Updated: 2.28.2012**
-
 The core of the Cyclus nuclear fuel cycle simulator from the University of 
 Wisconsin - Madison is intended to be a simulation framework upon which to 
 develop innovative fuel cycle simulations. 


### PR DESCRIPTION
It doesn't make sense to have a human-modified date stamp in a
revision controlled file when the primary modes for viewing that file
(cli & github) already give ready access to change date.
