### PR TITLE
fixes readme?

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -168,7 +168,7 @@ Now, run it with some input file, for this example, call it
     .../cyclus/install/cyclus/bin$ ./cyclus input.xml
 
 Debugging Build
-^^^^^^^^^^^^^^^
+---------------
 
 Building the debug version of the core library requires an additional
 CMake variable flag. Simply add the following to your cmake command:


### PR DESCRIPTION
This fixes the slightly mis-ordered headings in the readme from commit 28c51ad118e3c426e0dc7dacc6e6f211d4b6b3be .
