### PR TITLE
csv backend

### DIFF
--- a/src/App.cpp
+++ b/src/App.cpp
@@ -18,6 +18,7 @@
 #include "EventManager.h"
 #include "SqliteBack.h"
 #include "Hdf5Back.h"
+#include "CsvBack.h"
 
 using namespace std;
 namespace po = boost::program_options;
@@ -133,6 +134,8 @@ int main(int argc, char* argv[]) {
   EventBackend* back;
   if (ext == ".h5") {
     back = new Hdf5Back(output_path.c_str());
+  } else if (ext == ".csv") {
+    back = new CsvBack(output_path.c_str());
   } else {
     back = new SqliteBack(output_path);
   }

--- a/src/Core/Utility/CMakeLists.txt
+++ b/src/Core/Utility/CMakeLists.txt
@@ -37,6 +37,7 @@ SET(CYCLUS_CORE_SRC ${CYCLUS_CORE_SRC}
   ${CMAKE_CURRENT_SOURCE_DIR}/CommodityProducer.cpp 
   ${CMAKE_CURRENT_SOURCE_DIR}/CommodityProducerManager.cpp 
   ${CMAKE_CURRENT_SOURCE_DIR}/CycArithmetic.cpp  
+  ${CMAKE_CURRENT_SOURCE_DIR}/CsvBack.cpp 
   ${CMAKE_CURRENT_SOURCE_DIR}/CycException.cpp 
   ${CMAKE_CURRENT_SOURCE_DIR}/DecayHandler.cpp 
   ${CMAKE_CURRENT_SOURCE_DIR}/Enrichment.cpp 
@@ -68,6 +69,7 @@ INSTALL(FILES
   CommodityProducer.h
   CommodityProducerManager.h
   CycArithmetic.h
+  CsvBack.h
   CycException.h
   CycLimits.h
   DecayHandler.h

--- a/src/Core/Utility/CsvBack.cpp
+++ b/src/Core/Utility/CsvBack.cpp
@@ -1,0 +1,115 @@
+// CsvBack.cpp
+#include "CsvBack.h"
+
+#include "CycException.h"
+#include "Logger.h"
+#include "Event.h"
+
+#include <boost/lexical_cast.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/filesystem.hpp>
+#include <fstream>
+
+namespace fs = boost::filesystem;
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+CsvBack::CsvBack(std::string path, bool overwrite) : path_(path) {
+  if (overwrite) {
+    fs::remove_all(path);
+  }
+  fs::create_directory(path);
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+void CsvBack::notify(EventList evts) {
+  for (EventList::iterator it = evts.begin(); it != evts.end(); it++) {
+    writeEvent(*it);
+  }
+  flush();
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+void CsvBack::close() {
+  flush();
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+std::string CsvBack::name() {
+  return path_.string();
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+void CsvBack::writeEvent(Event* e) {
+  std::stringstream line;
+  std::stringstream header;
+  Event::Vals vals = e->vals();
+  fs::path fname(e->title() + ".csv");
+  std::string path = (path_ / fname).string();
+
+  // create header if first event with this title
+  Event::Vals::iterator it = vals.begin();
+  if (file_data_.find(path) == file_data_.end() && !fs::exists(path)) {
+    it = vals.begin();
+    while (true) {
+      header << it->first;
+      ++it;
+      if (it == vals.end()) {
+        break;
+      }
+      header << ", ";
+    }
+    file_data_[path].push_back(header.str());
+  }
+
+  it = vals.begin();
+  while (true) {
+    line << valAsString(it->second);
+    ++it;
+    if (it == vals.end()) {
+      break;
+    }
+    line << ", ";
+  }
+
+  file_data_[path].push_back(line.str());
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+std::string CsvBack::valAsString(boost::spirit::hold_any& v) {
+  std::stringstream ss;
+  if (v.type() == typeid(int)) {
+    ss << v.cast<int>();
+  } else if (v.type() == typeid(float)) {
+    ss << v.cast<float>();
+  } else if (v.type() == typeid(double)) {
+    ss << v.cast<double>();
+  } else if (v.type() == typeid(std::string)) {
+    ss << "\"" << v.cast<std::string>() << "\"";
+  } else if (v.type() == typeid(boost::uuids::uuid)) {
+    boost::uuids::uuid u = v.cast<boost::uuids::uuid>();
+    ss << "\"" << boost::lexical_cast<std::string>(u) << "\"";
+  } else {
+    ss << "\"unsupported-type: " << v.type().name() << "\"";
+    CLOG(LEV_ERROR) << "attempted to record unsupported type '"
+                    << v.type().name() << "' in backend "
+                    << name();
+  }
+  return ss.str();
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+void CsvBack::flush() {
+  std::map<std::string, LineList>::iterator it;
+  for (it = file_data_.begin(); it != file_data_.end(); it++) {
+    LineList lines = it->second;
+
+    std::ofstream file;
+    file.open(it->first.c_str(), std::fstream::in | std::fstream::app);
+    for (int i = 0; i < lines.size(); ++i) {
+      file << lines[i] << std::endl;
+    }
+    file.close();
+    file_data_[it->first].clear();
+  }
+}
+

--- a/src/Core/Utility/CsvBack.h
+++ b/src/Core/Utility/CsvBack.h
@@ -1,0 +1,58 @@
+// CsvBack.h
+#pragma once
+
+#include "EventBackend.h"
+#include "any.hpp"
+
+#include <string>
+#include <boost/filesystem.hpp>
+
+typedef std::vector<std::string> LineList;
+
+/*!
+An EventManager backend that writes data to a collection of csv files.
+Identically named events have their data placed in the same file.  Handles the
+following event value types: int, float, double, std::string.
+*/
+class CsvBack: public EventBackend {
+  public:
+    /*!
+    Creates a new csv backend that will write to a set of csv files in path
+
+    @param path directory to place csv file into
+    @param overwrite true to overwrite existing csv files with same path/name.
+    */
+    CsvBack(std::string path, bool overwrite = false);
+
+    /*!
+    Collect events to be written to csv files.
+
+    @param events group of events to write to the csv file collection.
+    */
+    void notify(EventList events);
+
+    std::string name();
+
+    /// Writes any remaining csv lines to files.
+    void close();
+
+  protected: // for testing
+
+    /// Write all buffered csv lines.
+    virtual void flush();
+
+    /// maps filenames to pending csv lines
+    std::map<std::string, LineList> file_data_;
+
+  private:
+
+    /// converts the value to a valid csv value string.
+    std::string valAsString(boost::spirit::hold_any& v);
+
+    /// constructs a valid csv line for the event and queues it for writing
+    void writeEvent(Event* e);
+
+    /// Stores the database's path, declared during construction.
+    boost::filesystem::path path_;
+};
+

--- a/src/Testing/CMakeLists.txt
+++ b/src/Testing/CMakeLists.txt
@@ -14,6 +14,7 @@ set ( CYCLUS_TEST_CORE
   ${CMAKE_CURRENT_SOURCE_DIR}/CommodityProducerTests.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/CommodityProducerManagerTests.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/CommodityTestHelper.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/CsvBackTests.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/CycArithmeticTests.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/EnrichmentTests.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/EnvironmentTests.cpp

--- a/src/Testing/CsvBackTests.cpp
+++ b/src/Testing/CsvBackTests.cpp
@@ -1,0 +1,67 @@
+#include <gtest/gtest.h>
+
+#include "CsvBack.h"
+#include "boost/lexical_cast.hpp"
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/filesystem.hpp>
+#include <fstream>
+
+static std::string const path = "testdb.csv";
+namespace fs = boost::filesystem;
+
+class DirDel {
+  public:
+    DirDel(std::string path) : path_(path) { };
+    ~DirDel() {fs::remove_all(path);};
+  private:
+    std::string path_;
+};
+
+//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+TEST(CsvBackTest, Regression) {
+  DirDel dd(path);
+
+  EventManager m;
+  CsvBack back(path);
+  m.registerBackend(&back);
+  m.newEvent("DumbTitle")
+   ->addVal("animal", std::string("monkey"))
+   ->addVal("weight", 10)
+   ->addVal("height", 5.5)
+   ->record();
+  m.newEvent("DumbTitle")
+   ->addVal("animal", std::string("elephant"))
+   ->addVal("weight", 1000)
+   ->addVal("height", 7.2)
+   ->record();
+  m.close();
+
+  // make sure append works
+  EventManager m2;
+  CsvBack back2(path);
+  m2.registerBackend(&back2);
+  m2.newEvent("DumbTitle")
+   ->addVal("animal", std::string("sea cucumber"))
+   ->addVal("weight", 1)
+   ->addVal("height", .4)
+   ->record();
+  m2.close();
+
+  std::string sid1 = boost::lexical_cast<std::string>(m.sim_id());
+  std::string sid2 = boost::lexical_cast<std::string>(m2.sim_id());
+  std::vector<std::string> lines(4);
+  lines[0] = "SimID, animal, weight, height";
+  lines[1] = std::string("\"") + sid1 + std::string("\", \"monkey\", 10, 5.5");
+  lines[2] = std::string("\"") + sid1 + std::string("\", \"elephant\", 1000, 7.2");
+  lines[3] = std::string("\"") + sid2 + std::string("\", \"sea cucumber\", 1, 0.4");
+
+  std::string fname = path + "/" + "DumbTitle.csv";
+  std::ifstream file(fname.c_str());
+  std::string str;
+  int count = 0;
+  while(std::getline(file, str)) {
+    EXPECT_EQ(lines[count], str);
+    ++count;
+  }
+}
+


### PR DESCRIPTION
use `cyclus -o=[dirname].csv ...` and cyclus will write data to a set of csv files (one per table) in the named directory.  Multiple simulations' data in files is supported.
