### PR TITLE
This is a better fix to issue #231

### DIFF
--- a/src/Core/Utility/CMakeLists.txt
+++ b/src/Core/Utility/CMakeLists.txt
@@ -22,6 +22,14 @@ INSTALL(FILES
   COMPONENT core
   )
 
+SET(cyclus_build_dir ${CYCLUS_BINARY_DIR})
+
+CONFIGURE_FILE(
+  ${CMAKE_CURRENT_SOURCE_DIR}/Env.cpp.in
+  ${CMAKE_CURRENT_SOURCE_DIR}/Env.cpp
+  @ONLY
+  )
+  
 # Add any new cyclus core source files to this list
 SET(CYCLUS_CORE_SRC ${CYCLUS_CORE_SRC} 
   ${CMAKE_CURRENT_SOURCE_DIR}/BookKeeper.cpp 

--- a/src/Core/Utility/Env.cpp.in
+++ b/src/Core/Utility/Env.cpp.in
@@ -45,7 +45,7 @@ string Env::getCyclusPath() {
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 const string Env::getBuildPath() {
   // return the join of cwd_ and rel path to cyclus MINUS the bin directory
-  string to_ret = pathBase(getCyclusPath());
+  string to_ret = "@cyclus_build_dir@";
   return to_ret;
 }
 


### PR DESCRIPTION
There is no reason to go futzing around for the absolute cyclus path when we can just find it during configuration. I have made it so that Env.cpp is produced during the configure step from Env.cpp.in and contains the absolute path to the build directory, whether being built locally or installed. I don't think there are any unforseen negative consequences of this. However, it's possible that I've overlooked some. Also, I only implemented this in the getBuildPath method. It's likely that the getCyclusPath method should also be implemented in this way, but this commit seeks only to satisfy issue #231.
