### PR TITLE
Modify ResourceBuff::PopQty to be more exact.

### DIFF
--- a/cli/cyclus.cc
+++ b/cli/cyclus.cc
@@ -182,12 +182,12 @@ int main(int argc, char* argv[]) {
   Model::PrintModelList();
 
   // Run the simulation 
-  try {
+  //try {
     ti.RunSim();
-  } catch (Error err) {
-    success = false;
-    CLOG(LEV_ERROR) << err.what();
-  }
+  //} catch (Error err) {
+  //  success = false;
+  //  CLOG(LEV_ERROR) << err.what();
+  //}
 
   em.close();
   delete back;

--- a/src/resource_buff.cc
+++ b/src/resource_buff.cc
@@ -13,24 +13,23 @@ void ResourceBuff::set_capacity(double cap) {
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Manifest ResourceBuff::PopQty(double qty) {
-  if (qty - quantity() > eps_rsrc()) {
+  if (qty > quantity()) {
     throw ValueError("Removal quantity larger than store tot quantity.");
-  } else if (qty < eps_rsrc()) {
-    throw ValueError("Removal quantity cannot be negative.");
   }
 
   Manifest manifest;
-  Resource::Ptr r, leftover;
+  Resource::Ptr r, tmp;
   double left = qty;
   double quan;
-  while (left > eps_rsrc()) {
+  while (left > 0 && count() > 0) {
     r = mats_.front();
     mats_.pop_front();
     quan = r->quantity();
-    if ((quan - left) > eps_rsrc()) {
-      // too big - split the res before pushing
-      leftover = r->ExtractRes(quan - left);
-      mats_.push_front(leftover);
+    if (quan > left) {
+      // too big - split the res before popping
+      tmp = r->ExtractRes(left);
+      mats_.push_front(r);
+      r = tmp;
       qty_ -= left;
     } else {
       mats_present_.erase(r);

--- a/tests/resource_buff_tests.cc
+++ b/tests/resource_buff_tests.cc
@@ -112,77 +112,44 @@ TEST_F(ResourceBuffTest, RemoveQty_ExceptionsFilled) {
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -    
-TEST_F(ResourceBuffTest, RemoveQty_NoSplitExactFilled) {
+TEST_F(ResourceBuffTest, RemoveQty_SingleNoSplit) {
   using cyclus::Manifest;
   // pop one no splitting leaving one mat in the store
   Manifest manifest;
 
   ASSERT_NO_THROW(manifest = filled_store_.PopQty(exact_qty));
   ASSERT_EQ(manifest.size(), 1);
-  EXPECT_DOUBLE_EQ(manifest.at(0)->quantity(), mat1_->quantity());
   EXPECT_EQ(manifest.at(0), mat1_);
   EXPECT_EQ(filled_store_.count(), 1);
   EXPECT_DOUBLE_EQ(filled_store_.quantity(), mat2_->quantity());
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -    
-TEST_F(ResourceBuffTest, RemoveQty_NoSplitOverFilled) {
+TEST_F(ResourceBuffTest, RemoveQty_SingleWithSplit) {
   // pop one no splitting leaving one mat in the store
   using cyclus::Manifest;
   Manifest manifest;
 
-  ASSERT_NO_THROW(manifest = filled_store_.PopQty(exact_qty_over));
-  ASSERT_EQ(manifest.size(), 1);
-  EXPECT_DOUBLE_EQ(manifest.at(0)->quantity(), mat1_->quantity());
-  EXPECT_EQ(manifest.at(0), mat1_);
-  EXPECT_EQ(filled_store_.count(), 1);
-  EXPECT_DOUBLE_EQ(filled_store_.quantity(), mat2_->quantity());
-}
-
-//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -    
-TEST_F(ResourceBuffTest, RemoveQty_NoSplitUnderFilled) {
-  // pop one no splitting leaving one mat in the store
-  using cyclus::Manifest;
-  Manifest manifest;
-
+  double orig_qty = filled_store_.quantity();
   ASSERT_NO_THROW(manifest = filled_store_.PopQty(exact_qty_under));
   ASSERT_EQ(manifest.size(), 1);
-  EXPECT_DOUBLE_EQ(manifest.at(0)->quantity(), mat1_->quantity());
-  EXPECT_EQ(manifest.at(0), mat1_);
-  EXPECT_EQ(filled_store_.count(), 1);
-  EXPECT_DOUBLE_EQ(filled_store_.quantity(), mat2_->quantity());
-}
-
-//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -    
-TEST_F(ResourceBuffTest, RemoveQty_SplitOverFilled) {
-  // pop two with splitting leaving one mat in the store
-  using cyclus::Manifest;
-  Manifest manifest;
-  double store_final = mat1_->quantity() + mat2_->quantity() - over_qty;
-
-  ASSERT_NO_THROW(manifest = filled_store_.PopQty(over_qty));
-  ASSERT_EQ(manifest.size(), 2);
-  EXPECT_DOUBLE_EQ(manifest.at(0)->quantity(), mat1_->quantity());
-  EXPECT_NEAR(manifest.at(1)->quantity(), overeps, cyclus::eps_rsrc()); // not sure why DOUBLE_EQ doesn't work
-  EXPECT_EQ(manifest.at(0), mat1_);
-  EXPECT_EQ(manifest.at(1), mat2_);
-  EXPECT_EQ(filled_store_.count(), 1);
-  EXPECT_DOUBLE_EQ(filled_store_.quantity(), store_final);
-}
-
-//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -    
-TEST_F(ResourceBuffTest, RemoveQty_SplitUnderFilled) {
-  // pop one with splitting leaving two mats in the store
-  using cyclus::Manifest;
-  Manifest manifest;
-  double store_final = mat1_->quantity() + mat2_->quantity() - under_qty;
-
-  ASSERT_NO_THROW(manifest = filled_store_.PopQty(under_qty));
-  ASSERT_EQ(manifest.size(), 1);
-  EXPECT_DOUBLE_EQ(manifest.at(0)->quantity(), under_qty);
-  EXPECT_EQ(manifest.at(0), mat1_);
+  EXPECT_DOUBLE_EQ(manifest.at(0)->quantity(), exact_qty_under);
   EXPECT_EQ(filled_store_.count(), 2);
-  EXPECT_DOUBLE_EQ(filled_store_.quantity(), store_final);
+  EXPECT_DOUBLE_EQ(filled_store_.quantity(), orig_qty - exact_qty_under);
+}
+
+//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -    
+TEST_F(ResourceBuffTest, RemoveQty_DoubleWithSplit) {
+  // pop one no splitting leaving one mat in the store
+  using cyclus::Manifest;
+  Manifest manifest;
+
+  double orig_qty = filled_store_.quantity();
+  ASSERT_NO_THROW(manifest = filled_store_.PopQty(exact_qty_over));
+  ASSERT_EQ(manifest.size(), 2);
+  EXPECT_DOUBLE_EQ(manifest.at(0)->quantity() + manifest.at(1)->quantity(), exact_qty_over);
+  EXPECT_TRUE(filled_store_.count() == 1);
+  EXPECT_DOUBLE_EQ(filled_store_.quantity(), orig_qty - exact_qty_over);
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -    


### PR DESCRIPTION
Previously, resourcebuf would return to you a total quantity of resources +/- eps_rsrc of the quantity you tried to extract.  This is really annoying and so I have changed it.  It now does exact matching.  If you want to extract more than is there, you can't.  If you want to extract everything, then you can `buf.PopN(buf.count());.

Two examples of where the previous behavior is problematic:
- Impossible to extract a quantity less than eps_rsrc from a buffer.
- I am an enrichment facility.  I calculate the amount of natural uranium needed to satisfy an order of quantity X of arbitrary enrichment.  I extract quantity Y of necessary natural u from my natural u buffer, but my buffer quietly actually gave me slightly less than the quantity I told it to extract, Y'.  If the order enrichment happens to be for natural uranium, then X == Y.  If I every try to extract quantity X of the order's enriched composition from this popped natural u material, I get a negative quantity extraction error (rightfully), because that resource isn't actually qty>=X since Y' < Y.  So the enrichment facility would have to write special code to work around this behavior.
