### PR TITLE
Cycamore hotfix

### DIFF
--- a/src/Testing/converter_model_tests.cc
+++ b/src/Testing/converter_model_tests.cc
@@ -1,7 +1,7 @@
 // Convertermodel_tests.cc 
 #include <gtest/gtest.h>
 
-#include "Convertermodel_tests.h"
+#include "converter_model_tests.h"
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 TEST_P(ConverterModelTests, ConverterType) {

--- a/src/Testing/facility_model_tests.cc
+++ b/src/Testing/facility_model_tests.cc
@@ -1,7 +1,7 @@
 // facility_model_tests.cc 
 #include <gtest/gtest.h>
 
-#include "Facilitymodel_tests.h"
+#include "facility_model_tests.h"
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 TEST_P(FacilityModelTests, DISABLED_Tick) {

--- a/src/Testing/inst_model_tests.cc
+++ b/src/Testing/inst_model_tests.cc
@@ -1,7 +1,7 @@
 // inst_model_tests.cc 
 #include <gtest/gtest.h>
 
-#include "Instmodel_tests.h"
+#include "inst_model_tests.h"
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 //- - - - - - - - - - - Param per-Inst Tests  - - - - - - - - - - - - - - - 

--- a/src/Testing/market_model_tests.cc
+++ b/src/Testing/market_model_tests.cc
@@ -1,7 +1,7 @@
 // market_model_tests.cc 
 #include <gtest/gtest.h>
 
-#include "Marketmodel_tests.h"
+#include "market_model_tests.h"
 #include <string>
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

--- a/src/Testing/region_model_tests.cc
+++ b/src/Testing/region_model_tests.cc
@@ -1,7 +1,7 @@
 // Regionmodel_tests.cc 
 #include <gtest/gtest.h>
 
-#include "Regionmodel_tests.h"
+#include "region_model_tests.h"
 #include "test_facility.h"
 #include <string>
 

--- a/src/Testing/region_model_tests.h
+++ b/src/Testing/region_model_tests.h
@@ -1,7 +1,7 @@
 // Regionmodel_tests.h
 #include <gtest/gtest.h>
 
-#include "Regionmodel.h"
+#include "region_model.h"
 #include "suffix.h"
 #include "test_region.h"
 

--- a/src/Testing/stub_comm_model_tests.h
+++ b/src/Testing/stub_comm_model_tests.h
@@ -1,7 +1,7 @@
 // stub_comm_model_tests.h
 #include <gtest/gtest.h>
 
-#include "StubCommmodel.h"
+#include "stub_comm_model.h"
 #include "suffix.h"
 
 #if GTEST_HAS_PARAM_TEST

--- a/src/Testing/stub_model_tests.h
+++ b/src/Testing/stub_model_tests.h
@@ -1,7 +1,7 @@
 // stub_model_tests.h
 #include <gtest/gtest.h>
 
-#include "Stubmodel.h"
+#include "stub_model.h"
 #include "suffix.h"
 
 #if GTEST_HAS_PARAM_TEST


### PR DESCRIPTION
fixes some naming issues in tests that only crop up when you combine with cycamore. this issue should go away once we incorporate source and sink facilities in cyclus.
