### PR TITLE
changed resource creation to take "this" ptr instead of context ptr.

### DIFF
--- a/src/generic_resource.cc
+++ b/src/generic_resource.cc
@@ -10,11 +10,12 @@ namespace cyclus {
 const ResourceType GenericResource::kType = "GenericResource";
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-GenericResource::Ptr GenericResource::Create(Context* ctx,
+GenericResource::Ptr GenericResource::Create(Model* creator,
                                              double quantity,
                                              std::string quality,
                                              std::string units) {
-  GenericResource::Ptr r(new GenericResource(ctx, quantity, quality, units));
+  GenericResource::Ptr r(new GenericResource(creator->context(), quantity,
+                                             quality, units));
   r->tracker_.Create();
   return r;
 }
@@ -70,6 +71,7 @@ Resource::Ptr GenericResource::ExtractRes(double qty) {
 GenericResource::GenericResource(Context* ctx, double quantity,
                                  std::string quality,
                                  std::string units)
-  : units_(units), quality_(quality), quantity_(quantity), tracker_(ctx, this), ctx_(ctx) { }
+  : units_(units), quality_(quality), quantity_(quantity), tracker_(ctx, this),
+    ctx_(ctx) { }
 
 } // namespace cyclus

--- a/src/generic_resource.h
+++ b/src/generic_resource.h
@@ -20,9 +20,11 @@ class GenericResource : public Resource {
   boost::shared_ptr<GenericResource> Ptr;
   static const ResourceType kType;
 
-  /// Creates a new generic resource that is "live" and tracked. All future
-  /// output data recorded will be done using the passed simulation context ctx.
-  static Ptr Create(Context* ctx, double quantity, std::string quality,
+  /// Creates a new generic resource that is "live" and tracked. creator is a
+  /// pointer to the model creating the resource (usually will be the caller's
+  /// "this" pointer). All future output data recorded will be done using the
+  /// creator's context.
+  static Ptr Create(Model* creator, double quantity, std::string quality,
                     std::string units);
 
   /// Creates a new generic resource that does not actually exist as part of

--- a/src/material.cc
+++ b/src/material.cc
@@ -15,16 +15,16 @@ Material::~Material() {
   all_mats_.erase(this);
 }
 
-Material::Ptr Material::Create(Context* ctx, double quantity,
+Material::Ptr Material::Create(Model* creator, double quantity,
                                Composition::Ptr c) {
-  Material::Ptr m(new Material(ctx, quantity, c));
+  Material::Ptr m(new Material(creator->context(), quantity, c));
   m->tracker_.Create();
   return m;
 }
 
-Material::Ptr Material::CreateUntracked(Context* ctx, double quantity,
+Material::Ptr Material::CreateUntracked(double quantity,
                                         Composition::Ptr c) {
-  Material::Ptr m(new Material(ctx, quantity, c));
+  Material::Ptr m(new Material(NULL, quantity, c));
   m->tracker_.DontTrack();
   return m;
 }
@@ -128,9 +128,12 @@ Composition::Ptr Material::comp() const {
 }
 
 Material::Material(Context* ctx, double quantity, Composition::Ptr c)
-  : qty_(quantity), comp_(c), tracker_(ctx, this), ctx_(ctx) {
+  : qty_(quantity), comp_(c), tracker_(ctx, this), ctx_(ctx),
+    prev_decay_time_(0) {
   all_mats_[this] = true;
-  prev_decay_time_ = ctx->time();
+  if (ctx != NULL) {
+    prev_decay_time_ = ctx->time();
+  }
 }
 
 } // namespace cyclus

--- a/src/material.h
+++ b/src/material.h
@@ -43,8 +43,8 @@ const double ug = kg* .000000001;
 /// * A conversion facility mixing uranium and flourine:
 ///
 ///   @code
-///   Material::Ptr uf6 = uranium_buf.PopOne();
-///   Material::Ptr f = flourine_buf.PopOne();
+///   Material::Ptr uf6 = uranium_buf.Pop();
+///   Material::Ptr f = flourine_buf.Pop();
 ///
 ///   uf6.Absorb(f);
 ///   @endcode
@@ -53,7 +53,7 @@ const double ug = kg* .000000001;
 ///
 ///   @code
 ///   Composition::Ptr burned_comp = ... // fancy code to calculate burned isotopics
-///   Material::Ptr assembly = core_fuel.PopOne();
+///   Material::Ptr assembly = core_fuel.Pop();
 ///
 ///   assembly.Transmute(burned_comp);
 ///   @endcode
@@ -62,7 +62,7 @@ const double ug = kg* .000000001;
 ///
 ///   @code
 ///   Composition::Ptr comp = ... // fancy code to calculate extraction isotopics
-///   Material::Ptr bucket = spent_fuel.PopOne();
+///   Material::Ptr bucket = spent_fuel.Pop();
 ///   double qty = 3.0;
 ///
 ///   Material::Ptr mox = bucket.ExtractComp(qty, comp);
@@ -75,13 +75,15 @@ class Material: public Resource {
 
   virtual ~Material();
 
-  /// Creates a new material resource that is "live" and tracked. All future
-  /// output data recorded will be done using the passed simulation context ctx.
-  static Ptr Create(Context* ctx, double quantity, Composition::Ptr c);
+  /// Creates a new material resource that is "live" and tracked. creator is a
+  /// pointer to the model creating the resource (usually will be the caller's
+  /// "this" pointer). All future output data recorded will be done using the
+  /// creator's context.
+  static Ptr Create(Model* creator, double quantity, Composition::Ptr c);
 
   /// Creates a new material resource that does not actually exist as part of
   /// the simulation and is untracked.
-  static Ptr CreateUntracked(Context* ctx, double quantity, Composition::Ptr c);
+  static Ptr CreateUntracked(double quantity, Composition::Ptr c);
 
   /// Returns the id of the material's internal nuclide composition.
   virtual int state_id() const;

--- a/src/resource.h
+++ b/src/resource.h
@@ -19,6 +19,8 @@ class Resource {
  public:
   typedef boost::shared_ptr<Resource> Ptr;
 
+  Resource() : id_(0) { };
+
   virtual ~Resource() { };
 
   /// Returns the unique id corresponding to this resource and its current

--- a/tests/enrichment_tests.cc
+++ b/tests/enrichment_tests.cc
@@ -33,7 +33,7 @@ void EnrichmentTests::SetUp() {
   v[92235] = assay_u_;
   v[92238] = 1 - assay_u_;
   Composition::Ptr comp = Composition::CreateFromAtom(v);
-  mat_ = Material::Create(&ctx, mass_u_, comp);
+  mat_ = Material::CreateUntracked(mass_u_, comp);
 
   SetEnrichmentParameters();
 }

--- a/tests/mat_query_tests.cc
+++ b/tests/mat_query_tests.cc
@@ -20,7 +20,7 @@ TEST(MatQueryTests, MassAndMoles) {
   v[92235] = 1.5;
   v[1008] = 2.5;
   cyclus::Composition::Ptr c = cyclus::Composition::CreateFromMass(v);
-  cyclus::Material::Ptr m = cyclus::Material::Create(&ctx, 4.0, c);
+  cyclus::Material::Ptr m = cyclus::Material::CreateUntracked(4.0, c);
 
   cyclus::MatQuery mq(m);
 
@@ -46,25 +46,25 @@ TEST(MatQueryTests, AlmostEq) {
   v[92235] = 1.5;
   v[1008] = 2.5;
   c = cyclus::Composition::CreateFromMass(v);
-  cyclus::Material::Ptr m1 = cyclus::Material::Create(&ctx, 4.0, c);
+  cyclus::Material::Ptr m1 = cyclus::Material::CreateUntracked(4.0, c);
   cyclus::MatQuery mq(m1);
 
-  cyclus::Material::Ptr m2 = cyclus::Material::Create(&ctx, 4.0, c);
+  cyclus::Material::Ptr m2 = cyclus::Material::CreateUntracked(4.0, c);
   EXPECT_TRUE(mq.AlmostEq(m2, 0));
 
   c = cyclus::Composition::CreateFromMass(v);
-  cyclus::Material::Ptr m3 = cyclus::Material::Create(&ctx, 4.0, c);
+  cyclus::Material::Ptr m3 = cyclus::Material::CreateUntracked(4.0, c);
   EXPECT_TRUE(mq.AlmostEq(m3, 0));
 
   v[1008] += 0.99 * cyclus::eps_rsrc();
   c = cyclus::Composition::CreateFromMass(v);
-  cyclus::Material::Ptr m4 = cyclus::Material::Create(&ctx, 4.0, c);
+  cyclus::Material::Ptr m4 = cyclus::Material::CreateUntracked(4.0, c);
   EXPECT_FALSE(mq.AlmostEq(m4, 0));
   EXPECT_TRUE(mq.AlmostEq(m4, cyclus::eps_rsrc()));
 
   v[1008] += 4.0 * cyclus::eps_rsrc();
   c = cyclus::Composition::CreateFromMass(v);
-  cyclus::Material::Ptr m5 = cyclus::Material::Create(&ctx, 4.0, c);
+  cyclus::Material::Ptr m5 = cyclus::Material::CreateUntracked(4.0, c);
   EXPECT_FALSE(mq.AlmostEq(m5, cyclus::eps_rsrc()));
   EXPECT_TRUE(mq.AlmostEq(m5, 4.0 * cyclus::eps_rsrc()));
 }

--- a/tests/material_tests.cc
+++ b/tests/material_tests.cc
@@ -17,7 +17,7 @@ using cyclus::Material;
 TEST_F(MaterialTest, Constructors) {
   EXPECT_EQ(default_mat_->units(), "kg");
   EXPECT_EQ(default_mat_->type(), cyclus::Material::kType);
-  EXPECT_GE(default_mat_->id(), 1);
+  EXPECT_GE(default_mat_->id(), 0);
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -43,8 +43,8 @@ TEST_F(MaterialTest, ExtractRes) {
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(MaterialTest, SimpleAbsorb) {
   double val = 1.5 * units::kg;
-  cyclus::Material::Ptr m1 = cyclus::Material::Create(ctx_, val, test_comp_);
-  cyclus::Material::Ptr m2 = cyclus::Material::Create(ctx_, val, test_comp_);
+  cyclus::Material::Ptr m1 = cyclus::Material::CreateUntracked(val, test_comp_);
+  cyclus::Material::Ptr m2 = cyclus::Material::CreateUntracked(val, test_comp_);
   ASSERT_EQ(m1->comp(), m2->comp());
   ASSERT_EQ(m1->quantity(), m2->quantity());
 
@@ -60,9 +60,9 @@ TEST_F(MaterialTest, AbsorbLikeMaterial) {
   cyclus::Material::Ptr mat1;
   cyclus::Material::Ptr mat2;
   cyclus::Material::Ptr mat10;
-  mat1 = cyclus::Material::Create(ctx_, 1 * test_size_, test_comp_);
-  mat2 = cyclus::Material::Create(ctx_, 2 * test_size_, test_comp_);
-  mat10 = cyclus::Material::Create(ctx_, 10 * test_size_, test_comp_);
+  mat1 = cyclus::Material::CreateUntracked(1 * test_size_, test_comp_);
+  mat2 = cyclus::Material::CreateUntracked(2 * test_size_, test_comp_);
+  mat10 = cyclus::Material::CreateUntracked(10 * test_size_, test_comp_);
 
   // see that two materials with the same composition do the right thing
   double orig = test_mat_->quantity();
@@ -85,7 +85,7 @@ TEST_F(MaterialTest, AbsorbLikeMaterial) {
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(MaterialTest, AbsorbUnLikeMaterial) {
   // make a number of materials masses 1, 2, and 10
-  cyclus::Material::Ptr same_as_orig_test_mat = cyclus::Material::Create(ctx_, 0,
+  cyclus::Material::Ptr same_as_orig_test_mat = cyclus::Material::CreateUntracked(0,
                                                 test_comp_);
 
   CompMap v;
@@ -94,7 +94,7 @@ TEST_F(MaterialTest, AbsorbUnLikeMaterial) {
   v[th228_] = 1.0 * units::g;
   cyclus::Composition::Ptr diff_test_comp = cyclus::Composition::CreateFromMass(
                                               v);
-  cyclus::Material::Ptr diff_test_mat = cyclus::Material::Create(ctx_,
+  cyclus::Material::Ptr diff_test_mat = cyclus::Material::CreateUntracked(
                                         test_size_ / 2,
                                         diff_test_comp);
 
@@ -116,14 +116,14 @@ TEST_F(MaterialTest, AbsorbUnLikeMaterial) {
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(MaterialTest, AbsorbZeroMaterial) {
-  Material::Ptr same_as_test_mat = Material::Create(ctx_, 0, test_comp_);
+  Material::Ptr same_as_test_mat = Material::CreateUntracked(0, test_comp_);
   EXPECT_NO_THROW(test_mat_->Absorb(same_as_test_mat));
   EXPECT_FLOAT_EQ(test_size_, test_mat_->quantity());
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(MaterialTest, AbsorbIntoZeroMaterial) {
-  Material::Ptr same_as_test_mat = Material::Create(ctx_, 0, test_comp_);
+  Material::Ptr same_as_test_mat = Material::CreateUntracked(0, test_comp_);
   EXPECT_NO_THROW(same_as_test_mat->Absorb(test_mat_));
   EXPECT_FLOAT_EQ(test_size_, same_as_test_mat->quantity());
 }

--- a/tests/material_tests.h
+++ b/tests/material_tests.h
@@ -3,10 +3,7 @@
 #include <gtest/gtest.h>
 
 #include "composition.h"
-#include "context.h"
-#include "event_manager.h"
 #include "material.h"
-#include "timer.h"
 
 namespace units = cyclus::units;
 
@@ -24,13 +21,7 @@ class MaterialTest : public ::testing::Test {
   int th228_halflife_;
   double u235_g_per_mol_;
 
-  cyclus::EventManager em_;
-  cyclus::Timer ti_;
-  cyclus::Context* ctx_;
-
   virtual void SetUp() {
-    ctx_ = new cyclus::Context(&ti_, &em_);
-
     // composition set up
     u235_ = 92235;
     am241_ = 95241;
@@ -49,11 +40,11 @@ class MaterialTest : public ::testing::Test {
     v[am241_] = 1;
     diff_comp_ = cyclus::Composition::CreateFromMass(v);
 
-    default_mat_ = cyclus::Material::Create(ctx_, 0 * units::g, test_comp_);
-    test_mat_ = cyclus::Material::Create(ctx_, test_size_, test_comp_);
-    two_test_mat_ = cyclus::Material::Create(ctx_, 2 * test_size_, test_comp_);
-    ten_test_mat_ = cyclus::Material::Create(ctx_, 10 * test_size_, test_comp_);
-    diff_mat_ = cyclus::Material::Create(ctx_, test_size_, diff_comp_);
+    default_mat_ = cyclus::Material::CreateUntracked(0 * units::g, test_comp_);
+    test_mat_ = cyclus::Material::CreateUntracked(test_size_, test_comp_);
+    two_test_mat_ = cyclus::Material::CreateUntracked(2 * test_size_, test_comp_);
+    ten_test_mat_ = cyclus::Material::CreateUntracked(10 * test_size_, test_comp_);
+    diff_mat_ = cyclus::Material::CreateUntracked(test_size_, diff_comp_);
 
     // test info
     u235_g_per_mol_ = 235.044;


### PR DESCRIPTION
Allows us more flexibility in the future for resource tracking without needing to change API (e.g. we can now record who created a resource if we wanted to).  This has a companion PR in cycamore.
