### PR TITLE
minor mods and additions to GenericResource

### DIFF
--- a/src/Resources/GenericResource.cpp
+++ b/src/Resources/GenericResource.cpp
@@ -7,6 +7,7 @@
 #include "Logger.h"
 
 bool GenericResource::type_is_logged_ = false;
+table_ptr GenericResource::genres_table = new Table("GenericResources"); 
 
 using namespace std;
 
@@ -16,6 +17,7 @@ GenericResource::GenericResource(std::string units,
   units_ = units;
   quality_ = quality;
   quantity_ = quantity;
+  recorded_ = false;
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -    
@@ -87,3 +89,42 @@ gen_rsrc_ptr GenericResource::extract(double quantity) {
 
   return gen_rsrc_ptr(new GenericResource(units_, quality_, quantity));
 }
+
+//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+void GenericResource::addToTable() {
+  Resource::addToTable();
+
+  if ( !genres_table->defined() ) {
+    GenericResource::define_table();
+  }
+
+  if (recorded_) {
+    return;
+  }
+
+  recorded_ = true;
+
+  data an_id( ID() );
+  entry id("ResourceID", an_id);
+
+  data a_qual( quality() );
+  entry qual("Quality", a_qual);
+
+  row aRow;
+  aRow.push_back(id), aRow.push_back(qual);
+
+  genres_table->addRow(aRow);
+}
+
+//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+void GenericResource::define_table() {
+  genres_table->addField("ResourceID","INTEGER");
+  genres_table->addField("Quality","VARCHAR(128)");
+
+  primary_key pk;
+  pk.push_back("ResourceID");
+  genres_table->setPrimaryKey(pk);
+
+  genres_table->tableDefined();
+}
+

--- a/src/Resources/GenericResource.h
+++ b/src/Resources/GenericResource.h
@@ -90,11 +90,6 @@ public:
   std::string quality() {return quality_;};
 
   /**
-     Sets the quality of this resource 
-   */ 
-  void setQuality(std::string new_quality) {quality_ = new_quality;};
-    
-  /**
      A boolean comparing the quantity of the other resource is 
      to the quantity of the base 
       
@@ -151,6 +146,8 @@ public:
    */
   virtual gen_rsrc_ptr extract(double mass);
 
+  virtual void addToTable();
+
 private:  
   /**
      The units of the resource 
@@ -167,11 +164,20 @@ private:
    */ 
   double quantity_;
 
+  bool recorded_;
+
  private:
   /**
      A boolean to tell if the resource has been logged 
    */ 
   static bool type_is_logged_;
+
+  /**
+     defines the resource table 
+   */
+  static void define_table();
+
+  static table_ptr genres_table;
 };
 
 #endif


### PR DESCRIPTION
Added table that tracks the quality of each generic resource in the simulation (wasn't being tracked before).

Removed setQuality method in favor of immutable quality.  To "convert" the quality of a generic resource, you have to destroy/create instead.  this makes output db recording (among other things) much simpler.
