### PR TITLE
Namespace aliases in pp

### DIFF
--- a/cli/cycpp.py
+++ b/cli/cycpp.py
@@ -551,13 +551,10 @@ class StateAccumulator(object):
         class whose scope we are in, but may be any class whatsoever. Returns 
         None if the class could not be canonized.
         """
-        #if cls == 'cyc::Facility':
-        #    import pdb; pdb.set_trace()
         if cls in self.superclasses:
             return cls
         cls = cls.strip("::")
         scope = [ns for d, ns in self.namespaces] + [c for d, c in self.classes]
-                #[c for d, c in self.classes[:-1]]
         # see if the class in in scope somehow
         for i in range(1, len(scope) + 1)[::-1]:
             trycls = "::".join(scope[:i]) + "::" + cls


### PR DESCRIPTION
This fixes a bunch of issues related to namespace aliases and should close #781.  It also +1s what we count as a 'class' to include structs, templated classes, and templated structs.  This was trickier than I suspected. 

On a related note, I am not really a huge fan of using `cyc` to alias `cyclus` is a project called 'cyc'amore.  Even `lus` would be a better alias.
