### PR TITLE
fixed bug where Database and BookKeeper tests were failing due to undeleted test files

### DIFF
--- a/src/Testing/BookKeeperTests.cpp
+++ b/src/Testing/BookKeeperTests.cpp
@@ -29,9 +29,10 @@ class BookKeeperTest : public ::testing::Test {
       BI->closeDB();
     }
     BI->turnLoggingOff();
-    const char* test_file = (fpath + "/" + test_filename).c_str();
-    if( BI->getDB()->fexists(test_file) && std::remove( test_file ) != 0 ){
-      throw ("Error deleting file " + test_filename ); 
+
+    std::string path = fpath + "/" + test_filename;
+    if( BI->getDB()->fexists(path.c_str()) && std::remove( path.c_str() ) != 0 ){
+      FAIL() << "could not remove file '" << path.c_str() << "'";
     }
   };
 };

--- a/src/Testing/DatabaseTests.cpp
+++ b/src/Testing/DatabaseTests.cpp
@@ -60,9 +60,9 @@ class DatabaseTest : public ::testing::Test {
   
   // this tears down the fixtures
   virtual void TearDown() {
-    const char* test_file = (dbPath + "/" + dbName).c_str();
-    if( db->fexists(test_file) && std::remove( test_file ) != 0 ){
-      throw ("Error deleting file " + dbName );
+    std::string path = dbPath + "/" + dbName;
+    if( db->fexists(path.c_str()) && std::remove( path.c_str() ) != 0 ){
+      FAIL() << "could not remove file '" << path.c_str() << "'";
     }
   };
 };


### PR DESCRIPTION
This had something to do with screwy, failed conversion between std::string and c_str for the test file paths.  I think we didn't notice this before because of the recent CyclusUnitTestDriver binary move to /bin/.  I (and maybe others) had been running the old, leftover binary in the Testing directory instead of the up-to-date one in the bin directory.
