### PR TITLE
Simple input

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,7 @@ CONFIGURE_FILE(
 INSTALL(FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/mass.sqlite
     ${CMAKE_CURRENT_SOURCE_DIR}/cyclus.rng.in
+    ${CMAKE_CURRENT_SOURCE_DIR}/cyclus-flat.rng.in
     ${CMAKE_CURRENT_SOURCE_DIR}/decayInfo.dat
   DESTINATION share
   COMPONENT core
@@ -105,6 +106,7 @@ SET(CYCLUS_CORE_SRC ${CYCLUS_CORE_SRC}
   ${CMAKE_CURRENT_SOURCE_DIR}/uniform_taylor.cc 
   ${CMAKE_CURRENT_SOURCE_DIR}/variable.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/xml_file_loader.cc 
+  ${CMAKE_CURRENT_SOURCE_DIR}/xml_flat_loader.cc 
   ${CMAKE_CURRENT_SOURCE_DIR}/xml_parser.cc 
   ${CMAKE_CURRENT_SOURCE_DIR}/xml_query_engine.cc 
   )
@@ -188,6 +190,7 @@ INSTALL(FILES
   version.h
   windows_helper_functions.h
   xml_file_loader.h
+  xml_flat_loader.h
   xml_parser.h
   xml_query_engine.h
   DESTINATION include/cyclus

--- a/src/builder.cc
+++ b/src/builder.cc
@@ -12,37 +12,37 @@ Builder::~Builder() {}
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Builder::RegisterProducer(CommodityProducer* producer) {
-  if (producers_.find(producer) != producers_.end()) {
+  if (commod_producers_.find(producer) != commod_producers_.end()) {
     throw KeyError("A builder is trying to register a producer twice.");
   } else {
-    producers_.insert(producer);
+    commod_producers_.insert(producer);
   }
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Builder::UnRegisterProducer(CommodityProducer* producer) {
-  if (producers_.find(producer) == producers_.end()) {
+  if (commod_producers_.find(producer) == commod_producers_.end()) {
     throw KeyError("A builder is trying to unregister a producer not originally registered with it.");
   } else {
-    producers_.erase(producer);
+    commod_producers_.erase(producer);
   }
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 double Builder::NBuildingPrototypes() {
-  return producers_.size();
+  return commod_producers_.size();
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 std::set<CommodityProducer*>::iterator
 Builder::BeginningProducer() {
-  return producers_.begin();
+  return commod_producers_.begin();
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 std::set<CommodityProducer*>::iterator
 Builder::EndingProducer() {
-  return producers_.end();
+  return commod_producers_.end();
 }
 
 } // namespace cyclus

--- a/src/builder.h
+++ b/src/builder.h
@@ -36,9 +36,9 @@ class Builder {
   /// @return the beginning iterator of the set of producers
   std::set<CommodityProducer*>::iterator EndingProducer();
 
- private:
+ protected:
   /// the set of managed producers
-  std::set<CommodityProducer*> producers_;
+  std::set<CommodityProducer*> commod_producers_;
 
   //#include "commodity_producer_manager_tests.h"
   //friend class CommodityProducerManagerTests;

--- a/src/cyclus-flat.rng.in
+++ b/src/cyclus-flat.rng.in
@@ -1,0 +1,218 @@
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+<start>
+<element name="simulation">
+<interleave>
+
+  <element name ="control">
+    <interleave>
+      <optional>
+        <element name="simhandle"><data type="string"/></element>
+      </optional>
+      <element name="duration"><data type="nonNegativeInteger"/></element>
+      <element name="startmonth"><data type="nonNegativeInteger"/></element>
+      <element name="startyear"><data type="nonNegativeInteger"/></element>
+      <element name="simstart"><data type="nonNegativeInteger"/></element>
+      <element name="decay"><data type="integer"/></element>
+    </interleave>
+  </element>
+
+  <oneOrMore>
+    <element name="commodity">
+      <element name="name"><text/></element>
+    </element>
+    <optional>
+      <element name="solution_order"><data type="double"/></element>
+    </optional>
+  </oneOrMore>
+
+  <oneOrMore>
+    <element name="prototype">
+    <interleave>
+      <element name="name"><text/></element>
+
+      <!-- For compatibility with nested schema format -->
+      <!-- Facility/Inst/Region specific data -->
+      <optional>
+      <choice>
+
+        <optional>
+          <element name="lifetime">
+            <data type="nonNegativeInteger"/>
+          </element>
+        </optional>
+
+        <oneOrMore>
+          <element name="allowedfacility"><text/></element>
+        </oneOrMore>
+
+        <group>
+          <optional>
+            <oneOrMore>
+              <element name="availableprototype">
+                <text/>
+              </element>
+            </oneOrMore>
+          </optional>
+          <optional>
+            <element name="initialfacilitylist">
+              <oneOrMore>
+                <element name="entry">
+                  <element name="prototype">
+                    <text/>
+                  </element>
+                  <element name="number">
+                    <data type="nonNegativeInteger"/>
+                  </element>
+                </element>
+              </oneOrMore>
+            </element>
+          </optional>
+        </group>
+
+      </choice>
+      </optional>
+      <!-- end compatibility section -->
+
+      <element name="model">
+        <choice>
+          @MODEL_SCHEMAS@
+        </choice>
+      </element>
+      <zeroOrMore>
+        <element name="incommodity"><text/></element>
+      </zeroOrMore>
+      <zeroOrMore>
+        <element name="outcommodity"><text/></element>
+      </zeroOrMore>
+    </interleave>
+    </element>
+  </oneOrMore>
+
+  <oneOrMore>
+    <element name="agent">
+      <element name="name"><text/></element>
+      <element name="prototype"><text/></element>
+      <optional>
+        <element name="parent"><text/></element>
+      </optional>
+    </element>
+  </oneOrMore>
+
+  <zeroOrMore>
+    <element name="recipe">
+      <element name="name"><text/></element>
+      <element name="basis"><text/></element>
+      <oneOrMore>
+        <element name="isotope">
+          <element name="id"><text/></element>
+          <element name="comp"><text/></element>
+        </element>
+      </oneOrMore>
+    </element>
+  </zeroOrMore>
+
+</interleave>
+</element><!-- end of simulation -->
+</start>
+
+<!-- for compatibility with nested schema format -->
+  <define name="capacity">
+      <element name="capacity">
+        <data type="double"/>
+      </element>
+  </define>
+
+  <define name="commodprice">
+      <element name="commodprice">
+        <data type="double"/>
+      </element>
+  </define>
+
+  <define name="componenttype">
+      <element name="componenttype">
+        <data type="string"/>
+      </element>
+  </define>
+
+  <define name="incommodity">
+      <element name="incommodity">
+          <text/>
+      </element>
+  </define>
+
+  <define name="input_capacity">
+      <element name="input_capacity">
+         <data type="double"/>
+      </element>
+  </define>
+
+  <define name="innerradius">
+      <element name="innerradius">
+        <data type="double"/>
+      </element>
+  </define>
+
+  <define name="inrecipe">
+      <element name="inrecipe">
+          <text/>
+      </element>
+  </define>
+
+  <define name="inventorysize">
+      <element name="inventorysize">
+        <data type="double"/>
+      </element>
+  </define>
+
+  <define name="name">
+      <element name="name">
+        <data type="string"/>
+      </element>
+  </define>
+
+  <define name="outcommodity">
+      <element name="outcommodity">
+         <text/>
+      </element>
+  </define>
+
+  <define name="output_capacity">
+      <element name="output_capacity">
+         <data type="double"/>
+      </element>
+  </define>
+
+  <define name="outerradius">
+      <element name="outerradius">
+        <data type="double"/>
+      </element>
+  </define>
+
+  <define name="outrecipe">
+      <element name="outrecipe">
+          <text/>
+      </element>
+  </define>
+
+  <define name="startOperMonth">
+      <element name="startOperMonth">
+        <data type="nonNegativeInteger"/>
+      </element>
+  </define>
+
+  <define name="startOperYear">
+      <element name="startOperYear">
+        <data type="nonNegativeInteger"/>
+      </element>
+  </define>
+
+  <define name="tailsassay">
+      <element name="tailsassay">
+        <data type="double"/>
+      </element>
+  </define>
+<!-- end compatibility section -->
+
+</grammar>
+

--- a/src/facility_model.cc
+++ b/src/facility_model.cc
@@ -60,6 +60,7 @@ void FacilityModel::InitCoreMembers(QueryEngine* qe) {
 void FacilityModel::InitFrom(FacilityModel* m) {
   Model::InitFrom(m);
   fac_lifetime_ = m->fac_lifetime_;
+  inst_name_ = m->inst_name_;
   in_commods_ = m->in_commods_;
   out_commods_ = m->out_commods_;
 }

--- a/src/inst_model.cc
+++ b/src/inst_model.cc
@@ -21,6 +21,13 @@ InstModel::InstModel(Context* ctx) : TimeListener(ctx), Model(ctx) {
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+void InstModel::InitFrom(InstModel* m) {
+  Model::InitFrom(m);
+  this->initial_build_order_ = m->initial_build_order_;
+  this->prototypes_ = m->prototypes_;
+}
+
+//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void InstModel::InitCoreMembers(QueryEngine* qe) {
   Model::InitCoreMembers(qe);
 

--- a/src/inst_model.h
+++ b/src/inst_model.h
@@ -153,6 +153,8 @@ class InstModel : public TimeListener {
   void Build(std::string proto_name);
 
  protected:
+  void InitFrom(InstModel* m);
+
   /**
      add a prototoype to the set of available prototypes
      @param proto_name the name of the prototype to add

--- a/src/model.cc
+++ b/src/model.cc
@@ -55,6 +55,7 @@ void Model::InitCoreMembers(QueryEngine* qe) {
 Model::Model(Context* ctx)
   : ctx_(ctx),
     id_(next_id_++),
+    model_type_("Model"),
     parent_id_(-1),
     birthtime_(-1),
     deathtime_(-1),

--- a/src/model.h
+++ b/src/model.h
@@ -13,6 +13,9 @@
 #include "query_engine.h"
 #include "exchange_context.h"
 
+#define SHOW(X) \
+  std::cout << __FILE__ << ":" << __LINE__ << ": "#X" = " << X << "\n"
+
 namespace cyclus {
 
 class Material;

--- a/src/region_model.cc
+++ b/src/region_model.cc
@@ -15,6 +15,13 @@
 
 namespace cyclus {
 
+//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+void RegionModel::InitFrom(RegionModel* m) {
+  Model::InitFrom(m);
+  this->allowedFacilities_ = m->allowedFacilities_;
+  this->inst_names_ = m->inst_names_;
+}
+
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 RegionModel::RegionModel(Context* ctx) : TimeListener(ctx), Model(ctx) {
   SetModelType("Region");

--- a/src/region_model.h
+++ b/src/region_model.h
@@ -124,6 +124,8 @@ class RegionModel : public TimeListener {
   } ;
 
  protected:
+  void InitFrom(RegionModel* m);
+
   /**
      populate the region's list of allowed facilities
    */

--- a/src/xml_file_loader.h
+++ b/src/xml_file_loader.h
@@ -7,6 +7,7 @@
 #include <sstream>
 #include <boost/shared_ptr.hpp>
 
+#include "composition.h"
 #include "dynamic_module.h"
 #include "query_engine.h"
 #include "xml_parser.h"
@@ -15,10 +16,16 @@ namespace cyclus {
 
 class Context;
 
+/// Reads the given file path into the passed stream.
+void LoadStringstreamFromFile(std::stringstream& stream, std::string file);
+
 /// Builds and returns a master cyclus input xml schema that includes the
 /// sub-schemas defined by all installed cyclus modules (e.g. facility models).
 /// This is used to validate simulation input files.
-std::string BuildMasterSchema();
+std::string BuildMasterSchema(std::string schema_path);
+
+/// Creates a composition from the recipe in the query engine.
+Composition::Ptr ReadRecipe(QueryEngine* qe);
 
 /// a class that encapsulates the methods needed to load input to
 /// a cyclus simulation from xml
@@ -28,7 +35,8 @@ class XMLFileLoader {
   /// @param ctx all input file configuration will be loaded into here
   /// @param load_filename The filename for the file to be loaded; defaults to
   /// an empty string
-  XMLFileLoader(Context* ctx, const std::string load_filename = "");
+  XMLFileLoader(Context* ctx, std::string schema_path,
+                const std::string load_filename = "");
 
   virtual ~XMLFileLoader();
 
@@ -38,8 +46,8 @@ class XMLFileLoader {
 
   /// Load an entire simulation from the inputfile.
   ///
-  /// @param use_main_schema whether or not to use the main schema
-  void LoadSim(bool use_main_schema = true);
+  /// @param use_flat_schema whether or not to use the flat schema
+  virtual void LoadSim();
 
   /// Method to load the simulation exchange solver.
   void LoadSolver();
@@ -56,23 +64,19 @@ class XMLFileLoader {
   /// commodity
   void ProcessCommodities(std::map<std::string, double>* commodity_order);
 
- private:
+ protected:
+  virtual std::string master_schema();
+
   /// Creates all initial agent instances from the input file.
-  void LoadInitialAgents();
-
-  /// Method to load all dyamic modules
-  void LoadDynamicModules();
-
-  /// loads a specific recipe
-  void LoadRecipe(QueryEngine* qe);
-
-  /// a map of module types to their paths in xml
-  std::map<std::string, std::string> schema_paths_;
+  virtual void LoadInitialAgents();
 
   Context* ctx_;
 
-  /// the input file name
-  std::string file_;
+  /// filepath to the schema
+  std::string schema_path_;
+
+  /// a map of module types to their paths in xml
+  std::map<std::string, std::string> schema_paths_;
 
   /// the parser
   boost::shared_ptr<XMLParser> parser_;
@@ -80,7 +84,17 @@ class XMLFileLoader {
   /// a map of loaded modules. all dynamically loaded modules are
   /// registered with this map when loaded.
   std::map< std::string, DynamicModule*> modules_;
+
+  /// Method to load all dyamic modules
+  void LoadDynamicModules();
+
+  /// loads a specific recipe
+  void LoadRecipe(QueryEngine* qe);
+
+  /// the input file name
+  std::string file_;
 };
 } // namespace cyclus
 
 #endif // ifndef CYCLUS_XML_FILE_LOADER_H_
+

--- a/src/xml_flat_loader.cc
+++ b/src/xml_flat_loader.cc
@@ -1,0 +1,103 @@
+// xml_flat_loader.cc
+
+#include "xml_flat_loader.h"
+
+#include "context.h"
+#include "env.h"
+#include "error.h"
+#include "logger.h"
+#include "model.h"
+#include "recorder.h"
+#include "timer.h"
+#include "xml_query_engine.h"
+
+namespace cyclus {
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+std::string BuildFlatMasterSchema(std::string schema_path) {
+  Timer ti;
+  Recorder rec;
+  Context ctx(&ti, &rec);
+
+  std::stringstream schema("");
+  LoadStringstreamFromFile(schema, schema_path);
+  std::string master = schema.str();
+
+  std::vector<std::string> names = Env::ListModules();
+  std::string subschemas;
+  for (int i = 0; i < names.size(); ++i) {
+    DynamicModule dyn(names[i]);
+    Model* m = dyn.ConstructInstance(&ctx);
+    subschemas += "<element name=\"" + names[i] + "\">\n";
+    subschemas += m->schema() + "\n";
+    subschemas += "</element>\n";
+    delete m;
+    dyn.CloseLibrary();
+  }
+
+  // replace refs in master rng template file
+  std::string search_str = std::string("@MODEL_SCHEMAS@");
+  size_t pos = master.find(search_str);
+  if (pos != std::string::npos) {
+    master.replace(pos, search_str.size(), subschemas);
+  }
+
+  return master;
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+std::string XMLFlatLoader::master_schema() {
+  return BuildFlatMasterSchema(schema_path_);
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+void XMLFlatLoader::LoadInitialAgents() {
+  XMLQueryEngine xqe(*parser_);
+
+  int num_protos = xqe.NElementsMatchingQuery("/*/prototype");
+  for (int i = 0; i < num_protos; i++) {
+    QueryEngine* qe = xqe.QueryElement("/*/prototype", i);
+    QueryEngine* module_data = qe->QueryElement("model");
+    std::string module_name = module_data->GetElementName();
+
+    Model* model = modules_[module_name]->ConstructInstance(ctx_);
+    model->InitCoreMembers(qe);
+    model->SetModelImpl(module_name);
+    model->InitModuleMembers(module_data->QueryElement(module_name));
+
+    CLOG(LEV_DEBUG3) << "Module '" << model->name()
+                     << "' has had its module members initialized:";
+    CLOG(LEV_DEBUG3) << " * Type: " << model->ModelType();
+    CLOG(LEV_DEBUG3) << " * Implementation: " << model->ModelImpl() ;
+    CLOG(LEV_DEBUG3) << " * ID: " << model->id();
+
+    // register module
+    ctx_->AddPrototype(model->name(), model);
+  }
+
+  int num_agents = xqe.NElementsMatchingQuery("/*/agent");
+  std::map<std::string, Model*> agents; // map<name, agent>
+  std::map<std::string, std::string> parents; // map<agent, parent>
+  for (int i = 0; i < num_agents; i++) {
+    QueryEngine* qe = xqe.QueryElement("/*/agent", i);
+    std::string name = qe->GetElementContent("name");
+    std::string proto = qe->GetElementContent("prototype");
+    std::string parent = GetOptionalQuery<std::string>(qe, "parent", "");
+    agents[name] = ctx_->CreateModel<Model>(proto);
+    parents[name] = parent;
+  }
+
+  std::map<std::string, Model*>::iterator it;
+  for (it = agents.begin(); it != agents.end(); ++it) {
+    std::string name = it->first;
+    Model* agent = it->second;
+    if (parents[name] == "") {
+      agent->Deploy();
+    } else {
+      agent->Deploy(agents[parents[name]]);
+    }
+  }
+}
+
+} // namespace cyclus
+

--- a/src/xml_flat_loader.h
+++ b/src/xml_flat_loader.h
@@ -1,0 +1,32 @@
+// xml_flat_loader.h
+#ifndef CYCLUS_XML_FLAT_LOADER_H_
+#define CYCLUS_XML_FLAT_LOADER_H_
+
+#include "xml_file_loader.h"
+
+namespace cyclus {
+
+/// Builds and returns a master cyclus input xml schema defining a flat
+/// prototype and instance structure that includes the sub-schemas defined by
+/// all installed cyclus modules (e.g. facility models).  This is used to
+/// validate simulation input files.
+std::string BuildFlatMasterSchema(std::string schema_path);
+
+/// a class that encapsulates the methods needed to load input to
+/// a cyclus simulation from xml
+class XMLFlatLoader : public XMLFileLoader {
+ public:
+  XMLFlatLoader(Context* ctx, std::string schema_path,
+                const std::string load_filename = "")
+    : XMLFileLoader(ctx, schema_path, load_filename) { };
+
+ protected:
+  virtual std::string master_schema();
+
+  /// Creates all initial agent instances from the input file.
+  void LoadInitialAgents();
+};
+} // namespace cyclus
+
+#endif // ifndef CYCLUS_XML_FLAT_LOADER_H_
+

--- a/tests/xml_file_loader_tests.cc
+++ b/tests/xml_file_loader_tests.cc
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "model.h"
+#include "env.h"
 #include "error.h"
 #include "dynamic_module.h"
 
@@ -14,6 +15,8 @@ using namespace std;
 using cyclus::XMLFileLoader;
 
 void XMLFileLoaderTests::SetUp() {
+  schema_path = cyclus::Env::GetInstallPath() + "/share/cyclus.rng.in";
+
   ctx_ = new cyclus::Context(&ti_, &rec_);
   falseFile = "false.xml";
   CreateTestInputFile(falseFile, FalseSequence());
@@ -138,25 +141,25 @@ std::string XMLFileLoaderTests::ControlSchema() {
 }
 
 TEST_F(XMLFileLoaderTests, openfile) {
-  EXPECT_NO_THROW(XMLFileLoader file(ctx_, controlFile));
+  EXPECT_NO_THROW(XMLFileLoader file(ctx_, schema_path, controlFile));
 }
 
 TEST_F(XMLFileLoaderTests, throws) {
-  EXPECT_THROW(XMLFileLoader file(ctx_, "blah"), cyclus::IOError);
+  EXPECT_THROW(XMLFileLoader file(ctx_, schema_path, "blah"), cyclus::IOError);
 }
 
 TEST_F(XMLFileLoaderTests, control) {
-  XMLFileLoader file(ctx_, controlFile);
+  XMLFileLoader file(ctx_, schema_path, controlFile);
   EXPECT_NO_THROW(file.LoadControlParams());
 }
 
 TEST_F(XMLFileLoaderTests, recipes) {
-  XMLFileLoader file(ctx_, recipeFile);
+  XMLFileLoader file(ctx_, schema_path, recipeFile);
   EXPECT_NO_THROW(file.LoadRecipes());
 }
 
 TEST_F(XMLFileLoaderTests, schema) {
-  XMLFileLoader file(ctx_, controlFile);
+  XMLFileLoader file(ctx_, schema_path, controlFile);
   std::stringstream schema(ControlSchema());
   EXPECT_NO_THROW(file.ApplySchema(schema););
 }

--- a/tests/xml_file_loader_tests.h
+++ b/tests/xml_file_loader_tests.h
@@ -29,6 +29,7 @@ class XMLFileLoaderTests : public ::testing::Test {
   cyclus::Recorder rec_;
   cyclus::Timer ti_;
   cyclus::Context* ctx_;
+  std::string schema_path;
 
   virtual void SetUp();
 


### PR DESCRIPTION
- tweaks to XMLFileLoader to allow subclassing
- subclass to handle xml flat schema format
- added cyclus-flat.rng.in
- refactored recipe creating method into its own function for reuse by other things in future like recipe libraries.
- added cli flag for toggling to flat schema format
- added cli flag for user specified schema file
- fixed some missing details regarding cloning/initing

Companion PR in cycamore cyclus/cycamore#175
