### PR TITLE
change module install dir to not be split into separate fac, reg, inst subdirs

### DIFF
--- a/CMake/CyclusModuleMacros.cmake
+++ b/CMake/CyclusModuleMacros.cmake
@@ -15,11 +15,11 @@ macro(cyclus_init  _path _dir _name)
     )
 endmacro()
   
-macro(cyclus_init_model _type _dir _name)
-  SET(MODEL_PATH "/cyclus/${_type}/${_dir}")
+macro(cyclus_init_model _dir _name)
+  SET(MODEL_PATH "/cyclus/${_dir}")
   cyclus_init(${MODEL_PATH} ${_dir} ${_name})
 
-  SET(${_type}TestSource ${${_type}TestSource} 
+  SET(TestSource ${TestSource} 
     ${CMAKE_CURRENT_SOURCE_DIR}/${_name}_tests.cc
     PARENT_SCOPE)
 endmacro()

--- a/src/env.cc.in
+++ b/src/env.cc.in
@@ -108,19 +108,33 @@ const std::string Env::ModuleEnvVar() {
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-std::vector<std::string> Env::ListModules(std::string type) {
-  fs::path modelpath = Env::module_install_path() + "/" + type;
-  fs::recursive_directory_iterator end;
+std::vector<std::string> Env::ListModules() {
   std::vector<std::string> names;
-  for (fs::recursive_directory_iterator it(modelpath); it != end; ++it) {
-    fs::path p = it->path();
-    // build refs and includes
-    if (p.extension() == SUFFIX) {
-      std::string name = p.stem().string();
-      name = name.erase(0, 3); // remove lib prefix
-      names.push_back(name);
+
+  std::vector<std::string> dirs;
+  boost::split(dirs, ModuleEnvVar(), boost::is_any_of(EnvDelimiter()),
+               boost::token_compress_on);
+  dirs.push_back(Env::module_install_path());
+  fs::recursive_directory_iterator end;
+  for (int i = 0; i < dirs.size(); ++i) {
+    if (dirs[i] == "") {
+      continue;
+    }
+
+    try {
+      for (fs::recursive_directory_iterator it(dirs[i]); it != end; ++it) {
+        fs::path p = it->path();
+        if (p.extension() == SUFFIX) {
+          std::string name = p.stem().string();
+          name = name.erase(0, 3); // remove lib prefix
+          names.push_back(name);
+        }
+      }
+    } catch (boost::filesystem::filesystem_error err) {
+      continue;
     }
   }
+
   return names;
 }
 

--- a/src/env.h
+++ b/src/env.h
@@ -86,13 +86,14 @@ class Env {
   /// @return the current value of the module environment variable
   static const std::string ModuleEnvVar();
 
-  /// Returns names of all dynamically loadable, installed modules of the
-  /// specified type.
+  /// Returns names of all dynamically loadable, discoverable modules.
+  /// Returned lists includes modules installed in the default location
+  /// (module_install_path) as well as modules in directories listed in the
+  /// CYCLUS_MODULE_PATH environment variable.
   ///
-  /// @param type one of "Region", "Inst", "Facility", etc.
   /// @return module names without the "lib" prefix or file extension.
   /// Equivalent to the module class name (e.g. SourceFacility).
-  static std::vector<std::string> ListModules(std::string type);
+  static std::vector<std::string> ListModules();
 
   /// @return the correct environment variable delimeter based on the file system
   static const std::string EnvDelimiter();

--- a/src/xml_file_loader.h
+++ b/src/xml_file_loader.h
@@ -3,7 +3,6 @@
 #define _XMLFILELOADER_H
 
 #include <map>
-#include <set>
 #include <string>
 #include <sstream>
 #include <boost/shared_ptr.hpp>

--- a/tests/test_modules/CMakeLists.txt
+++ b/tests/test_modules/CMakeLists.txt
@@ -1,4 +1,4 @@
-cyclus_init_model("Facility" "TestFacility" "test_facility")
-cyclus_init_model("Inst" "TestInst" "test_inst")
-cyclus_init_model("Region" "TestRegion" "test_region")
-cyclus_init_model("Market" "TestMarket" "test_market")
+cyclus_init_model("TestFacility" "test_facility")
+cyclus_init_model("TestInst" "test_inst")
+cyclus_init_model("TestRegion" "test_region")
+cyclus_init_model("TestMarket" "test_market")


### PR DESCRIPTION
Also made Env::ListModules more robust and include CYCLUS_MODULE_PATH env var dirs in search. Note companion PR in cycamore.
