### PR TITLE
adds default conditioning if no preconditioner exists

### DIFF
--- a/src/exchange_solver.h
+++ b/src/exchange_solver.h
@@ -13,17 +13,21 @@ class ExchangeSolver {
   explicit ExchangeSolver(bool exclusive_orders = false) {};
   virtual ~ExchangeSolver() {};
 
+  inline void graph(ExchangeGraph* graph) { graph_ = graph; }
+  inline ExchangeGraph* graph() { return graph_; }
+  
   /// @brief interface for solving a given exchange graph
   /// @param a pointer to the graph to be solved
-  void Solve(ExchangeGraph* graph) {
-    graph_ = graph;
-    this->Solve();
+  void Solve(ExchangeGraph* graph = NULL) {
+    if (graph != NULL)
+      graph_ = graph;
+    this->SolveGraph();
   }
   
  protected:
   /// @brief Worker function for solving a graph. This must be implemented by
   /// any solver.
-  virtual void Solve() = 0;
+  virtual void SolveGraph() = 0;
   ExchangeGraph* graph_;
   bool exclusive_orders_;
 };

--- a/src/greedy_preconditioner.cc
+++ b/src/greedy_preconditioner.cc
@@ -64,10 +64,7 @@ void GreedyPreconditioner::Condition(ExchangeGraph* graph) {
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-void GreedyPreconditioner::ProcessWeights_(WgtOrder order) {
-  if (commod_weights_.size() == 0)
-    commod_weights_[""] = 0; // add at least one weight
-  
+void GreedyPreconditioner::ProcessWeights_(WgtOrder order) {  
   double min = std::min_element(
       commod_weights_.begin(),
       commod_weights_.end(),
@@ -122,7 +119,7 @@ double GroupWeight(RequestGroup::Ptr g,
 double NodeWeight(ExchangeNode::Ptr n,
                   std::map<std::string, double>* weights,
                   double avg_pref) {
-  double commod_weight = (*weights)[n->commod];
+  double commod_weight = (weights->size() != 0) ? (*weights)[n->commod] : 1;
   double node_weight = commod_weight * ( 1 + avg_pref / ( 1 + avg_pref));
   
   CLOG(LEV_DEBUG5) << "Determining node weight: ";

--- a/src/greedy_preconditioner.h
+++ b/src/greedy_preconditioner.h
@@ -70,7 +70,8 @@ class GreedyPreconditioner {
   /// @warning weights are assumed to be positive
   GreedyPreconditioner(const std::map<std::string, double>& commod_weights)
     : commod_weights_(commod_weights) {
-    ProcessWeights_(END);
+    if (commod_weights_.size() != 0)
+      ProcessWeights_(END);
   }
   
   /// @brief constructor if weights may not be given in heaviest-first order
@@ -78,7 +79,8 @@ class GreedyPreconditioner {
   GreedyPreconditioner(const std::map<std::string, double>& commod_weights,
                        WgtOrder order)
     : commod_weights_(commod_weights) {
-    ProcessWeights_(order);
+    if (commod_weights_.size() != 0)
+      ProcessWeights_(order);
   };
 
   /// @brief conditions the graph as described above
@@ -107,6 +109,7 @@ class GreedyPreconditioner {
   /// direction
   void ProcessWeights_(WgtOrder order);
   
+  bool apply_commod_weights_;
   std::map<ExchangeNode::Ptr, double> avg_prefs_;
   std::map<std::string, double> commod_weights_;
   std::map<RequestGroup::Ptr, double> group_weights_;

--- a/src/greedy_solver.cc
+++ b/src/greedy_solver.cc
@@ -22,13 +22,19 @@ GreedySolver::~GreedySolver() {
     delete conditioner_;
 }
 
-//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-void GreedySolver::Solve() {
+void GreedySolver::Condition() {
   if (conditioner_ == NULL)
     conditioner_ = new GreedyPreconditioner(std::map<std::string, double>());
   
   conditioner_->Condition(graph_);
 
+}
+
+
+//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+void GreedySolver::SolveGraph() {
+  Condition();
+  
   n_qty_.clear();
   
   std::for_each(graph_->request_groups().begin(),

--- a/src/greedy_solver.h
+++ b/src/greedy_solver.h
@@ -43,11 +43,19 @@ class GreedySolver: public ExchangeSolver {
   
   virtual ~GreedySolver();
 
+  /// Uses the provided (or a default) GreedyPreconditioner to condition the
+  /// solver's ExchangeGraph so that RequestGroups are ordered by average
+  /// preference and commodity weight.
+  ///
+  /// @warning this function is called during the Solve step and should most
+  /// likely not be called independently thereof (except for testing)
+  void Condition();
+  
  protected:
   /// @brief the GreedySolver solves an ExchangeGraph by iterating over each
   /// RequestGroup and matching requests with the minimum bids possible, starting
   /// from the beginning of the the respective request and bid containers.
-  virtual void Solve();
+  virtual void SolveGraph();
 
  private:
   /// @brief updates the capacity of a given ExchangeNode (i.e., its max_qty and the

--- a/src/prog_solver.cc
+++ b/src/prog_solver.cc
@@ -15,7 +15,7 @@ ProgSolver::ProgSolver(std::string solver_t, bool exclusive_orders)
 ProgSolver::~ProgSolver() { }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-void ProgSolver::Solve() {
+void ProgSolver::SolveGraph() {
   SolverFactory sf(solver_t_);
   OsiSolverInterface* iface = sf.get();
   try {

--- a/src/prog_solver.h
+++ b/src/prog_solver.h
@@ -19,7 +19,7 @@ class ProgSolver: public ExchangeSolver {
 
  protected:
   /// @brief the ProgSolver solves an ExchangeGraph...
-  virtual void Solve();
+  virtual void SolveGraph();
 
  private:
   std::string solver_t_;

--- a/tests/exchange_solver_tests.cc
+++ b/tests/exchange_solver_tests.cc
@@ -8,8 +8,8 @@ using cyclus::ExchangeSolver;
 class MockSolver: public ExchangeSolver {
  public:
   explicit MockSolver() : i(0) {}
-
-  virtual void Solve() { ++i; }
+  
+  virtual void SolveGraph() { ++i; }
 
   int i;
 };

--- a/tests/greedy_solver_tests.cc
+++ b/tests/greedy_solver_tests.cc
@@ -4,10 +4,13 @@
 #include "greedy_preconditioner.h"
 #include "greedy_solver.h"
 
-
 using cyclus::Arc;
 using cyclus::AvgPrefComp;
+using cyclus::ExchangeGraph;
 using cyclus::ExchangeNode;
+using cyclus::ExchangeNodeGroup;
+using cyclus::RequestGroup;
+using cyclus::GreedySolver;
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST(GreedySolverTests, AvgPref) {
@@ -30,4 +33,39 @@ TEST(GreedySolverTests, AvgPref) {
   std::sort(nodes.begin(), nodes.end(), AvgPrefComp);
   EXPECT_EQ(nodes[0], u2);
   EXPECT_EQ(nodes[1], u1);
+}
+
+//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+TEST(GreedySolverTests, Condition) {
+  ExchangeNode::Ptr u1(new ExchangeNode());
+  ExchangeNode::Ptr u2(new ExchangeNode());
+  ExchangeNode::Ptr v(new ExchangeNode());
+
+  Arc a1(u1, v);
+  Arc a2(u2, v);
+
+  u1->prefs[a1] = 1;
+  u2->prefs[a2] = 2;
+
+  RequestGroup::Ptr gu1(new RequestGroup());
+  gu1->AddExchangeNode(u1);
+  RequestGroup::Ptr gu2(new RequestGroup());
+  gu2->AddExchangeNode(u2);
+  ExchangeNodeGroup::Ptr gv(new ExchangeNodeGroup());
+  gv->AddExchangeNode(v);
+
+  ExchangeGraph g;
+  g.AddRequestGroup(gu1);
+  g.AddRequestGroup(gu2);
+  g.AddSupplyGroup(gv);
+
+  EXPECT_EQ(g.request_groups()[0], gu1);
+  EXPECT_EQ(g.request_groups()[1], gu2);
+
+  GreedySolver s;
+  s.graph(&g);
+  s.Condition();
+
+  EXPECT_EQ(g.request_groups()[1], gu1);
+  EXPECT_EQ(g.request_groups()[0], gu2);
 }


### PR DESCRIPTION
This PR guarantees group-level sorting whether or not a preconditioner is provided to the greedy solver. Previous behavior required that the greedy solver have a preconditioner to get group-level sorting (i.e., the `GreedyPreconditioner` "conditions" the graph by sorting the order in which request groups will be seen by the `GreedySolver`). 
