### PR TITLE
re-added missing decay interval from output db

### DIFF
--- a/src/timer.cc
+++ b/src/timer.cc
@@ -244,6 +244,7 @@ void Timer::LogTimeData(Context* ctx, std::string handle) {
   ->AddVal("InitialMonth", month0_)
   ->AddVal("SimulationStart", start_time_)
   ->AddVal("Duration", dur_)
+  ->AddVal("DecayInterval", decay_interval_)
   ->Record();
 }
 } // namespace cyclus


### PR DESCRIPTION
Somewhere the decay-interval recording was removed from db.  I just added it back.  @rakhimov might need to update his integration/regression test code a bit.
