### PR TITLE
Boost capitalization matters on a mac. 

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,6 +76,8 @@ SET(CYCLUS_INCLUDE_DIR ${CYCLUS_INCLUDE_DIR} ${SQLITE3_INCLUDE_DIR})
 SET(LIBS ${LIBS} ${SQLITE3_LIBRARIES})
 
 # Include the boost header files and the program_options library
+# Please be sure to use Boost rather than BOOST. 
+# Capitalization matters on some platforms
 SET(Boost_USE_STATIC_LIBS       OFF)
 SET(Boost_USE_STATIC_RUNTIME    OFF)
 FIND_PACKAGE( Boost COMPONENTS program_options filesystem system REQUIRED)


### PR DESCRIPTION
I've fixed this before, so I'm not sure why it's reappeared. I hope everyone can keep an eye on it and not change Boost back to BOOST in the future. 

This issue is essential for building cyclus on a mac.
