### PR TITLE
changes func signature to explicit namespaces so that the older version ...

### DIFF
--- a/src/Core/Utility/BuildingManager.h
+++ b/src/Core/Utility/BuildingManager.h
@@ -121,7 +121,7 @@ namespace ActionBuilding {
        @param orders the set of orders to fill
        @param solution the solution determining how to fill the orders
      */
-    void constructBuildOrdersFromSolution(std::vector<BuildOrder>& orders,
+    void constructBuildOrdersFromSolution(std::vector<ActionBuilding::BuildOrder>& orders,
                                           std::vector<Cyclopts::VariablePtr>& solution);
   private:
     /// the set of registered builders


### PR DESCRIPTION
...of doxygen stops throwing errors at @gonuke
