### PR TITLE
fixes situation in which delete var1, var2, var3 is used. 

### DIFF
--- a/src/Testing/SDManagerTests.cpp
+++ b/src/Testing/SDManagerTests.cpp
@@ -28,7 +28,9 @@ void SDManagerTests::SetUp() {
   
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 void SDManagerTests::TearDown() {
-  delete commod, p1, p2;
+  delete commod;
+  delete p1;
+  delete p2;
 }  
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 


### PR DESCRIPTION
fixes situation in which delete var1, var2, var3 is used. Since delete has higher precedence than , the expression only deletes var1.

See this stackoverflow discussion for details : 
http://stackoverflow.com/questions/3037655/c-delete-syntax
