### PR TITLE
Complete quoting for parameters of some CMake commands.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,28 +9,28 @@ IF(NOT CYCLUS_DOC_ONLY)
 ##############################################################################################
 
 # set project directories
-SET( PROJECT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR} )
-SET( CYCLUS_CLI_DIR ${CMAKE_CURRENT_SOURCE_DIR}/cli )
-SET( CYCLUS_DOC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/doc )
-SET( CYCLUS_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src )
-SET( CYCLUS_STUB_DIR ${CMAKE_CURRENT_SOURCE_DIR}/stubs )
-SET( CYCLUS_TEST_DIR ${CMAKE_CURRENT_SOURCE_DIR}/tests )
+SET(PROJECT_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+SET(CYCLUS_CLI_DIR "${PROJECT_SOURCE_DIR}/cli")
+SET(CYCLUS_DOC_DIR "${PROJECT_SOURCE_DIR}/doc")
+SET(CYCLUS_SOURCE_DIR "${PROJECT_SOURCE_DIR}/src")
+SET(CYCLUS_STUB_DIR "${PROJECT_SOURCE_DIR}/stubs")
+SET(CYCLUS_TEST_DIR "${PROJECT_SOURCE_DIR}/tests")
 
 # This makes all the libraries build as SHARED
 SET(BUILD_SHARED_LIBS true)
 
 # Setup build locations.
 IF(NOT CMAKE_RUNTIME_OUTPUT_DIRECTORY)
-  SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CYCLUS_BINARY_DIR}/bin)
+  SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CYCLUS_BINARY_DIR}/bin")
 endif()
 IF(NOT CMAKE_LIBRARY_OUTPUT_DIRECTORY)
-  SET(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CYCLUS_BINARY_DIR}/lib)
+  SET(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CYCLUS_BINARY_DIR}/lib")
 endif()
 IF(NOT CMAKE_ARCHIVE_OUTPUT_DIRECTORY)
-  SET(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CYCLUS_BINARY_DIR}/lib)
+  SET(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CYCLUS_BINARY_DIR}/lib")
 ENDIF()
 
-SET(CYCLUS_EXECUTABLE_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+SET(CYCLUS_EXECUTABLE_DIR "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
 
 # use, i.e. don't skip the full RPATH for the build tree
 SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
@@ -52,8 +52,8 @@ IF("${isSystemDir}" STREQUAL "-1")
 ENDIF("${isSystemDir}" STREQUAL "-1")
 
 # Tell CMake where the modules are
-SET( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_DIR}/share/cmake-2.8/Modules")
-SET( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/CMake )
+LIST(APPEND CMAKE_MODULE_PATH
+     "${CMAKE_DIR}/share/cmake-2.8/Modules" "${PROJECT_SOURCE_DIR}/CMake")
 
 # Include macros
 INCLUDE(CyclusModuleMacros)
@@ -89,24 +89,20 @@ ENDIF()
 # Debian installs useful LibXML2 files to /usr/include/libxml2/libxml
 # libxml2 is required for relaxng schema validation
 FIND_PACKAGE( LibXml2 REQUIRED )
-SET(CYCLUS_INCLUDE_DIR ${CYCLUS_INCLUDE_DIR} ${LIBXML2_INCLUDE_DIR})
 ADD_DEFINITIONS (${LIBXML2_DEFINITIONS})
 SET(LIBS ${LIBS} ${LIBXML2_LIBRARIES})
 
 # Find LibXML++ and dependencies
 FIND_PACKAGE( LibXML++ REQUIRED )
-SET(CYCLUS_INCLUDE_DIR ${CYCLUS_INCLUDE_DIR} ${LibXML++_INCLUDE_DIR} ${Glibmm_INCLUDE_DIRS} ${LibXML++Config_INCLUDE_DIR})
 SET(LIBS ${LIBS} ${LibXML++_LIBRARIES})
 MESSAGE(${LIBS})
 
 # Find Sqlite3
 FIND_PACKAGE( Sqlite3 REQUIRED )
-SET(CYCLUS_INCLUDE_DIR ${CYCLUS_INCLUDE_DIR} ${SQLITE3_INCLUDE_DIR})
 SET(LIBS ${LIBS} ${SQLITE3_LIBRARIES})
 
 # Find HDF5
 FIND_PACKAGE( HDF5 REQUIRED)
-SET(CYCLUS_INCLUDE_DIR ${CYCLUS_INCLUDE_DIR} ${HDF5_INCLUDE_DIRS})
 ADD_DEFINITIONS(${HDF5_DEFINITIONS})
 set(LIBS ${LIBS} ${HDF5_LIBRARIES} )
 
@@ -117,7 +113,6 @@ SET(Boost_USE_STATIC_LIBS       OFF)
 SET(Boost_USE_STATIC_RUNTIME    OFF)
 # SET(Boost_USE_MULTITHREADED    OFF)
 FIND_PACKAGE( Boost COMPONENTS program_options filesystem system REQUIRED)
-SET(CYCLUS_INCLUDE_DIR ${CYCLUS_INCLUDE_DIR} ${Boost_INCLUDE_DIR})
 MESSAGE("--    Boost Root: ${Boost_ROOT}")
 MESSAGE("--    Boost Include directory: ${Boost_INCLUDE_DIR}")
 MESSAGE("--    Boost Library directories: ${Boost_LIBRARY_DIRS}")
@@ -135,7 +130,6 @@ MESSAGE("\tFound LAPACK Libraries: ${LAPACK_LIBRARIES}")
 
 # find coin and link to it
 FIND_PACKAGE( COIN REQUIRED )
-SET(CYCLUS_INCLUDE_DIR ${CYCLUS_INCLUDE_DIR} ${COIN_INCLUDE_DIRS})
 set(LIBS ${LIBS} ${COIN_LIBRARIES})
 
 ##############################################################################################
@@ -147,12 +141,19 @@ set(LIBS ${LIBS} ${COIN_LIBRARIES})
 ##############################################################################################
 
 # include all the directories we just found
-INCLUDE_DIRECTORIES( ${CYCLUS_INCLUDE_DIR} )
+INCLUDE_DIRECTORIES("${LIBXML2_INCLUDE_DIR}"
+                    "${LibXML++_INCLUDE_DIR}"
+                    ${Glibmm_INCLUDE_DIRS}
+                    "${LibXML++Config_INCLUDE_DIR}"
+                    "${SQLITE3_INCLUDE_DIR}"
+                    ${HDF5_INCLUDE_DIRS}
+                    "${Boost_INCLUDE_DIR}"
+                    ${COIN_INCLUDE_DIRS})
 
-ADD_SUBDIRECTORY(${CYCLUS_SOURCE_DIR})
-ADD_SUBDIRECTORY(${CYCLUS_CLI_DIR})
-ADD_SUBDIRECTORY(${CYCLUS_STUB_DIR})
-ADD_SUBDIRECTORY(${CYCLUS_TEST_DIR})
+ADD_SUBDIRECTORY("${CYCLUS_SOURCE_DIR}")
+ADD_SUBDIRECTORY("${CYCLUS_CLI_DIR}")
+ADD_SUBDIRECTORY("${CYCLUS_STUB_DIR}")
+ADD_SUBDIRECTORY("${CYCLUS_TEST_DIR}")
 
 ##############################################################################################
 ####################################### end includes #########################################
@@ -169,7 +170,7 @@ configure_file(
     )
 
 add_custom_target(uninstall
-    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+    COMMAND "${CMAKE_COMMAND}" -P "\"${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake\"")
 
 ##############################################################################################
 ################################### end uninstall target #####################################
@@ -215,14 +216,14 @@ ENDIF(NOT CYCLUS_DOC_ONLY)
 ##############################################################################################
 
 # This is the directory that holds the doxygen doxyfile template (doxy.conf.in)
-SET( DOC_SOURCE_DIR ${CYCLUS_SOURCE_DIR} )
-SET( DOC_INPUT_DIR ${CYCLUS_DOC_DIR} )
-SET( DOC_OUTPUT_DIR ${CMAKE_BINARY_DIR}/doc )
+SET(DOC_SOURCE_DIR "${CYCLUS_SOURCE_DIR}")
+SET(DOC_INPUT_DIR "${CYCLUS_DOC_DIR}")
+SET(DOC_OUTPUT_DIR "${CMAKE_BINARY_DIR}/doc")
   
 # If doxygen exists, use the doc/CMakeLists.txt file for further instructions. 
 FIND_PACKAGE(Doxygen)
 IF (DOXYGEN_FOUND)
-  ADD_SUBDIRECTORY(${CYCLUS_DOC_DIR})
+  ADD_SUBDIRECTORY("${CYCLUS_DOC_DIR}")
 ELSE (DOXYGEN_FOUND)
   MESSAGE(STATUS "WARNING: Doxygen not found - doc won't be created")
 ENDIF (DOXYGEN_FOUND)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -5,9 +5,9 @@
 # ---------------------------------
 
 IF (DOXYGEN_FOUND)
-  SET(DOXYGEN_SOURCE_DIR ${DOC_SOURCE_DIR})
-  SET(DOXYGEN_INPUT ${DOC_INPUT_DIR}/doxygen.conf)
-  SET(DOXYGEN_OUTPUT ${DOC_OUTPUT_DIR}/html/index.html)
+  SET(DOXYGEN_SOURCE_DIR "${DOC_SOURCE_DIR}")
+  SET(DOXYGEN_INPUT "${DOC_INPUT_DIR}/doxygen.conf")
+  SET(DOXYGEN_OUTPUT "${DOC_OUTPUT_DIR}/html/index.html")
   
   FIND_PACKAGE(HTMLHelp)
   
@@ -39,7 +39,7 @@ IF (DOXYGEN_FOUND)
   
   STRING(REGEX REPLACE ";" " " DOXYGEN_INPUT_LIST "${DOXYGEN_SOURCE_DIR}")
   
-  CONFIGURE_FILE(${DOC_INPUT_DIR}/doxy.conf.in ${DOC_INPUT_DIR}/doxygen.conf)
+  CONFIGURE_FILE("${DOC_INPUT_DIR}/doxy.conf.in" "${DOXYGEN_INPUT}")
   
 
   IF (WIN32)
@@ -54,22 +54,22 @@ IF (DOXYGEN_FOUND)
   ENDIF (WIN32)
 
   ADD_CUSTOM_COMMAND(
-    OUTPUT ${DOXYGEN_OUTPUT}
-    COMMAND ${CMAKE_COMMAND} -E echo_append "Building cyclus Documentation..."
-    COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_INPUT}
-    COMMAND ${CMAKE_COMMAND} -E echo "Done."
-    WORKING_DIRECTORY ${DOC_OUTPUT_DIR}
-    DEPENDS ${DOXYGEN_INPUT}
+    OUTPUT "${DOXYGEN_OUTPUT}"
+    COMMAND "${CMAKE_COMMAND}" -E echo_append "Building cyclus Documentation..."
+    COMMAND "${DOXYGEN_EXECUTABLE}" "\"${DOXYGEN_INPUT}\""
+    COMMAND "${CMAKE_COMMAND}" -E echo "Done."
+    WORKING_DIRECTORY "${DOC_OUTPUT_DIR}"
+    DEPENDS "${DOXYGEN_INPUT}"
     )
 
-  ADD_CUSTOM_TARGET(cyclusdoc DEPENDS ${DOXYGEN_OUTPUT})
+  ADD_CUSTOM_TARGET(cyclusdoc DEPENDS "${DOXYGEN_OUTPUT}")
   ADD_CUSTOM_TARGET(coredoc DEPENDS cyclusdoc)
 
   ADD_CUSTOM_TARGET(cyclusdoc_forced
-    COMMAND ${CMAKE_COMMAND} -E echo_append "Building cyclus Documentation..."
-    COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_INPUT}
-    COMMAND ${CMAKE_COMMAND} -E echo "Done."
-    WORKING_DIRECTORY ${DOC_OUTPUT_DIR}
+    COMMAND "${CMAKE_COMMAND}" -E echo_append "Building cyclus Documentation..."
+    COMMAND "${DOXYGEN_EXECUTABLE}" "\"${DOXYGEN_INPUT}\""
+    COMMAND "${CMAKE_COMMAND}" -E echo "Done."
+    WORKING_DIRECTORY "${DOC_OUTPUT_DIR}"
     )
 
 ENDIF (DOXYGEN_FOUND)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,36 +3,36 @@
 ############# special file configuration ########################
 #################################################################
 
-CONFIGURE_FILE(suffix.h.in ${CMAKE_CURRENT_SOURCE_DIR}/suffix.h @ONLY)
+CONFIGURE_FILE(suffix.h.in "${CMAKE_CURRENT_SOURCE_DIR}/suffix.h" @ONLY)
 
 EXECUTE_PROCESS(COMMAND git describe --tags OUTPUT_VARIABLE core_version OUTPUT_STRIP_TRAILING_WHITESPACE)
-CONFIGURE_FILE(version.h.in ${CMAKE_CURRENT_SOURCE_DIR}/version.h @ONLY)
+CONFIGURE_FILE(version.h.in "${CMAKE_CURRENT_SOURCE_DIR}/version.h" @ONLY)
 
 CONFIGURE_FILE(
-  ${CMAKE_CURRENT_SOURCE_DIR}/mass.sqlite
-  ${CYCLUS_BINARY_DIR}/share/mass.sqlite
+  "${CMAKE_CURRENT_SOURCE_DIR}/mass.sqlite"
+  "${CYCLUS_BINARY_DIR}/share/mass.sqlite"
   COPYONLY
   )
 
 CONFIGURE_FILE(
-  ${CMAKE_CURRENT_SOURCE_DIR}/decayInfo.dat
-  ${CYCLUS_BINARY_DIR}/share/decayInfo.dat
+  "${CMAKE_CURRENT_SOURCE_DIR}/decayInfo.dat"
+  "${CYCLUS_BINARY_DIR}/share/decayInfo.dat"
   COPYONLY
   )
 
-SET(cyclus_install_dir ${CMAKE_INSTALL_PREFIX})
-SET(cyclus_build_dir ${CYCLUS_BINARY_DIR})
+SET(cyclus_install_dir "${CMAKE_INSTALL_PREFIX}")
+SET(cyclus_build_dir "${CYCLUS_BINARY_DIR}")
 CONFIGURE_FILE(
-  ${CMAKE_CURRENT_SOURCE_DIR}/env.cc.in
-  ${CMAKE_CURRENT_SOURCE_DIR}/env.cc
+  "${CMAKE_CURRENT_SOURCE_DIR}/env.cc.in"
+  "${CMAKE_CURRENT_SOURCE_DIR}/env.cc"
   @ONLY
   )
 
 INSTALL(FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/mass.sqlite
-    ${CMAKE_CURRENT_SOURCE_DIR}/cyclus.rng.in
-    ${CMAKE_CURRENT_SOURCE_DIR}/cyclus-flat.rng.in
-    ${CMAKE_CURRENT_SOURCE_DIR}/decayInfo.dat
+    "${CMAKE_CURRENT_SOURCE_DIR}/mass.sqlite"
+    "${CMAKE_CURRENT_SOURCE_DIR}/cyclus.rng.in"
+    "${CMAKE_CURRENT_SOURCE_DIR}/cyclus-flat.rng.in"
+    "${CMAKE_CURRENT_SOURCE_DIR}/decayInfo.dat"
   DESTINATION share
   COMPONENT core
   )
@@ -46,69 +46,69 @@ INSTALL(FILES
 #################################################################
 
 INCLUDE_DIRECTORIES(
-  ${CMAKE_CURRENT_SOURCE_DIR}
+  "${CMAKE_CURRENT_SOURCE_DIR}"
   )
 
 SET(
   CYCLUS_CORE_INCLUDE_DIRS ${CYCLUS_CORE_INCLUDE_DIRS}
-  ${CMAKE_CURRENT_SOURCE_DIR}
+  "${CMAKE_CURRENT_SOURCE_DIR}"
   PARENT_SCOPE
   )
 
 SET(CYCLUS_CORE_SRC ${CYCLUS_CORE_SRC} 
-  ${CMAKE_CURRENT_SOURCE_DIR}/builder.cc  
-  ${CMAKE_CURRENT_SOURCE_DIR}/building_manager.cc  
-  ${CMAKE_CURRENT_SOURCE_DIR}/cbc_solver.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/commodity.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/commodity_producer.cc 
-  ${CMAKE_CURRENT_SOURCE_DIR}/commodity_producer_manager.cc 
-  ${CMAKE_CURRENT_SOURCE_DIR}/commodity_recipe_context.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/comp_math.cc 
-  ${CMAKE_CURRENT_SOURCE_DIR}/composition.cc 
-  ${CMAKE_CURRENT_SOURCE_DIR}/context.cc 
-  ${CMAKE_CURRENT_SOURCE_DIR}/csv_back.cc 
-  ${CMAKE_CURRENT_SOURCE_DIR}/cyc_arithmetic.cc  
-  ${CMAKE_CURRENT_SOURCE_DIR}/datum.cc 
-  ${CMAKE_CURRENT_SOURCE_DIR}/decayer.cc 
-  ${CMAKE_CURRENT_SOURCE_DIR}/dynamic_module.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/enrichment.cc 
-  ${CMAKE_CURRENT_SOURCE_DIR}/env.cc 
-  ${CMAKE_CURRENT_SOURCE_DIR}/error.cc 
-  ${CMAKE_CURRENT_SOURCE_DIR}/exchange_graph.cc  
-  ${CMAKE_CURRENT_SOURCE_DIR}/facility_model.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/function.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/generic_resource.cc 
-  ${CMAKE_CURRENT_SOURCE_DIR}/greedy_preconditioner.cc 
-  ${CMAKE_CURRENT_SOURCE_DIR}/greedy_solver.cc 
-  ${CMAKE_CURRENT_SOURCE_DIR}/hdf5_back.cc 
-  ${CMAKE_CURRENT_SOURCE_DIR}/inst_model.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/l_matrix.cc 
-  ${CMAKE_CURRENT_SOURCE_DIR}/logger.cc 
-  ${CMAKE_CURRENT_SOURCE_DIR}/mass_table.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/mat_query.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/material.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/model.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/query_engine.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/recorder.cc 
-  ${CMAKE_CURRENT_SOURCE_DIR}/region_model.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/relax_ng_validator.cc 
-  ${CMAKE_CURRENT_SOURCE_DIR}/res_tracker.cc 
-  ${CMAKE_CURRENT_SOURCE_DIR}/resource.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/resource_buff.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/solver.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/solver_interface.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/sqlite_back.cc 
-  ${CMAKE_CURRENT_SOURCE_DIR}/sqlite_db.cc 
-  ${CMAKE_CURRENT_SOURCE_DIR}/supply_demand_manager.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/symbolic_function_factories.cc  
-  ${CMAKE_CURRENT_SOURCE_DIR}/symbolic_functions.cc 
-  ${CMAKE_CURRENT_SOURCE_DIR}/timer.cc 
-  ${CMAKE_CURRENT_SOURCE_DIR}/uniform_taylor.cc 
-  ${CMAKE_CURRENT_SOURCE_DIR}/variable.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/xml_file_loader.cc 
-  ${CMAKE_CURRENT_SOURCE_DIR}/xml_flat_loader.cc 
-  ${CMAKE_CURRENT_SOURCE_DIR}/xml_parser.cc 
-  ${CMAKE_CURRENT_SOURCE_DIR}/xml_query_engine.cc 
+  "${CMAKE_CURRENT_SOURCE_DIR}/builder.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/building_manager.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/cbc_solver.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/commodity.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/commodity_producer.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/commodity_producer_manager.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/commodity_recipe_context.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/comp_math.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/composition.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/context.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/csv_back.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/cyc_arithmetic.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/datum.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/decayer.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/dynamic_module.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/enrichment.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/env.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/error.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/exchange_graph.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/facility_model.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/function.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/generic_resource.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/greedy_preconditioner.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/greedy_solver.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/hdf5_back.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/inst_model.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/l_matrix.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/logger.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/mass_table.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/mat_query.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/material.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/model.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/query_engine.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/recorder.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/region_model.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/relax_ng_validator.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/res_tracker.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/resource.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/resource_buff.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/solver.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/solver_interface.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/sqlite_back.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/sqlite_db.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/supply_demand_manager.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/symbolic_function_factories.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/symbolic_functions.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/timer.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/uniform_taylor.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/variable.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/xml_file_loader.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/xml_flat_loader.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/xml_parser.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/xml_query_engine.cc"
   )
 
 INSTALL(FILES

--- a/stubs/CMakeLists.txt
+++ b/stubs/CMakeLists.txt
@@ -6,9 +6,9 @@
 INCLUDE_DIRECTORIES(${CYCLUS_CORE_INCLUDE_DIRS})
 
 SET(CYCLUS_STUB_SOURCE ${CYCLUS_STUB_SOURCE}
-  ${CMAKE_CURRENT_SOURCE_DIR}/stub_facility.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/stub_inst.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/stub_region.cc
+  "${CMAKE_CURRENT_SOURCE_DIR}/stub_facility.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/stub_inst.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/stub_region.cc"
   )
 
 ADD_LIBRARY( cyclusstubs ${CYCLUS_STUB_SOURCE} )
@@ -32,9 +32,9 @@ INSTALL(
 
 # add stub test source to be used by tests
 SET( CYCLUS_STUB_TEST_SOURCE ${CYCLUS_STUB_TEST_SOURCE}
-  ${CMAKE_CURRENT_SOURCE_DIR}/stub_facility_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/stub_inst_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/stub_region_tests.cc
+  "${CMAKE_CURRENT_SOURCE_DIR}/stub_facility_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/stub_inst_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/stub_region_tests.cc"
   PARENT_SCOPE
   )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,10 +25,10 @@ ENDIF()
 
 # Build libgtest
 SET( GTest
-  ${CMAKE_CURRENT_SOURCE_DIR}/GoogleTest/gtest/gtest-all.cc
+  "${CMAKE_CURRENT_SOURCE_DIR}/GoogleTest/gtest/gtest-all.cc"
   )
 
-INCLUDE_DIRECTORIES( ${CMAKE_CURRENT_SOURCE_DIR} )
+INCLUDE_DIRECTORIES("${CMAKE_CURRENT_SOURCE_DIR}")
 
 ADD_LIBRARY(gtest ${GTest})
 
@@ -67,60 +67,60 @@ ADD_SUBDIRECTORY(test_modules)
 # added to ctest.
 set ( CYCLUS_CORE_TEST_SOURCE ${CYCLUS_CORE_TEST_SOURCE}
   # --
-  ${CMAKE_CURRENT_SOURCE_DIR}/bid_portfolio_tests.cc  
-  ${CMAKE_CURRENT_SOURCE_DIR}/bid_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/building_manager_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/building_manager_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/building_test_helper.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/building_test_helper.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/capacity_constraint_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/cbc_solver_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/commodity_producer_manager_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/commodity_producer_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/commodity_producer_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/commodity_recipe_context_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/commodity_test_helper.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/comp_math_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/composition_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/context_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/csv_back_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/cyc_arithmetic_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/dynamic_loading_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/enrichment_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/environment_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/recorder_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/exchange_context_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/exchange_manager_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/exchange_solver_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/exchange_translator_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/exchange_graph_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/exchange_test_cases.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/facility_model_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/full_sim_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/function_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/greedy_preconditioner_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/hdf5_back_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/header_impl.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/inst_model_class_tests.cc 
-  ${CMAKE_CURRENT_SOURCE_DIR}/mass_table_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/mat_query_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/material_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/model_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/region_model_class_tests.cc 
-  ${CMAKE_CURRENT_SOURCE_DIR}/request_portfolio_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/request_tests.cc 
-  ${CMAKE_CURRENT_SOURCE_DIR}/resource_buff_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/resource_exchange_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/sd_manager_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/solver_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/sqlite_back_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/sqlite_db_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/symbolic_function_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/trade_executor_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/variable_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/xml_file_loader_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/xml_parser_tests.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/xml_query_engine_tests.cc
+  "${CMAKE_CURRENT_SOURCE_DIR}/bid_portfolio_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/bid_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/building_manager_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/building_manager_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/building_test_helper.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/building_test_helper.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/capacity_constraint_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/cbc_solver_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/commodity_producer_manager_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/commodity_producer_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/commodity_producer_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/commodity_recipe_context_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/commodity_test_helper.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/comp_math_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/composition_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/context_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/csv_back_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/cyc_arithmetic_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/dynamic_loading_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/enrichment_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/environment_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/recorder_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/exchange_context_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/exchange_manager_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/exchange_solver_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/exchange_translator_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/exchange_graph_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/exchange_test_cases.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/facility_model_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/full_sim_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/function_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/greedy_preconditioner_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/hdf5_back_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/header_impl.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/inst_model_class_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/mass_table_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/mat_query_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/material_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/model_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/region_model_class_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/request_portfolio_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/request_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/resource_buff_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/resource_exchange_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/sd_manager_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/solver_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/sqlite_back_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/sqlite_db_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/symbolic_function_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/trade_executor_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/variable_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/xml_file_loader_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/xml_parser_tests.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/xml_query_engine_tests.cc"
   ${CYCLUS_STUB_TEST_SOURCE} # needed to test stubs 
   )
 
@@ -155,12 +155,11 @@ INSTALL(FILES ${model_test_files}
 
 # read tests after building the driver, and add them to ctest
 set( tgt "cyclus_unit_tests" )
-set( script "${CMAKE_CURRENT_SOURCE_DIR}/generate_test_macros.py" )
-set( exec "--executable=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${tgt}" )
-set( out "--output=${CYCLUS_BINARY_DIR}/CTestTestfile.cmake" )
 add_custom_command(TARGET ${tgt}
   POST_BUILD
-  COMMAND python ${script} ${exec} ${out}
+  COMMAND python "${CMAKE_CURRENT_SOURCE_DIR}/generate_test_macros.py"
+          "--executable=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${tgt}"
+          "--output=${CYCLUS_BINARY_DIR}/CTestTestfile.cmake"
   COMMENT "adding tests from ${tgt}"
   DEPENDS
   VERBATIM

--- a/tests/GoogleTest/CMakeLists.txt
+++ b/tests/GoogleTest/CMakeLists.txt
@@ -48,12 +48,12 @@ endif()
 
 # Where gtest's .h files can be found.
 include_directories(
-  ${gtest_SOURCE_DIR}/include
-  ${gtest_SOURCE_DIR})
+  "${gtest_SOURCE_DIR}/include"
+  "${gtest_SOURCE_DIR}")
 
 # Where the gtest libraries can be found.
 link_directories(
-  ${gtest_BINARY_DIR}/src)
+  "${gtest_BINARY_DIR}/src")
 
 # Defines CMAKE_USE_PTHREADS_INIT and CMAKE_THREAD_LIBS_INIT.
 find_package(Threads)
@@ -336,8 +336,8 @@ function(py_test name)
     # only at ctest runtime (by calling ctest -c <Configuration>), so
     # we have to escape $ to delay variable substitution here.
     add_test(${name}
-      ${PYTHON_EXECUTABLE} ${gtest_SOURCE_DIR}/test/${name}.py
-          --gtest_build_dir=${gtest_BINARY_DIR}/\${CTEST_CONFIGURATION_TYPE})
+      "${PYTHON_EXECUTABLE}" "${gtest_SOURCE_DIR}/test/${name}.py"
+          "--gtest_build_dir=${gtest_BINARY_DIR}/\${CTEST_CONFIGURATION_TYPE}")
   endif()
 endfunction()
 


### PR DESCRIPTION
[A Wiki article pointed out](http://cmake.org/Wiki/CMake/Language_Syntax#CMake_splits_arguments_unless_you_use_quotation_marks_or_escapes.) that whitespace will only be preserved for parameters in CMake commands if passed strings will be appropriately quoted or escaped.

Quoting can be added so that more places should also handle file names correctly which contain space characters eventually.
