### PR TITLE
fixed cycpp for python 2.7.3

### DIFF
--- a/cli/cycpp.py
+++ b/cli/cycpp.py
@@ -164,7 +164,7 @@ class LinemarkerFilter(Filter):
     This is useful for debugging. See the cpp for more info:
     http://gcc.gnu.org/onlinedocs/cpp/Preprocessor-Output.html
     """
-    regex = re.compile(RE_COMMENTS + r'*#\s+(\d+)\s+"(.*?)"(\s+\d+)*?', re.DOTALL)
+    regex = re.compile(r'\s*#\s+(\d+)\s+"(.*?)"(\s+\d+)*?', re.DOTALL)
     allowed_flags = {'1', '2'}
     last_was_linemarker = False
 
@@ -220,7 +220,7 @@ class UsingFilter(AliasFilter):
 class NamespaceFilter(Filter):
     """Filter for accumumating namespace encapsulations."""
     # handles anonymous namespaces as group(1) == None
-    regex = re.compile(RE_COMMENTS + "*\s*namespace(\s+\w*)?\s*$", re.DOTALL)
+    regex = re.compile("\s*namespace(\s+\w*)?\s*$", re.DOTALL)
 
     def transform(self, statement, sep):
         state = self.machine
@@ -268,8 +268,7 @@ class NamespaceAliasFilter(AliasFilter):
 
 class ClassFilter(Filter):
     """Filter for picking out class names."""
-    regex = re.compile(RE_COMMENTS + "*\s*class\s+(\w+)(\s*:[\n\s\w,:]+)?\s*", 
-                       re.DOTALL)
+    regex = re.compile("\s*class\s+(\w+)(\s*:[\n\s\w,:]+)?\s*", re.DOTALL)
 
     def transform(self, statement, sep):
         state = self.machine
@@ -307,8 +306,7 @@ class ClassFilter(Filter):
 
 class AccessFilter(Filter):
     """Filter for setting the current access control flag."""
-    regex = re.compile(RE_COMMENTS + '*\s*(public|private|protected)\s*', 
-                       re.DOTALL)
+    regex = re.compile('\s*(public|private|protected)\s*', re.DOTALL)
 
     def transform(self, statement, sep):
         access = self.match.group(1)
@@ -564,9 +562,9 @@ def accumulate_state(canon):
 # pass 3
 #
 class CodeGeneratorFilter(Filter):
-    re_template = RE_COMMENTS + ("*?\s*#\s*pragma\s+cyclus\s*?"
-                                 "(\s+def\s+|\s+decl\s+|\s+impl\s+|\s*?)?"
-                                 "(?:\s*?{0}\s*?)(\s+?(?:[\w:\.]+)?)?")
+    re_template = ("\s*#\s*pragma\s+cyclus\s*?"
+                   "(\s+def\s+|\s+decl\s+|\s+impl\s+|\s*?)?"
+                   "(?:\s*?{0}\s*?)(\s+?(?:[\w:\.]+)?)?")
 
     def_template = "\n{ind}{virt}{rtn} {ns}{methodname}({args}){sep}\n"
 
@@ -1037,8 +1035,7 @@ class DefaultPragmaFilter(Filter):
     """Filter for handling default pragma code generation:
         #pragma cyclus [def|decl|impl]
     """
-    regex = re.compile(RE_COMMENTS + \
-                       "*\s*#\s*pragma\s+cyclus(\s+def|\s+decl|\s+impl)?\s*$", 
+    regex = re.compile("\s*#\s*pragma\s+cyclus(\s+def|\s+decl|\s+impl)?\s*$", 
                        re.DOTALL)
 
     def transform(self, statement, sep):
@@ -1051,7 +1048,6 @@ class DefaultPragmaFilter(Filter):
     def revert(self, statement, sep):
         for f in self.machine.codegen_filters:
             f.revert(statement, sep)
-    # pass
 
 class Indenter(object):
     def __init__(self, n=2, level=0):


### PR DESCRIPTION
Hopefully this will also fix the Python 3 issues that @rwcarlsen was experiencing.  This PR will need to be merged before CI can be brought back up.  After CI is back, the moratorium will be lifted and we can proceed with development normally.  Because this blocks all future development, please review post-haste.

Here is what went wrong.  I moved the comments to become first-class statements in the top level `RE_STATEMENT` regex. However many of the filter regexes still were prefixed to ignore comments.  This caused problems if the statement _was_ a comment.  In Python 2.7.3, the `re.match()` call would start to match because the comment starts as a comment.  However, since the ending separator didn't exist in the string, the regex would continue to try to match forever and ever.  This would eat up memory until the process died.  In Python 2.7.4 and higher, regex would notice that the end of the string was reached and it would correctly report that no match was found.  

The fix for this issue was to remove the comment prefixes from the regexes on the filters.  Everything proceeded hunky dory after that. 
