### PR TITLE
Nan from atom frac

### DIFF
--- a/src/Core/Resources/CompMap.cpp
+++ b/src/Core/Resources/CompMap.cpp
@@ -130,8 +130,10 @@ double CompMap::atomFraction(const Iso& tope) const {
     return 0.0;
   }
   double factor = 1.0;
-  if (basis_ != ATOM) {
+  if (basis_ != ATOM && mass_to_atom_ratio_ != 0 ) {
     factor = 1 / (MT->gramsPerMol(tope) / mass_to_atom_ratio_);
+  } else if (mass_to_atom_ratio_ == 0 ){
+    factor = 0;
   }
   return factor * map_.find(tope)->second;
 }
@@ -206,11 +208,12 @@ void CompMap::normalize() {
       other_sum += it->second / MT->gramsPerMol(it->first);
     }
   }
-  if (atom) {
+  if (atom && sum != 0) {
     mass_to_atom_ratio_ = other_sum / sum;
-  }
-  else {
+  } else if (sum != 0){
     mass_to_atom_ratio_ = sum / other_sum;
+  } else if (sum == 0){
+    mass_to_atom_ratio_ = 0 ;
   }
   normalize(sum);
 }
@@ -251,7 +254,7 @@ void CompMap::change_basis(Basis b) {
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 void CompMap::normalize(double sum) {
-  if (sum != 1) { // only normalize if needed
+  if (sum != 1 && sum != 0) { // only normalize if needed
     for (iterator it = map_.begin(); it != map_.end(); it++) {
       it->second /= sum;
     }

--- a/src/Testing/CompMapTests.cpp
+++ b/src/Testing/CompMapTests.cpp
@@ -86,8 +86,8 @@ TEST_F(CompMapTests,lineage) {
 TEST_F(CompMapTests,empty_comp_behaviors) {
   comp_[92235]=0;
   comp_.normalize();
-  EXPECT_FLOAT_EQ(1,comp_.atomFraction(92235));
-  EXPECT_FLOAT_EQ(1,comp_.massFraction(92235));
+  EXPECT_FLOAT_EQ(0,comp_.atomFraction(92235));
+  EXPECT_FLOAT_EQ(0,comp_.massFraction(92235));
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 


### PR DESCRIPTION
I was getting nan when asking for the atomFraction of an isotope that exists as an index in an empty CompMap. I think the real answer should either be 0 or to throw an exception. 

I opted for 0, wrote a test to that effect, and implemented the solution. 

Katy
