### PR TITLE
fixes #491 and an interesting dlopen/close bug.

### DIFF
--- a/src/App.cpp
+++ b/src/App.cpp
@@ -139,6 +139,8 @@ int main(int argc, char* argv[]) {
     CLOG(LEV_ERROR) << err.what();
   }
 
+  EM->close();
+
   // Close Dynamically loaded modules 
   try {
     Model::unloadModules();
@@ -146,8 +148,6 @@ int main(int argc, char* argv[]) {
     success = false;
     CLOG(LEV_ERROR) << err.what();
   }
-
-  EM->close();
 
   if (success) {
     cout << endl;

--- a/src/Core/Models/Model.cpp
+++ b/src/Core/Models/Model.cpp
@@ -386,7 +386,7 @@ void Model::addResource(Transaction trans,
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Model::addToTable(){
-  EM->newEvent("Agents")
+  EM->newEvent("Agent")
     ->addVal("ID", ID())
     ->addVal("AgentType", modelType())
     ->addVal("ModelType", modelImpl())

--- a/src/Core/Utility/Event.h
+++ b/src/Core/Utility/Event.h
@@ -35,9 +35,6 @@ class Event: IntrusiveBase<Event> {
 
     @warning for the val argument - what variable types are supported
     depends on what the backend(s) in use are designed to handle.
-
-    @throw CycDupEventFieldErr the passed field has been used already in
-    this event
     */
     event_ptr addVal(const char* field, boost::any val);
 

--- a/src/Core/Utility/SqliteBack.cpp
+++ b/src/Core/Utility/SqliteBack.cpp
@@ -37,6 +37,24 @@ void SqliteBack::notify(EventList evts) {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void SqliteBack::close() {
+  if (tableExists("Agent")) {
+    // merge agent and agentdeaths tables into the agent table
+    std::string cmd;
+    if (!tableExists("Agents")) {
+      cmd = "CREATE TABLE Agents AS ";
+      cmd += "SELECT A.SimId,ID,AgentType,ModelType,Prototype,ParentID,EnterDate,DeathDate ";
+      cmd += "FROM Agent AS A INNER JOIN AgentDeaths AS AD ON (A.ID=AD.AgentID AND A.SimId=AD.SimId);";
+      cmds_.push_back(cmd);
+    } else {
+      cmd = "INSERT INTO Agents ";
+      cmd += "SELECT A.SimId,ID,AgentType,ModelType,Prototype,ParentID,EnterDate,DeathDate ";
+      cmd += "FROM Agent AS A INNER JOIN AgentDeaths AS AD ON (A.ID=AD.AgentID AND A.SimId=AD.SimId);";
+      cmds_.push_back(cmd);
+    }
+    cmds_.push_back("DROP TABLE Agent");
+    cmds_.push_back("DROP TABLE AgentDeaths");
+  }
+
   flush();
   db_.close();
 }


### PR DESCRIPTION
fixes #491 by adding a post processing step inside the SqliteBack class's close method. Fixed deprecated doc comment. Fixed segfault issue relating to dynamically unloading of libraries before the event manager recorded its events. The const char\* passed to addVal method was trying to access memory that was already cleaned up when externally loaded agents were unloaded.  In short, the module unloading needs to come _after_ the final event logging.
