### PR TITLE
Temporarily removes generic facility module tests (read description)

### DIFF
--- a/src/Testing/FacilityModelTests.cpp
+++ b/src/Testing/FacilityModelTests.cpp
@@ -3,15 +3,15 @@
 
 #include "FacilityModelTests.h"
 
-// //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-// TEST_P(FacilityModelTests, Tick) {
-//   int time = 1;
-//   facility_model_->handleTick(time);
-//     //EXPECT_NO_THROW();
-// }
+//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+TEST_P(FacilityModelTests, DISABLED_Tick) {
+  int time = 1;
+  facility_model_->handleTick(time);
+    //EXPECT_NO_THROW();
+}
 
-// //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-// TEST_P(FacilityModelTests, Tock) {
-//   int time = 1;
-//   EXPECT_NO_THROW(facility_model_->handleTock(time));
-// }
+//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+TEST_P(FacilityModelTests, DISABLED_Tock) {
+  int time = 1;
+  EXPECT_NO_THROW(facility_model_->handleTock(time));
+}


### PR DESCRIPTION
I propose we take out the facility model tests for now. First of all, they're the source of errors related to #131. Secondly, it's not at all clear how this interplays with our dynamic loading framework. I think one of us needs to sit down and think hard about how we want these to work and provide the group with a proposal and example.
