### PR TITLE
This may fix issue #228 for the CAE machines. Please check it.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,25 @@ ENDIF()
 
 SET(CYCLUS_EXECUTABLE_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 
+# use, i.e. don't skip the full RPATH for the build tree
+SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
+
+# when building, don't use the install RPATH already
+# (but later on when installing)
+SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE) 
+
+SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/cyclus/lib")
+
+# add the automatically determined parts of the RPATH
+# which point to directories outside the build tree to the install RPATH
+SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+# the RPATH to be used when installing, but only if it's not a system directory
+LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/cyclus/lib" isSystemDir)
+IF("${isSystemDir}" STREQUAL "-1")
+   SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/cyclus/lib")
+ENDIF("${isSystemDir}" STREQUAL "-1")
+
 # Tell CMake where the modules are
 SET( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_DIR}/share/cmake-2.8/Modules")
 SET( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CYCLUS_SOURCE_DIR}/CMake )


### PR DESCRIPTION
The reason I wasn't seeing @gidden's symptom on lise was that it had a /usr/lib/libgtest.so  installed (i guess I installed it with cae-apt a while ago). Once I deleted that, I got the symptom and now have a patch. It seems to work both on MacOSX and on the CAE machine, lise.

For posterity, here are some details about why this is complicated : 

I've tried to set cmake up to link properly with relative paths no matter what your ld_library_paths are. However, there's a lot of complication with "RPATH handling" in cmake.
http://www.cmake.org/Wiki/CMake_RPATH_handling

It seems clear that RPATH works differently on different platforms and that some systems ignore RPATHS from cmake (namely MACOSX). The property setting is meant to help with the OSX situation while the section added in this commit is meant to help in the linux situation where LD_LIBRARY_PATH doesn't lead to the install prefix directory.
