### PR TITLE
removed checkQuantity, checkQuantityGT, and checkEquality methods

### DIFF
--- a/src/Resources/GenericResource.cpp
+++ b/src/Resources/GenericResource.cpp
@@ -52,22 +52,6 @@ bool GenericResource::checkQuality(rsrc_ptr other){
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-bool GenericResource::checkQuantityEqual(rsrc_ptr other) {
-  // KDHFLAG : Should allow epsilon as a parameter to this function?
-  bool toRet;
-  toRet =( checkQuality(other) && quantity_ == other->quantity());
-  return toRet;
-}
-
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-bool GenericResource::checkQuantityGT(rsrc_ptr other) {
-  // KDHFLAG : Should allow epsilon as a parameter to this function?
-  bool toRet;
-  toRet = ( checkQuality(other) && quantity_ < other->quantity());
-  return toRet;
-}
-
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 void GenericResource::absorb(gen_rsrc_ptr other) {
   if (! checkQuality(boost::dynamic_pointer_cast<Resource>(other))) {
     throw CycGenResourceIncompatible("incompatible resource types.");

--- a/src/Resources/GenericResource.h
+++ b/src/Resources/GenericResource.h
@@ -95,28 +95,6 @@ public:
   void setQuality(std::string new_quality) {quality_ = new_quality;};
     
   /**
-     A boolean comparing the quantity of the other resource is 
-     to the quantity of the base 
-      
-     @param other The resource to evaluate against the base 
-      
-     @return True if other is sufficiently equal in quantity to 
-     the base, False otherwise. 
-   */
-  virtual bool checkQuantityEqual(rsrc_ptr other);
-
-  /**
-     Returns true if the quantity of the other resource is 
-     greater than the quantity of the base 
-      
-     @param second The resource to evaluate against the base 
-      
-     @return True if second is sufficiently equal in quantity to 
-     first, False otherwise. 
-   */
-  virtual bool checkQuantityGT(rsrc_ptr second);
-
-  /**
      Returns the concrete type of this resource 
    */ 
   virtual ResourceType type(){return GENERIC_RES;};

--- a/src/Resources/Material.cpp
+++ b/src/Resources/Material.cpp
@@ -154,41 +154,6 @@ bool Material::checkQuality(rsrc_ptr other){
   return toRet;
 }
 
-//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -    
-bool Material::checkQuantityEqual(rsrc_ptr other) {
-  // This will be false until proven true
-  bool toRet = false;
-
-  // Make sure the other is a material
-  try{
-    // check mass values
-    double second_qty = boost::dynamic_pointer_cast<Material>(other)->quantity();
-    toRet=( abs(quantity() - second_qty) < EPS_KG);
-  } catch (exception e) { }
-  return toRet;
-}
-
-//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -    
-bool Material::checkQuantityGT(rsrc_ptr other){
-  // true if the total atoms in the other is greater than in the base.
-  // This will be true until proven false
-  bool toRet = false;
-
-  // Make sure the other is a material
-  try{
-    // check mass values
-    double second_qty = boost::dynamic_pointer_cast<Material>(other)->quantity();
-    toRet = second_qty - quantity() > EPS_KG;
-  } catch (exception& e){ }
-
-  return toRet;
-}
-
-//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-double Material::mass(Iso tope) {
-  return iso_vector_.massFraction(tope) * quantity_;
-}
-
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Material::decay() {
   int curr_time = TI->time();

--- a/src/Resources/Material.h
+++ b/src/Resources/Material.h
@@ -129,16 +129,6 @@ public:
   /**
      Resource class method 
    */
-  bool checkQuantityEqual(rsrc_ptr other);
-
-  /**
-     Resource class method 
-   */
-  bool checkQuantityGT(rsrc_ptr other);
-
-  /**
-     Resource class method 
-   */
   ResourceType type() {return MATERIAL_RES;};
 
   /**
@@ -191,11 +181,6 @@ public:
      last entry in the material history. 
    */
   void decay();
-
-  /**
-     returns the mass of a given isotope
-   */
-  double mass(Iso tope);
 
   /**
      Returns a copy of this material's isotopic composition 

--- a/src/Resources/Resource.cpp
+++ b/src/Resources/Resource.cpp
@@ -21,12 +21,6 @@ Resource::~Resource() {
   MLOG(LEV_DEBUG4) << "Resource ID=" << ID_ << ", ptr=" << this << " deleted.";
 }
 
-bool Resource::checkEquality(rsrc_ptr other) {
-  bool toRet;
-  (this->checkQuality(other) && this->checkQuantityEqual(other)) ? toRet = true : toRet = false;
-  return toRet; 
-}
-
 void Resource::setOriginalID(int id){
   originalID_ = id;
 }

--- a/src/Resources/Resource.h
+++ b/src/Resources/Resource.h
@@ -72,39 +72,6 @@ public:
   virtual void setQuantity(double val) = 0;
     
   /**
-     A boolean comparing the quantity of the other resource is 
-     to the quantity of the base 
-      
-     @param other The resource to evaluate against the base 
-      
-     @return True if other is sufficiently equal in quantity to 
-     the base, False otherwise. 
-   */
-  virtual bool checkQuantityEqual(rsrc_ptr other) = 0;
-
-  /**
-     Returns true if the quantity of the other resource is 
-     greater than the quantity of the base 
-      
-     @param other The resource to evaluate against the base 
-      
-     @return True if second is sufficiently equal in quantity to 
-     first, False otherwise. 
-   */
-  virtual bool checkQuantityGT(rsrc_ptr other) = 0;
-
-  /**
-     Compares the quantity and quality of the other resource 
-     to the base 
-      
-     @param other The resource to evaluate 
-      
-     @return True if other is sufficiently equal to the base, 
-     False otherwise. 
-   */
-  virtual bool checkEquality(rsrc_ptr other);
-
-  /**
   The current state of the resource object.
 
   This can be used to prevent writing of redundant information into the output

--- a/src/Testing/MaterialTests.cpp
+++ b/src/Testing/MaterialTests.cpp
@@ -21,9 +21,8 @@ TEST_F(MaterialTest, Clone) {
   EXPECT_EQ(test_mat_->quantity(), clone_mat->quantity());
   EXPECT_EQ(test_mat_->type(), clone_mat->type());
   EXPECT_TRUE(test_mat_->checkQuality(clone_mat));
-  EXPECT_TRUE(test_mat_->checkQuantityEqual(clone_mat));
+  EXPECT_DOUBLE_EQ(test_mat_->quantity(), clone_mat->quantity());
   EXPECT_TRUE(clone_mat->checkQuality(test_mat_));
-  EXPECT_TRUE(clone_mat->checkQuantityEqual(test_mat_));
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -    
@@ -85,7 +84,7 @@ TEST_F(MaterialTest, AbsorbUnLikeMaterial) {
   // see that materials with different compositions do the right thing
   ASSERT_NO_THROW(test_mat_->absorb(diff_test_mat));
   EXPECT_FLOAT_EQ(orig + origdiff, test_mat_->quantity() );
-  EXPECT_FALSE(same_as_orig_test_mat->checkQuantityEqual(test_mat_));
+  EXPECT_DOUBLE_EQ(same_as_orig_test_mat->quantity(), test_mat_->quantity());
   EXPECT_TRUE(same_as_orig_test_mat->checkQuality(test_mat_));
 }
 


### PR DESCRIPTION
These methods were not used in any models, and their functionality can be simulated easily using already existing methods in the resource class.  Also, since what each method means can vary significantly between resource types (generic, vs material, etc), I think having them as a commonly-named base class methods can give a false sense of similarity between how they function.

I also removed the mass(Iso) method from the material class.  If models need to do operations that require knowing details about a material's composition, then they probably will need access to a larger range of methods on the composition anyway - this can be achieved via the isoVector() method.
