### PR TITLE
updated version.h.in to work on insam

### DIFF
--- a/src/version.h.in
+++ b/src/version.h.in
@@ -9,6 +9,10 @@
 #include "libxml/xmlversion.h"
 #include "CbcConfig.h"
 
+// required for coin-cbc v < 2.5
+#ifndef CBC_VERSION
+  #define CBC_VERSION CBCVERSION
+#endif
 
 namespace cyclus {
 namespace version {


### PR DESCRIPTION
- removed coin prefix on the include
- added preprocessor directive in case version name wasn't defined (thanks @gnuke!)
