### PR TITLE
utilizes cyclus::eps_rsrc() to fix extraction of one comp from its duplicate.

### DIFF
--- a/src/Core/Resources/Material.cpp
+++ b/src/Core/Resources/Material.cpp
@@ -120,7 +120,7 @@ mat_rsrc_ptr Material::extract(const CompMapPtr comp_to_rem, double kg_to_rem) {
       throw CycNegativeValueException(ss.str());
     } else if (remainder_kg_i <= cyclus::eps_rsrc()) {
       remainder_kg_i = 0; 
-    };
+    }
     
     // operate on information
     (*new_comp)[iso] = remainder_kg_i;


### PR DESCRIPTION
utilizes the cyclus::eps_rsrc() value to avoid exceptions being thrown because of floating point errors in material amounts.

I have been getting these mysterious errors : 

```
|--------------------------------------------|
|                  Cyclus                    |
|       a nuclear fuel cycle simulator       |
|  from the University of Wisconsin-Madison  |
|--------------------------------------------|

 ERROR(core  ):ERROR occured in sendTock(): cyclus exception: The Material 177 has insufficient material to extract the isotope : 92235
 ERROR(core  ):ERROR occured in sendTock(): cyclus exception: The Material 190 has insufficient material to extract the isotope : 95241
 ERROR(core  ):ERROR occured in sendTock(): cyclus exception: The Material 205 has insufficient material to extract the isotope : 96244
 ERROR(core  ):ERROR occured in sendTock(): cyclus exception: The Material 222 has insufficient material to extract the isotope : 95241
 ERROR(core  ):ERROR occured in sendTock(): cyclus exception: The Material 241 has insufficient material to extract the isotope : 95241
```

When I pulled these up in gdb, the amount being extracted is usually on the order of 0.000000000000000001 larger than the amount its being subtracted from. That's floating point error. It happens when I'm subtracting a composition almost exactly. The proper response to such a situation is to check if the amounts are within eps_rsrc() of each other and, if so, subtract the amount from the material (rather than throwing an exception) and set the difference to zero (rather than -0.000000000000000001). That's what this improvement does. 
