### PR TITLE
made output db have more consistent col names

### DIFF
--- a/src/composition.cc
+++ b/src/composition.cc
@@ -81,9 +81,9 @@ void Composition::Record(Context* ctx) {
     compmath::Normalize(&mass_, 1);
     for (it = mass().begin(); it != mass().end(); ++it) {
       ctx->NewDatum("Compositions")
-         ->AddVal("ID", id())
-         ->AddVal("NucID", it->first)
-         ->AddVal("Quantity", it->second)
+         ->AddVal("StateId", id())
+         ->AddVal("NucId", it->first)
+         ->AddVal("MassFrac", it->second)
          ->Record();
     }
     recorded_ = true;

--- a/src/model.cc
+++ b/src/model.cc
@@ -64,9 +64,9 @@ Model::~Model() {
   // set died on date and record it in the table if it was ever deployed
   if (birthtime_ > -1) {
     deathtime_ = ctx_->time();
-    ctx_->NewDatum("AgentDeaths")
-    ->AddVal("AgentID", id())
-    ->AddVal("DeathDate", deathtime_)
+    ctx_->NewDatum("AgentExit")
+    ->AddVal("AgentId", id())
+    ->AddVal("ExitTime", deathtime_)
     ->Record();
   }
   
@@ -171,13 +171,13 @@ const std::string Model::ModelImpl() {
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Model::AddToTable() {
-  ctx_->NewDatum("Agents")
-  ->AddVal("ID", id())
-  ->AddVal("AgentType", model_type())
-  ->AddVal("ModelType", ModelImpl())
+  ctx_->NewDatum("AgentEntry")
+  ->AddVal("AgentId", id())
+  ->AddVal("Kind", model_type())
+  ->AddVal("Implementation", ModelImpl())
   ->AddVal("Prototype", name())
-  ->AddVal("ParentID", parent_id_)
-  ->AddVal("EnterDate", birthtime())
+  ->AddVal("ParentId", parent_id_)
+  ->AddVal("EnterTime", birthtime())
   ->Record();
 }
 } // namespace cyclus

--- a/src/recorder.cc
+++ b/src/recorder.cc
@@ -44,7 +44,7 @@ void Recorder::set_dump_count(unsigned int count) {
   data_.reserve(count);
   for (int i = 0; i < count; ++i) {
     Datum* d = new Datum(this, "");
-    d->AddVal("SimID", uuid_);
+    d->AddVal("SimId", uuid_);
     data_.push_back(d);
   }
   dump_count_ = count;

--- a/src/res_tracker.cc
+++ b/src/res_tracker.cc
@@ -23,8 +23,8 @@ void ResTracker::Create(Model* creator) {
 
   Record();
   ctx_->NewDatum("ResCreators")
-    ->AddVal("ResID", res_->id())
-    ->AddVal("ModelID", creator->id())
+    ->AddVal("ResourceId", res_->id())
+    ->AddVal("AgentId", creator->id())
     ->Record();
 }
 
@@ -66,11 +66,11 @@ void ResTracker::Absorb(ResTracker* absorbed) {
 void ResTracker::Record() {
   res_->BumpId();
   ctx_->NewDatum("Resources")
-  ->AddVal("ID", res_->id())
+  ->AddVal("ResourceId", res_->id())
   ->AddVal("Type", res_->type())
   ->AddVal("TimeCreated", ctx_->time())
   ->AddVal("Quantity", res_->quantity())
-  ->AddVal("units", res_->units())
+  ->AddVal("Units", res_->units())
   ->AddVal("StateId", res_->state_id())
   ->AddVal("Parent1", parent1_)
   ->AddVal("Parent2", parent2_)

--- a/src/trade_executor.h
+++ b/src/trade_executor.h
@@ -79,10 +79,10 @@ class TradeExecutor {
         Trade<T>& trade = v_it->first;
         typename T::Ptr rsrc =  v_it->second;
         ctx->NewDatum("Transactions")
-            ->AddVal("ID", ctx->NextTransactionID())
-            ->AddVal("SenderID", supplier->id())
-            ->AddVal("ReceiverID", requester->id())
-            ->AddVal("ResourceID", rsrc->id())
+            ->AddVal("TransactionId", ctx->NextTransactionID())
+            ->AddVal("SenderId", supplier->id())
+            ->AddVal("ReceiverId", requester->id())
+            ->AddVal("ResourceId", rsrc->id())
             ->AddVal("Commodity", trade.request->commodity())
             ->AddVal("Price", trade.price)
             ->AddVal("Time", ctx->time())

--- a/tests/csv_back_tests.cc
+++ b/tests/csv_back_tests.cc
@@ -58,7 +58,7 @@ TEST(CsvBackTest, ReadWrite) {
   std::string sid1 = boost::lexical_cast<std::string>(m.sim_id());
   std::string sid2 = boost::lexical_cast<std::string>(m2.sim_id());
   std::vector<std::string> lines(4);
-  lines[0] = "SimID, animal, weight, height";
+  lines[0] = "SimId, animal, weight, height";
   lines[1] = "\"" + sid1 + "\", \"monkey\", 10, 5.5";
   lines[2] = "\"" + sid1 + "\", \"elephant\", 1000, 7.2";
   lines[3] = "\"" + sid2 + "\", \"sea cucumber\", 1, 0.4";

--- a/tests/recorder_tests.cc
+++ b/tests/recorder_tests.cc
@@ -156,7 +156,7 @@ TEST(RecorderTest, Datum_addVal) {
   ASSERT_EQ(d->vals().size(), 4);
 
   cyclus::Datum::Vals::const_iterator it = d->vals().begin();
-  EXPECT_STREQ(it->first, "SimID");
+  EXPECT_STREQ(it->first, "SimId");
   EXPECT_EQ(it->second.cast<boost::uuids::uuid>(), m.sim_id());
   ++it;
   EXPECT_STREQ(it->first, "animal");
@@ -172,7 +172,7 @@ TEST(RecorderTest, Datum_addVal) {
 
   cyclus::Datum::Vals vals = back.data.back()->vals();
   ASSERT_EQ(vals.size(), 4);
-  EXPECT_STREQ(vals.front().first, "SimID");
+  EXPECT_STREQ(vals.front().first, "SimId");
   EXPECT_EQ(vals.front().second.cast<boost::uuids::uuid>(), m.sim_id());
 }
 

--- a/tests/sqlite_back_tests.cc
+++ b/tests/sqlite_back_tests.cc
@@ -66,15 +66,15 @@ TEST(SqliteBackTest, Regression) {
 
   ASSERT_EQ(back.cmds.size(), 4);
   EXPECT_EQ(back.cmds.at(0),
-            "CREATE TABLE DumbTitle (SimID TEXT, animal TEXT, weight INTEGER, height REAL, data BLOB);");
+            "CREATE TABLE DumbTitle (SimId TEXT, animal TEXT, weight INTEGER, height REAL, data BLOB);");
   EXPECT_EQ(back.cmds.at(1),
-            "INSERT INTO DumbTitle (SimID, animal, weight, height, data) VALUES ('" + sid +
+            "INSERT INTO DumbTitle (SimId, animal, weight, height, data) VALUES ('" + sid +
             "', 'monkey', 10, 5.5, X'62616e616e61');");
   EXPECT_EQ(back.cmds.at(2),
-            "INSERT INTO DumbTitle (SimID, animal, weight) VALUES ('" + sid +
+            "INSERT INTO DumbTitle (SimId, animal, weight) VALUES ('" + sid +
             "', 'elephant', 1000);");
   EXPECT_EQ(back.cmds.at(3),
-            "INSERT INTO DumbTitle (SimID, animal, height) VALUES ('" + sid +
+            "INSERT INTO DumbTitle (SimId, animal, height) VALUES ('" + sid +
             "', 'sea cucumber', 1.2);");
 }
 


### PR DESCRIPTION
Also renamed Agents table to AgentEntry and AgentDeaths to AgentExit.  Post-processing will create the Agents table by joining them.  Note that this breaks regressions tests (that were already broken by anthony's iso->nuc PR.

No cycamore companion.
