### PR TITLE
reuse buffered event objects in EventManager to avoid new/delete hammering

### DIFF
--- a/src/Core/Utility/Event.cpp
+++ b/src/Core/Utility/Event.cpp
@@ -3,15 +3,17 @@
 #include "Event.h"
 #include "Timer.h"
 
+typedef boost::singleton_pool<Event, sizeof(Event)> EventPool;
+
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-event_ptr Event::addVal(const char* field, boost::spirit::hold_any val) {
+Event* Event::addVal(const char* field, boost::spirit::hold_any val) {
   vals_.push_back(std::pair<const char*, boost::spirit::hold_any>(field, val));
-  return event_ptr(this);
+  return this;
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Event::record() {
-  manager_->addEvent(event_ptr(this));
+  manager_->addEvent(this);
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -37,3 +39,25 @@ const Event::Vals& Event::vals() {
   return vals_;
 }
 
+//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+void* Event::operator new(size_t size) {
+  if (size != sizeof(Event)) 
+    return ::operator new(size);
+
+  while(true) {
+    void* ptr = EventPool::malloc();
+    if (ptr != NULL) return ptr;
+
+    std::new_handler globalNewHandler = std::set_new_handler(0);
+    std::set_new_handler(globalNewHandler);
+
+    if(globalNewHandler) globalNewHandler();
+    else throw std::bad_alloc();
+  }
+}
+
+//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+void Event::operator delete(void * rawMemory) throw() {
+  if(rawMemory == 0) return; 
+  EventPool::free(rawMemory);
+}

--- a/src/Core/Utility/Event.h
+++ b/src/Core/Utility/Event.h
@@ -2,20 +2,18 @@
 #if !defined(_EVENT_H)
 #define _EVENT_H
 
-#include "IntrusiveBase.h"
 #include "EventManager.h"
+#include <boost/pool/singleton_pool.hpp>
 #include "any.hpp"
 
 #include <list>
 #include <string>
 
-typedef boost::intrusive_ptr<Event> event_ptr;
-
 /*!
 Used to specify and send a collection of key-value pairs to the
 EventManager for recording.
 */
-class Event: IntrusiveBase<Event> {
+class Event {
     friend class EventManager;
 
   public:
@@ -36,7 +34,7 @@ class Event: IntrusiveBase<Event> {
     @warning for the val argument - what variable types are supported
     depends on what the backend(s) in use are designed to handle.
     */
-    event_ptr addVal(const char* field, boost::spirit::hold_any val);
+    Event* addVal(const char* field, boost::spirit::hold_any val);
 
     /*!
     Record this event to its EventManager. Recorded events of the same
@@ -50,6 +48,9 @@ class Event: IntrusiveBase<Event> {
 
     /// Returns a map of all field-value pairs that have been added to this event.
     const Vals& vals();
+
+    static void* operator new(size_t size); 
+    static void operator delete(void* rawMemory) throw();
 
   private:
     /// events should only be created via an EventManager

--- a/src/Core/Utility/EventBackend.h
+++ b/src/Core/Utility/EventBackend.h
@@ -6,7 +6,7 @@
 #include <vector>
 #include <boost/intrusive_ptr.hpp>
 
-typedef std::vector<event_ptr> EventList;
+typedef std::vector<Event*> EventList;
 
 /*!
 An abstract base class for listeners (e.g. output databases) that want

--- a/src/Core/Utility/EventManager.h
+++ b/src/Core/Utility/EventManager.h
@@ -4,12 +4,9 @@
 
 #include "CycException.h"
 
-#include <list>
 #include <vector>
+#include <list>
 #include <string>
-#include <map>
-#include <boost/intrusive_ptr.hpp>
-#include <boost/any.hpp>
 
 // TODO: Move away from singleton pattern (that is why we kept EventManager constructor public)
 #define EM EventManager::Instance()
@@ -18,8 +15,7 @@ class Event;
 class EventManager;
 class EventBackend;
 
-typedef boost::intrusive_ptr<Event> event_ptr;
-typedef std::vector<event_ptr> EventList;
+typedef std::vector<Event*> EventList;
 
 /// default number of events to collect before flushing to backends.
 static unsigned int const kDefaultDumpCount = 10000;
@@ -53,9 +49,10 @@ class EventManager {
 
   private:
     void notifyBackends();
-    void addEvent(event_ptr ev);
+    void addEvent(Event* ev);
 
     EventList events_;
+    int index_;
     std::list<EventBackend*> backs_;
     unsigned int dump_count_;
     std::string uuid_;
@@ -69,6 +66,8 @@ class EventManager {
     /// create a new event manager with default dump frequency.
     EventManager();
     // TODO: Move away from singleton pattern (that is why we kept the constructor public)
+
+    ~EventManager();
 
     /// Return the dump frequency, # events buffered between flushes to backends.
     unsigned int dump_count();
@@ -96,7 +95,7 @@ class EventManager {
     result in multiple instances of this agent storing event data together
     (e.g. the same table).
     */
-    event_ptr newEvent(std::string title);
+    Event* newEvent(std::string title);
 
     /*!
     Registers b to receive event notifications for all events collected

--- a/src/Core/Utility/Hdf5Back.h
+++ b/src/Core/Utility/Hdf5Back.h
@@ -5,8 +5,8 @@
 #include "hdf5.h"
 #include "hdf5_hl.h"
 
-#include <list>
 #include <string>
+#include <map>
 
 /*!
 An EventManager backend that writes data to an hdf5 file.
@@ -34,7 +34,7 @@ class Hdf5Back : public EventBackend {
   private:
 
     /// creates and initializes an hdf5 table
-    void createTable(event_ptr ev);
+    void createTable(Event* ev);
 
     /// write a group of events with the same title to their corresponding hdf5 dataset
     void writeGroup(EventList& group);

--- a/src/Core/Utility/SqliteBack.cpp
+++ b/src/Core/Utility/SqliteBack.cpp
@@ -65,7 +65,7 @@ std::string SqliteBack::name() {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-void SqliteBack::createTable(event_ptr e) {
+void SqliteBack::createTable(Event* e) {
   std::string name = e->title();
   tbl_names_.push_back(name);
 
@@ -125,7 +125,7 @@ bool SqliteBack::tableExists(std::string name) {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-void SqliteBack::writeEvent(event_ptr e) {
+void SqliteBack::writeEvent(Event* e) {
   std::stringstream colss, valss, cmd;
   Event::Vals vals = e->vals();
 

--- a/src/Core/Utility/SqliteBack.h
+++ b/src/Core/Utility/SqliteBack.h
@@ -67,10 +67,10 @@ class SqliteBack: public EventBackend {
     std::string valAsString(boost::spirit::hold_any v);
 
     /// Queue up a table-create command for e.
-    void createTable(event_ptr e);
+    void createTable(Event* e);
 
     /// constructs an SQL INSERT command for e and queues it for db insertion.
-    void writeEvent(event_ptr e);
+    void writeEvent(Event* e);
 
     /// An interface to a sqlite db managed by the SqliteBack class.
     SqliteDb db_;

--- a/src/Testing/EventManagerTests.cpp
+++ b/src/Testing/EventManagerTests.cpp
@@ -34,7 +34,7 @@ class TestBack : public EventBackend {
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 TEST(EventManagerTest, Manager_NewEvent) {
   EventManager m;
-  event_ptr ev = m.newEvent("DumbTitle");
+  Event* ev = m.newEvent("DumbTitle");
   EXPECT_EQ(ev->title(), "DumbTitle");
 }
 
@@ -49,9 +49,6 @@ TEST(EventManagerTest, Manager_GetSetDumpFreq) {
   EventManager m;
   m.set_dump_count(1);
   EXPECT_EQ(m.dump_count(), 1);
-
-  m.set_dump_count(-1);
-  EXPECT_EQ(m.dump_count(), -1);
 
   m.set_dump_count(kDefaultDumpCount);
   EXPECT_EQ(m.dump_count(), kDefaultDumpCount);
@@ -125,7 +122,7 @@ TEST(EventManagerTest, Event_record) {
   m.set_dump_count(1);
   m.registerBackend(&back);
 
-  event_ptr ev = m.newEvent("DumbTitle");
+  Event* ev = m.newEvent("DumbTitle");
   ev->addVal("animal", std::string("monkey"));
 
   EXPECT_EQ(back.flush_count, 0);
@@ -141,7 +138,7 @@ TEST(EventManagerTest, Event_addVal) {
   EventManager m;
   m.registerBackend(&back);
 
-  event_ptr ev = m.newEvent("DumbTitle");
+  Event* ev = m.newEvent("DumbTitle");
   ev->addVal("animal", std::string("monkey"));
   ev->addVal("weight", 10);
   ev->addVal("height", 5.5);


### PR DESCRIPTION
This does two things:
- adds a boost::singleton_pool that is used for Event new/delete memory handling (faster than standard allocator)
- modifies the EventManager to reuse a list of allocated events.  This avoids unnecessary construction/destruction and (de)alloc of Events.  This list is allocated once when the event manager is created and dealloced when the event manager dies.

This PR improves cep17 inpro from 1.5 min to 50 sec (on my machine).
