### PR TITLE
limit 100

### DIFF
--- a/src/Core/Utility/Event.cpp
+++ b/src/Core/Utility/Event.cpp
@@ -22,7 +22,7 @@ Event::Event(EventManager* m, std::string title)
   : title_(title),
     manager_(m),
     count_(0) {
-  vals_.resize(10);
+  vals_.resize(100);
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
This increases the limit to the number of columns allowed in an sqlite table. Rather than 10 (introduced in 74fb01ec5aa5d1382b4ed4cc8e49913d5e423aa6), it's now 100. Considerations about the nebulous/delicate/qualitative balance between speed optimizations and limitations like this should probably be thought about in the broader context of CEP 17. @rwcarlsen has a lot of knowledge at this point about which optimizations have how much benefit, so I imagine discussion on this topic will be well informed.
