### PR TITLE
this should fix some issues with rng installation using cycamore. needs ...

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -184,11 +184,10 @@ INSTALL(TARGETS CyclusUnitTestDriver
   COMPONENT testing
   )
 
-# Here we set some components for installation with cpack
 INSTALL(FILES 
   ${PROJECT_BINARY_DIR}/share/cyclus.rng
   ${PROJECT_BINARY_DIR}/share/cyclus.rng.in
-  DESTINATION cyclus/share
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/cyclus/share
   COMPONENT data
   )
 


### PR DESCRIPTION
This should fix the situation in which the cyclus.rng file doesn't fill in properly when you install and reinstall in nonstandard prefix locations. This is sensitive, and needs to to be tested on EVERY machine. Once you've tested it (that is, built and installed cyclus/core then built and installed cycamore against it) make note of it here. Once everyone has tried it, we should pull this. 

This ought to address issue #303.
