### PR TITLE
made model copy constructor private to force copying to use clone/initfrom

### DIFF
--- a/src/model.h
+++ b/src/model.h
@@ -213,6 +213,10 @@ class Model {
   std::string model_type_;
 
  private:
+  /// Prevents creation/use of copy constructors (including in subclasses).
+  /// Cloning and InitFrom should be used instead.
+  Model(const Model& m) {};
+
   /// add an agent to the transactiont table
   void AddToTable();
 

--- a/tests/mock_inst.h
+++ b/tests/mock_inst.h
@@ -12,7 +12,7 @@ class MockInst : public cyclus::InstModel {
   virtual ~MockInst() {};
 
   virtual cyclus::Model* Clone() {
-    MockInst* m = new MockInst(*this);
+    MockInst* m = new MockInst(context());
     m->InitFrom(this);
     return m;
   }

--- a/tests/mock_region.h
+++ b/tests/mock_region.h
@@ -12,7 +12,7 @@ class MockRegion : public cyclus::RegionModel {
   virtual ~MockRegion() {};
 
   virtual cyclus::Model* Clone() {
-    MockRegion* m = new MockRegion(*this);
+    MockRegion* m = new MockRegion(context());
     m->InitFrom(this);
     return m;
   }


### PR DESCRIPTION
no cycamore companion.
