### PR TITLE
removed singleton references in documentation

### DIFF
--- a/src/Core/env.h
+++ b/src/Core/env.h
@@ -8,8 +8,9 @@
 namespace cyclus {
 
 /// @class Env
-/// A (singleton) environment utility to help locate
-/// files and find environment settings
+/// An environment utility to help locate files and find environment
+/// settings. The environment for a given simulation can be accessed via the
+/// simulation's Context.
 class Env {
  private:
   /// the relative path from cwd to cyclus

--- a/src/Core/timer.h
+++ b/src/Core/timer.h
@@ -16,7 +16,8 @@ namespace cyclus {
 /**
    @class Timer
 
-   A (singleton) timer to control a simulation with a one-month time
+   A timer to control a simulation with a one-month time step. The timer for a
+   given simulation can be accessed via the simulation's Context.
  */
 class Timer {
  public:


### PR DESCRIPTION
This is the final step that fixes #567. We still use a singleton pool in the Event class, but from my understanding of the singleton pool is that this behavior is actually what we desire (i.e., threadsafe heap allocation of events).
