### PR TITLE
this renames the cyclopts Limits.h file to CycloptsLimits.h

### DIFF
--- a/src/Core/Utility/CommodityProducer.cpp
+++ b/src/Core/Utility/CommodityProducer.cpp
@@ -2,7 +2,7 @@
 
 #include "CycException.h"
 
-#include "Limits.h"
+#include "CycloptsLimits.h"
 
 using namespace std;
 using namespace SupplyDemand;


### PR DESCRIPTION
this renames the cyclopts Limits.h file to go along with the pull request in cyclopts of the same name. It all seeks to help address the cyclopts issue : https://github.com/cyclus/cyclopts/issues/17 , which is the result of a combination of Case Insensitivity in MacOSX, the name of the Limits.h file in Cyclopts, and the existing c++ system header, limits.h .
