### PR TITLE
adjusted environment to search build directory if libraries aren't found...

### DIFF
--- a/src/Core/env.cpp.in
+++ b/src/Core/env.cpp.in
@@ -111,6 +111,10 @@ bool Env::FindModuleLib(const std::string name,
                         boost::filesystem::path& path_found) {
   // explicitly check the install path first
   bool found = FindFile(GetInstallPath(), name, path_found);
+  // check the build dir next
+  if (!found) {
+    found = FindFile(GetBuildPath(), name, path_found);
+  }
 
   // append env var dirs
   std::vector<std::string> dirs;


### PR DESCRIPTION
... in install directory, allows for tests to pass when using of make, make test, make install workflow. fixes #592.
