### PR TITLE
adds ability to optionally specify simulation id prefix in input file

### DIFF
--- a/src/App.cpp
+++ b/src/App.cpp
@@ -98,19 +98,6 @@ int main(int argc, char* argv[]) {
   string path = Env::pathBase(argv[0]);
   Env::setCyclusRelPath(path);
 
-  // Create the output file
-  string output_path = "cyclus.sqlite";
-  try {
-    if (vm.count("output-path")){
-      output_path = vm["output-path"].as<string>();
-    }
-  } catch (CycException ge) {
-    success = false;
-    CLOG(LEV_ERROR) << ge.what();
-  }
-  SqliteBack* sqlBack = new SqliteBack(EM->sim_id(), output_path);
-  EM->registerBackend(sqlBack);
-
   // read input file and setup simulation
   try {
     string inputFile = vm["input-file"].as<string>();
@@ -124,6 +111,19 @@ int main(int argc, char* argv[]) {
     success = false;
     CLOG(LEV_ERROR) << e.what();
   }
+
+  // Create the output file
+  string output_path = "cyclus.sqlite";
+  try {
+    if (vm.count("output-path")){
+      output_path = vm["output-path"].as<string>();
+    }
+  } catch (CycException ge) {
+    success = false;
+    CLOG(LEV_ERROR) << ge.what();
+  }
+  SqliteBack* sqlBack = new SqliteBack(EM->sim_id(), output_path);
+  EM->registerBackend(sqlBack);
 
   // sim construction - should be handled by some entity
   Model::constructSimulation();
@@ -156,6 +156,7 @@ int main(int argc, char* argv[]) {
     cout << "|              run successful                |" << endl;
     cout << "|--------------------------------------------|" << endl;
     cout << "Output location: " << output_path << endl;
+    cout << "Simulation ID: " << EM->sim_id() << endl;
     cout << endl;
   } else {
     cout << endl;

--- a/src/Core/Config/cyclus.rng.in
+++ b/src/Core/Config/cyclus.rng.in
@@ -83,6 +83,7 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
   <define name="control">
     <element name ="control">
       <interleave>
+        <ref name="simprefix"/>
         <ref name="duration"/>
         <ref name="startmonth"/>
         <ref name="startyear"/>
@@ -90,6 +91,14 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
         <ref name="decay"/>
       </interleave>
     </element>
+  </define>
+
+  <define name="simprefix">
+    <optional>
+      <element name="simprefix">
+        <data type="string"/>
+      </element>
+    </optional>
   </define>
 
   <define name="duration">
@@ -131,6 +140,7 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
       </element>
 
     </element>
+
     <optional>
       <element name="enrichment">
         <data type="double"/>
@@ -449,3 +459,4 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
   <!-- end section for recipes -->
 
 </grammar>
+

--- a/src/Core/Input/XMLQueryEngine.cpp
+++ b/src/Core/Input/XMLQueryEngine.cpp
@@ -36,8 +36,7 @@ int XMLQueryEngine::nElements() {
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 int XMLQueryEngine::nElementsMatchingQuery(std::string query) {
-  const NodeSet nodeset = current_node_->find(query);
-  return nodeset.size();
+  return current_node_->find(query).size();
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

--- a/src/Core/Utility/EventManager.cpp
+++ b/src/Core/Utility/EventManager.cpp
@@ -14,7 +14,7 @@ EventManager* EventManager::instance_ = 0;
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 EventManager::EventManager() : dump_count_(kDefaultDumpCount) {
   boost::uuids::uuid uuid = boost::uuids::random_generator()();
-  sim_id_ = boost::lexical_cast<std::string>(uuid);
+  uuid_ = boost::lexical_cast<std::string>(uuid);
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -31,8 +31,13 @@ unsigned int EventManager::dump_count() {
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+void EventManager::setSimPrefix(std::string val) {
+  prefix_ = val + "_";
+}
+
+//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 std::string EventManager::sim_id() {
-  return sim_id_;
+  return prefix_ + uuid_;
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/Core/Utility/EventManager.h
+++ b/src/Core/Utility/EventManager.h
@@ -34,8 +34,9 @@ class CycInvalidSchemaErr: public CycException {
 };
 
 /*!
-Collects and manages output data generation for the cyclus core and
-agents during a simulation.
+Collects and manages output data generation for the cyclus core and agents
+during a simulation.  By default, event managers are auto-initialized with a
+unique uuid simulation id.
 
 Example usage:
 
@@ -68,7 +69,8 @@ class EventManager {
     std::map<std::string, event_ptr> schemas_;
     std::list<EventBackend*> backs_;
     unsigned int dump_count_;
-    std::string sim_id_;
+    std::string uuid_;
+    std::string prefix_;
 
     /// A pointer to singleton EventManager.
     static EventManager* instance_;
@@ -91,8 +93,11 @@ class EventManager {
     */
     void set_dump_count(unsigned int count);
 
-    /// returns the unique, auto-generated id associated with this cyclus simulation.
+    /// returns the unique id associated with this cyclus simulation.
     std::string sim_id();
+
+    /// adds a prefix to the auto-generated unique simulation id
+    void setSimPrefix(std::string val);
 
     /*!
     Creates a new event namespaced under the specified title.

--- a/src/Core/Utility/Timer.cpp
+++ b/src/Core/Utility/Timer.cpp
@@ -247,28 +247,27 @@ pair<int, int> Timer::convertDate(int time) {
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Timer::load_simulation(QueryEngine *qe) { 
-  
-  int dur, m0, y0, sim0, dec;
-  string dur_str, m0_str, y0_str, sim0_str, decay_str;
-  
+  if (qe->nElementsMatchingQuery("simprefix") > 0) {
+    EM->setSimPrefix(qe->getElementContent("simprefix"));
+  }
+
   // get duration
-  dur_str = qe->getElementContent("duration");
-  dur = strtol(dur_str.c_str(), NULL, 10);
+  std::string dur_str = qe->getElementContent("duration");
+  int dur = strtol(dur_str.c_str(), NULL, 10);
   // get start month
-  m0_str = qe->getElementContent("startmonth");
-  m0 = strtol(m0_str.c_str(), NULL, 10);
+  std::string m0_str = qe->getElementContent("startmonth");
+  int m0 = strtol(m0_str.c_str(), NULL, 10);
   // get start year
-  y0_str = qe->getElementContent("startyear");
-  y0 = strtol(y0_str.c_str(), NULL, 10);
+  std::string y0_str = qe->getElementContent("startyear");
+  int y0 = strtol(y0_str.c_str(), NULL, 10);
   // get simulation start
-  sim0_str = qe->getElementContent("simstart");
-  sim0 = strtol(sim0_str.c_str(), NULL, 10);
+  std::string sim0_str = qe->getElementContent("simstart");
+  int sim0 = strtol(sim0_str.c_str(), NULL, 10);
   // get decay interval
-  decay_str = qe->getElementContent("decay");
-  dec = strtol(decay_str.c_str(), NULL, 10);
+  std::string decay_str = qe->getElementContent("decay");
+  int dec = strtol(decay_str.c_str(), NULL, 10);
 
   TI->initialize(dur, m0, y0, sim0, dec);
-  
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 


### PR DESCRIPTION
I opted for the prefix way.  Having a separate field was less simple.  Also, as just a prefix, developers are more implicitly discouraged from using it as a way to store information about a simulation.

App.cpp now also prints a line to stdout at the end of a simulation `Simulation ID: blablabla-blablabla-blablabla`.
