### PR TITLE
test driver now adds the build directory to the cyclus module path. fixe...

### DIFF
--- a/src/Testing/cyclus_unit_test_driver.cc
+++ b/src/Testing/cyclus_unit_test_driver.cc
@@ -18,7 +18,6 @@ int main(int argc, char* argv[]) {
   // add the build path to the environment for testing
   std::string test_env = Env::ModuleEnvVarName() + "=" + Env::GetBuildPath();
   std::string curr_var = Env::ModuleEnvVar();
-  std::string new_var = "";
   if (curr_var != "") {
     test_env += ":" + curr_var;
   }


### PR DESCRIPTION
...s #592. note that this overwrites the global module variable only for the test driver's environment.

provides a second solution, per @rwcarlsen's comments.
