### PR TITLE
added adjustprefs methods to trader interface

### DIFF
--- a/src/resource_exchange.h
+++ b/src/resource_exchange.h
@@ -28,6 +28,14 @@ inline static void AdjustPrefs(Model* m,
                                PrefMap<GenericResource>::type& prefs) {
   m->AdjustGenRsrcPrefs(prefs);
 }
+inline static void AdjustPrefs(Trader* t,
+                               PrefMap<Material>::type& prefs) {
+  t->AdjustMatlPrefs(prefs);
+}
+inline static void AdjustPrefs(Trader* t,
+                               PrefMap<GenericResource>::type& prefs) {
+  t->AdjustGenRsrcPrefs(prefs);
+}
 
 /// @class ResourceExchange
 ///
@@ -122,7 +130,8 @@ class ResourceExchange {
   /// system
   void AdjustPrefs_(Trader* t) {
     typename PrefMap<T>::type& prefs = ex_ctx_.trader_prefs[t];
-    Model* m = t->manager();
+    AdjustPrefs(t, prefs);
+    Model* m = t->manager()->parent();
     while (m != NULL) {
       AdjustPrefs(m, prefs);
       m = m->parent();

--- a/src/trader.h
+++ b/src/trader.h
@@ -52,6 +52,12 @@ class Trader {
     return std::set<BidPortfolio<GenericResource>::Ptr>();
   }
 
+  /// default implementation for material preferences.
+  virtual void AdjustMatlPrefs(PrefMap<Material>::type& prefs) {};
+  
+  /// default implementation for material preferences.
+  virtual void AdjustGenRsrcPrefs(PrefMap<GenericResource>::type& prefs) {};
+
   /// @brief default implementation for responding to material trades
   /// @param trades all trades in which this trader is the supplier
   /// @param responses a container to populate with responses to each trade


### PR DESCRIPTION
 Updated resource exchange to call trader's adjust methods instead of trader->manager()'s.  No cycamore companion.  This allows delegation of trader preference adjustment to non-agent objects.
