### PR TITLE
Fix bugs in resource tracking

### DIFF
--- a/src/res_tracker.cc
+++ b/src/res_tracker.cc
@@ -41,11 +41,11 @@ void ResTracker::Extract(ResTracker* removed) {
 
   parent1_ = res_->id();
   parent2_ = 0;
-  Record();
-
-  removed->tracked_ = tracked_;
   removed->parent1_ = res_->id();
   removed->parent2_ = 0;
+  removed->tracked_ = tracked_;
+
+  Record();
   removed->Record();
 }
 
@@ -64,6 +64,7 @@ void ResTracker::Record() {
   ctx_->NewEvent("Resources")
   ->AddVal("ID", res_->id())
   ->AddVal("Type", res_->type())
+  ->AddVal("TimeCreated", ctx_->time())
   ->AddVal("Quantity", res_->quantity())
   ->AddVal("units", res_->units())
   ->AddVal("StateId", res_->state_id())

--- a/src/transaction.cc
+++ b/src/transaction.cc
@@ -46,16 +46,16 @@ Transaction* Transaction::Clone() {
 void Transaction::ApproveTransfer() {
   std::vector<Resource::Ptr> manifest;
   manifest = supplier_->RemoveResource(*this);
-  requester_->AddResource(*this, manifest);
 
   // register that this transaction occured
   this->Transaction::AddTransToTable();
   int nResources = manifest.size();
-
   for (int pos = 0; pos < nResources; pos++) {
     // record that what resources belong to this transaction
     this->Transaction::AddResourceToTable(pos + 1, manifest.at(pos));
   }
+
+  requester_->AddResource(*this, manifest);
 
   CLOG(LEV_INFO3) << "Material sent from " << supplier_->id() << " to "
                   << requester_->id() << ".";


### PR DESCRIPTION
- fixed res_tracker class where it was bumping an id before recording the original id.
- added a new col to the Resource table for the time a material object was created to assist in inventory calculation
- fixed a bug where transactions recorded transaction data AFTER sending resources to the receiving agent - potentially allowing the receiver to modify the resources before data were recorded.
