### PR TITLE
commodity.* : style corrections

### DIFF
--- a/src/commodity.cc
+++ b/src/commodity.cc
@@ -2,24 +2,24 @@
 
 namespace cyclus {
 
-//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Commodity::Commodity() : name_("") {}
 
-//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Commodity::Commodity(std::string name) : name_(name) {}
 
-//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 std::string Commodity::name() const {
   return name_;
 }
 
-//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 bool Commodity::operator==(const Commodity& other) const {
   return (name_ == other.name());
 }
 
-//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 bool Commodity::operator!=(const Commodity& other) const {
   return !(*this == other);
 }
-} // namespace cyclus
+}  // namespace cyclus

--- a/src/commodity.h
+++ b/src/commodity.h
@@ -1,26 +1,26 @@
-#ifndef COMMODITY_H
-#define COMMODITY_H
+#ifndef CYCLUS_SRC_COMMODITY_H_
+#define CYCLUS_SRC_COMMODITY_H_
 
 #include <string>
 
 namespace cyclus {
 /**
-   a simple class defining a commodity; it is currently super simple.
-   the reason this class exists is so that code may be cleaner and more straightforward
-   while one could have chosen to typedef a string, there may be some reason to extend
-   the class in the future.
- */
+  a simple class defining a commodity; it is currently super simple.
+  The reason this class exists is so that code may be cleaner and more straightforward
+  while one could have chosen to typedef a string, there may be some reason to extend
+  the class in the future.
+  */
 class Commodity {
  public:
   /**
-     default constructor
-  */
+    default constructor
+    */
   Commodity();
 
   /**
-     constructor
-     @param name the name of the commodity
-  */
+    constructor
+    @param name the name of the commodity
+    */
   Commodity(std::string name);
 
   /// the commodity's name
@@ -38,13 +38,13 @@ class Commodity {
 };
 
 /**
-   a comparitor so that commodities may be used in maps
-   we do not care how they are compared, only that they can be
- */
+  a comparator so that commodities may be used in maps
+  we do not care how they are compared, only that they can be
+  */
 struct CommodityCompare {
   inline bool operator()(const Commodity& lhs, const Commodity& rhs) const {
     return lhs.name() < rhs.name();
   }
 };
-} // namespace cyclus
-#endif
+}  // namespace cyclus
+#endif  // CYCLUS_SRC_COMMODITY_H_


### PR DESCRIPTION
Cpplint suggests making one argument constructor  _explicit_   at line 24 commodity.h, but that breaks cycamore's BatchReactor.

Should I avoid this suggestion in future?
