### PR TITLE
undisabled building manager bug

### DIFF
--- a/src/Testing/building_manager_tests.cc
+++ b/src/Testing/building_manager_tests.cc
@@ -40,13 +40,13 @@ void BuildingManagerTests::SetUpProblem()
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(BuildingManagerTests,init) 
+TEST_F(BuildingManagerTests, init) 
 {
   EXPECT_THROW(manager.UnRegisterBuilder(builder1), cyclus::KeyError);
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(BuildingManagerTests,registration) 
+TEST_F(BuildingManagerTests, registration) 
 {
   EXPECT_NO_THROW(manager.RegisterBuilder(builder1));
   EXPECT_THROW(manager.RegisterBuilder(builder1), cyclus::KeyError);
@@ -55,7 +55,7 @@ TEST_F(BuildingManagerTests,registration)
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(BuildingManagerTests,DISABLED_problem) 
+TEST_F(BuildingManagerTests, problem) 
 {
   using cyclus::action_building::BuildOrder;
   SetUpProblem();
@@ -74,7 +74,7 @@ TEST_F(BuildingManagerTests,DISABLED_problem)
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(BuildingManagerTests,emptyorder) 
+TEST_F(BuildingManagerTests, emptyorder) 
 {
   using cyclus::action_building::BuildOrder;
   SetUpProblem();


### PR DESCRIPTION
Went to try to fix issue #504, rebuilt everything on the utk mac, and all tests pass. I blew all my install/build directories away to make sure, and it passed as well. The original problem was fixed in PR #566, but there were still issues. I've now fully tested this on all the platforms I can (Debian - CAE, Ubuntu - home, Darwin - insam), and all tests pass, so I'm ready to say this fixes #504 and can be pulled).
