### PR TITLE
implements cep21.  Agent spec's, loading, discovery.

### DIFF
--- a/cli/cycpp.py
+++ b/cli/cycpp.py
@@ -998,7 +998,7 @@ class InfileToDbFilter(CodeGeneratorFilter):
         impl += self.shapes_impl(ctx, ind)
 
         # read data from infile onto class
-        impl += ind + 'tree = tree->SubTree("agent/" + agent_impl());\n'
+        impl += ind + 'tree = tree->SubTree("agent/*");\n'
         impl += ind + '{0}::InfileTree* sub;\n'.format(CYCNS)
         impl += ind + 'int i;\n'
         impl += ind + 'int n;\n'

--- a/src/agent.h
+++ b/src/agent.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 #include <boost/shared_ptr.hpp>
+#include <boost/algorithm/string.hpp>
 
 #include "dynamic_module.h"
 #include "resource.h"

--- a/src/commodity_recipe_context.cc
+++ b/src/commodity_recipe_context.cc
@@ -99,10 +99,10 @@ std::string CommodityRecipeContext::schema() {
   return
       "  <oneOrMore>                                 \n"
       "  <element name=\"fuel\">                     \n"
-      "   <ref name=\"incommodity\"/>                \n"
-      "   <ref name=\"inrecipe\"/>                   \n"
-      "   <ref name=\"outcommodity\"/>               \n"
-      "   <ref name=\"outrecipe\"/>                  \n"
+      "    <element name=\"incommodity\"><text/></element>\n"
+      "    <element name=\"inrecipe\"><text/></element>\n"
+      "    <element name=\"outcommodity\"><text/></element>\n"
+      "    <element name=\"outrecipe\"><text/></element>\n"
       "  </element>                                  \n"
       "  </oneOrMore>                                \n";
 }

--- a/src/cyclus-flat.rng.in
+++ b/src/cyclus-flat.rng.in
@@ -29,31 +29,29 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
     <element name="prototype">
     <interleave>
       <element name="name"><text/></element>
+      <element name="module"> 
+        <optional><element name="path"><text/></element></optional>
+        <optional><element name="lib"><text/></element></optional>
+        <element name="agent"><text/></element>
+        <optional><element name="alias"><text/></element></optional>
+      </element>
+      <optional>
+        <element name="lifetime"> <data type="nonNegativeInteger"/> </element>
+      </optional>
 
       <!-- For compatibility with nested schema format -->
       <!-- Facility/Inst/Region specific data -->
       <optional>
-
-        <optional>
-          <element name="lifetime">
-            <data type="nonNegativeInteger"/>
-          </element>
-        </optional>
-
         <choice>
           <oneOrMore>
             <element name="allowedfacility"><text/></element>
           </oneOrMore>
 
-          <group>
-            <optional>
-              <oneOrMore>
-                <element name="availableprototype">
-                  <text/>
-                </element>
-              </oneOrMore>
-            </optional>
-          </group>
+          <optional>
+            <oneOrMore>
+              <element name="availableprototype"> <text/> </element>
+            </oneOrMore>
+          </optional>
 
         </choice>
       </optional>
@@ -64,12 +62,7 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
           @MODEL_SCHEMAS@
         </choice>
       </element>
-      <zeroOrMore>
-        <element name="incommodity"><text/></element>
-      </zeroOrMore>
-      <zeroOrMore>
-        <element name="outcommodity"><text/></element>
-      </zeroOrMore>
+
     </interleave>
     </element>
   </oneOrMore>
@@ -100,104 +93,5 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
 </interleave>
 </element><!-- end of simulation -->
 </start>
-
-<!-- for compatibility with nested schema format -->
-  <define name="capacity">
-      <element name="capacity">
-        <data type="double"/>
-      </element>
-  </define>
-
-  <define name="commodprice">
-      <element name="commodprice">
-        <data type="double"/>
-      </element>
-  </define>
-
-  <define name="componenttype">
-      <element name="componenttype">
-        <data type="string"/>
-      </element>
-  </define>
-
-  <define name="incommodity">
-      <element name="incommodity">
-          <text/>
-      </element>
-  </define>
-
-  <define name="input_capacity">
-      <element name="input_capacity">
-         <data type="double"/>
-      </element>
-  </define>
-
-  <define name="innerradius">
-      <element name="innerradius">
-        <data type="double"/>
-      </element>
-  </define>
-
-  <define name="inrecipe">
-      <element name="inrecipe">
-          <text/>
-      </element>
-  </define>
-
-  <define name="inventorysize">
-      <element name="inventorysize">
-        <data type="double"/>
-      </element>
-  </define>
-
-  <define name="name">
-      <element name="name">
-        <data type="string"/>
-      </element>
-  </define>
-
-  <define name="outcommodity">
-      <element name="outcommodity">
-         <text/>
-      </element>
-  </define>
-
-  <define name="output_capacity">
-      <element name="output_capacity">
-         <data type="double"/>
-      </element>
-  </define>
-
-  <define name="outerradius">
-      <element name="outerradius">
-        <data type="double"/>
-      </element>
-  </define>
-
-  <define name="outrecipe">
-      <element name="outrecipe">
-          <text/>
-      </element>
-  </define>
-
-  <define name="startOperMonth">
-      <element name="startOperMonth">
-        <data type="nonNegativeInteger"/>
-      </element>
-  </define>
-
-  <define name="startOperYear">
-      <element name="startOperYear">
-        <data type="nonNegativeInteger"/>
-      </element>
-  </define>
-
-  <define name="tailsassay">
-      <element name="tailsassay">
-        <data type="double"/>
-      </element>
-  </define>
-<!-- end compatibility section -->
-
 </grammar>
 

--- a/src/cyclus.rng.in
+++ b/src/cyclus.rng.in
@@ -1,398 +1,127 @@
 <grammar xmlns="http://relaxng.org/ns/structure/1.0"
 datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+<start>
 
-  <start>
-  <choice>
-
-  <!-- top level for a SIMULATION input -->
-
-  <element name="simulation">
-
+<element name="simulation"> <interleave>
+  
+  <element name ="control">
     <interleave>
-    
-    <ref name="control"/>
-
-    <oneOrMore>
-    <ref name="commodity"/>
-    </oneOrMore>
-      
-    <oneOrMore>
-    <choice>
-    <ref name="facility"/>
-    <ref name="facilitycatalog"/>
-    </choice>
-    </oneOrMore>
-
-    <oneOrMore>
-    <ref name="region"/>
-    </oneOrMore>
-
-    <zeroOrMore>
-    <choice>
-    <ref name="recipe"/>
-    <ref name="recipebook"/>
-    </choice>
-    </zeroOrMore>
-
-    </interleave>
-
-  </element>
-
-  <!-- top level for a RECIPEBOOK input -->
-
-  <element name="recipebook">
-
-    <element name="name">
-      <text/>
-    </element>
-
-    <oneOrMore>
-    <ref name="recipe"/>
-    </oneOrMore>
-
-  </element>
-
-  <!-- top level for a FACILITYCATALOG input -->
-
-  <element name="facilitycatalog">
-
-    <element name="name">
-      <text/>
-    </element>
-
-    <oneOrMore>
-    <ref name="facility"/>
-    </oneOrMore>
-
-  </element>
-
-  </choice>
-  </start>
-
-  <!-- begin section for simulation parameters -->
-  <define name="control">
-    <element name ="control">
-      <interleave>
-        <ref name="simhandle"/>
-        <ref name="duration"/>
-        <ref name="startmonth"/>
-        <ref name="startyear"/>
-        <ref name="decay"/>
-      </interleave>
-    </element>
-  </define>
-
-  <define name="simhandle">
-    <optional>
-      <element name="simhandle">
-        <data type="string"/>
-      </element>
-    </optional>
-  </define>
-
-  <define name="duration">
-    <element name="duration">
-      <data type="nonNegativeInteger"/>
-    </element>
-  </define>
-
-  <define name="startmonth">
-    <element name="startmonth">
-      <data type="nonNegativeInteger"/>
-    </element>
-  </define>
-
-  <define name="startyear">
-    <element name="startyear">
-      <data type="nonNegativeInteger"/>
-    </element>
-  </define>
-
-  <define name="decay">
-    <element name="decay">
-      <data type="integer"/>
-    </element>
-  </define>
-
-  <!-- begin section for commodities -->
-  <define name="commodity">
-    <element name="commodity">
-
-      <element name="name">
-        <text/>
-      </element>
-
-    </element>
-
-    <optional>
-      <element name="solution_order">
-        <data type="double"/>
-      </element>
-    </optional>
-  </define>
-  <!-- end section for commodities -->
-
-  <!-- begin section for facilities -->
-  <define name="facility">
-    <element name="facility">
-
-      <element name="name">
-        <text/>
-      </element>
-
-      <ref name="lifetime" />
-
-      <element name="agent">
-      <choice> @Facility_REFS@
-      </choice>
-      </element>
-
-      <zeroOrMore>
-        <ref name="incommodity"/>
-      </zeroOrMore>
-
-      <zeroOrMore>
-        <ref name="outcommodity"/>
-      </zeroOrMore>
-
-    </element>
-  </define>
-
-  <define name="facilitycatalog">
-    <element name="facilitycatalog">
-
-      <element name="filename">
-        <text/>
-      </element>
-
-      <element name="namespace">
-        <text/>
-      </element>
-
-      <element name="format">
-        <text/>
-      </element>
-
-    </element>
-  </define>
-
-  <define name="capacity">
-      <element name="capacity">
-        <data type="double"/>
-      </element>
-  </define>
-
-  <define name="commodprice">
-      <element name="commodprice">
-        <data type="double"/>
-      </element>
-  </define>
-
-  <define name="componenttype">
-      <element name="componenttype">
-        <data type="string"/>
-      </element>
-  </define>
-
-  <define name="incommodity">
-      <element name="incommodity">
-          <text/>
-      </element>
-  </define>
-
-  <define name="input_capacity">
-      <element name="input_capacity">
-         <data type="double"/>
-      </element>
-  </define>
-
-  <define name="innerradius">
-      <element name="innerradius">
-        <data type="double"/>
-      </element>
-  </define>
-
-  <define name="inrecipe">
-      <element name="inrecipe">
-          <text/>
-      </element>
-  </define>
-
-  <define name="inventorysize">
-      <element name="inventorysize">
-        <data type="double"/>
-      </element>
-  </define>
-
-  <define name="lifetime">
-    <optional>
-      <element name="lifetime">
-        <data type="nonNegativeInteger"/>
-      </element>
-    </optional>
-  </define>
-
-  <define name="name">
-      <element name="name">
-        <data type="string"/>
-      </element>
-  </define>
-
-  <define name="outcommodity">
-      <element name="outcommodity">
-         <text/>
-      </element>
-  </define>
-
-  <define name="output_capacity">
-      <element name="output_capacity">
-         <data type="double"/>
-      </element>
-  </define>
-
-  <define name="outerradius">
-      <element name="outerradius">
-        <data type="double"/>
-      </element>
-  </define>
-
-  <define name="outrecipe">
-      <element name="outrecipe">
-          <text/>
-      </element>
-  </define>
-
-  <define name="startOperMonth">
-      <element name="startOperMonth">
-        <data type="nonNegativeInteger"/>
-      </element>
-  </define>
-
-  <define name="startOperYear">
-      <element name="startOperYear">
-        <data type="nonNegativeInteger"/>
-      </element>
-  </define>
-
-  <define name="tailsassay">
-      <element name="tailsassay">
-        <data type="double"/>
-      </element>
-  </define>
-
-
-  <!-- end section for facilities -->
-
-  <!-- begin section for regions -->
-  <define name="region">
-    <element name="region">
-      <interleave>
-
-      <element name="name">
-         <text/>
-      </element>
-
-      <ref name="lifetime" />
-
-      <oneOrMore>
-      <element name="allowedfacility">
-          <text/>
-      </element>
-      </oneOrMore>
-
-      <element name="agent">
-      <choice> @Region_REFS@
-      </choice>
-      </element>
-
-      <oneOrMore>
-      <ref name="institution" />
-      </oneOrMore>
-
-      </interleave>
-    </element>
-  </define>
-
-  <!-- end section for regions -->
-
-  <!-- begin section for institutions -->
-  <define name="institution">
-    <element name="institution">
-      
-      <interleave>
-
-      <element name="name">
-         <text/>
-      </element>
-      
-      <ref name="lifetime" />
-
       <optional>
-        <oneOrMore>
-          <element name="availableprototype">
-            <text/>
-          </element>
-        </oneOrMore>
+        <element name="simhandle"> <data type="string"/> </element>
+      </optional>
+      <element name="duration"> <data type="nonNegativeInteger"/> </element>
+      <element name="startmonth"> <data type="nonNegativeInteger"/> </element>
+      <element name="startyear"> <data type="nonNegativeInteger"/> </element>
+      <element name="decay"> <data type="integer"/> </element>
+    </interleave>
+  </element>
+
+  <oneOrMore>
+    <element name="commodity">
+      <element name="name"> <text/> </element>
+    </element>
+    <optional>
+      <element name="solution_order"> <data type="double"/> </element>
+    </optional>
+  </oneOrMore>
+    
+  <oneOrMore>
+    <element name="facility">
+      <element name="name"> <text/> </element>
+      <ref name="module"/> 
+      <optional>
+        <element name="lifetime"> <data type="nonNegativeInteger"/> </element>
       </optional>
 
+      <element name="agent">
+        <choice>
+        @Facility_REFS@
+        </choice>
+      </element>
+    </element>
+  </oneOrMore>
+
+  <oneOrMore>
+    <element name="region"> <interleave>
+      <element name="name"> <text/> </element>
+      <ref name="module"/> 
       <optional>
-        <element name="initialfacilitylist">
-          <oneOrMore>
-            <element name="entry">
-              <element name="prototype">
+        <element name="lifetime"> <data type="nonNegativeInteger"/> </element>
+      </optional>
+
+      <oneOrMore>
+      <element name="allowedfacility"> <text/> </element>
+      </oneOrMore>
+
+      <element name="agent">
+        <choice>
+        @Region_REFS@
+        </choice>
+      </element>
+
+      <oneOrMore>
+        <element name="institution"> <interleave>
+          <element name="name"> <text/> </element>
+          <ref name="module"/> 
+          <optional>
+            <element name="lifetime"> <data type="nonNegativeInteger"/> </element>
+          </optional>
+
+          <optional>
+            <oneOrMore>
+              <element name="availableprototype">
                 <text/>
               </element>
-              <element name="number">
-                <data type="nonNegativeInteger"/>
-              </element>
+            </oneOrMore>
+          </optional>
+
+          <optional>
+            <element name="initialfacilitylist">
+              <oneOrMore>
+                <element name="entry">
+                  <element name="prototype"> <text/> </element>
+                  <element name="number"> <data type="nonNegativeInteger"/> </element>
+                </element>
+              </oneOrMore>
             </element>
-          </oneOrMore>
-        </element>
-      </optional>
+          </optional>
 
-      <element name="agent">
-      <choice> @Inst_REFS@
-      </choice>
-      </element>
-      
-      </interleave>
-    </element>
-  </define>
+          <element name="agent">
+            <choice>
+            @Inst_REFS@
+            </choice>
+          </element>
+        </interleave> </element>
+      </oneOrMore>
 
-  <!-- end section for institutions -->
+    </interleave> </element>
+  </oneOrMore>
 
-  <!-- begin section for recipes -->
-  <define name="recipe">
+  <zeroOrMore>
     <element name="recipe">
       <element name="name"><text/></element>
       <element name="basis"><text/></element>
       <oneOrMore>
         <element name="nuclide">
-          <element name="id"><data type="integer"/></element>
+          <element name="id"><data type="nonNegativeInteger"/></element>
           <element name="comp"><data type="double"/></element>
         </element>
       </oneOrMore>
     </element>
-  </define>
+  </zeroOrMore>
 
-  <define name="recipebook">
-    <element name="recipebook">
+</interleave> </element>
 
-      <element name="filename">
-        <text/>
-      </element>
+</start>
 
-      <element name="namespace">
-        <text/>
-      </element>
-
-      <element name="format">
-        <text/>
-      </element>
-
-    </element>
-  </define>
-  <!-- end section for recipes -->
+<define name="module">
+  <element name="module"> 
+    <optional><element name="path"><text/></element></optional>
+    <optional><element name="lib"><text/></element></optional>
+    <element name="agent"><text/></element>
+    <optional><element name="alias"><text/></element></optional>
+  </element>
+</define>
 
 </grammar>
 

--- a/src/db_init.cc
+++ b/src/db_init.cc
@@ -13,7 +13,7 @@ DbInit::DbInit(Agent* m, bool dummy) : m_(m), full_prefix_(false) {}
 Datum* DbInit::NewDatum(std::string title) {
   std::string prefix = "AgentState";
   if (full_prefix_) {
-    prefix += m_->agent_impl();
+    prefix += AgentSpec(m_->agent_impl()).Sanitize();
   }
   Datum* d = m_->context()->NewDatum(prefix + title);
   d->AddVal("AgentId", m_->id());

--- a/src/env.cc.in
+++ b/src/env.cc.in
@@ -17,10 +17,8 @@ namespace fs = boost::filesystem;
 
 namespace cyclus {
 
-fs::path Env::path_from_cwd_to_cyclus_;
 fs::path Env::cwd_ = fs::current_path();
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 std::string Env::PathBase(std::string path) {
   std::string base;
   int index;
@@ -30,42 +28,15 @@ std::string Env::PathBase(std::string path) {
   return base;
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-std::string Env::GetCyclusPath() {
-  // return the join of cwd_ and rel path to cyclus
-  fs::path path;
-  if (path_from_cwd_to_cyclus_.has_root_path()) {
-    path = path_from_cwd_to_cyclus_.normalize();
-  } else {
-    path = (cwd_ / path_from_cwd_to_cyclus_).normalize();
-  }
-  CLOG(LEV_DEBUG4) << "Cyclus absolute path retrieved: "
-                   <<  path.string();
-  return path.string();
-}
-
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 const std::string Env::GetInstallPath() {
-  // return the join of cwd_ and rel path to cyclus MINUS the bin directory
-  std::string to_ret = "@cyclus_install_dir@";
-  return to_ret;
+  return "@cyclus_install_dir@";
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 const std::string Env::GetBuildPath() {
-  // return the join of cwd_ and rel path to cyclus MINUS the bin directory
-  std::string to_ret = "@cyclus_build_dir@";
-  return to_ret;
+  return "@cyclus_build_dir@";
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-void Env::SetCyclusRelPath(std::string path) {
-  path_from_cwd_to_cyclus_ = fs::path(path);
-  CLOG(LEV_DEBUG3) << "Cyclus rel path: " << path;
-}
-
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-std::string Env::CheckEnv(std::string varname) {
+std::string Env::GetEnv(std::string varname) {
   char* pVar = getenv(varname.c_str());
   if (pVar == NULL) {
     return "";
@@ -73,7 +44,6 @@ std::string Env::CheckEnv(std::string varname) {
   return pVar;
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 const std::string Env::EnvDelimiter() {
 #if _WIN32
   return ";";
@@ -82,7 +52,6 @@ const std::string Env::EnvDelimiter() {
 #endif
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 const std::string Env::PathDelimiter() {
 #if _WIN32
   return "\\";
@@ -91,121 +60,85 @@ const std::string Env::PathDelimiter() {
 #endif
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-const std::string Env::DataEnvVarName() {
-  return std::string("CYCLUS_NUC_DATA");
-}
-
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-const std::string Env::DataEnvVar() {
-  char* value = getenv(DataEnvVarName().c_str());
-  if (value != NULL) {
-    return std::string(value);
+const std::string Env::nuc_data() {
+  std::string p = GetEnv("CYCLUS_NUC_DATA");
+  if (p != "" && fs::exists(p)) {
+    return p;
   }
-  return "";
-}
-
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-const std::string Env::RngEnvVarName() {
-  return std::string("CYCLUS_RNG");
-}
-
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-const std::string Env::RngEnvVar() {
-  char* value = getenv(RngEnvVarName().c_str());
-  if (value != NULL) {
-    return std::string(value);
+  
+  p = GetInstallPath() + "/share/cyclus_nuc_data.h5";
+  if (fs::exists(p)) {
+    return p;
   }
-  return "";
-}
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-const std::string Env::ModuleEnvVarName() {
-  return std::string("CYCLUS_MODULE_PATH");
-}
-
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-const std::string Env::ModuleEnvVar() {
-  char* value = getenv(ModuleEnvVarName().c_str());
-  if (value != NULL) {
-    return std::string(value);
+  p = GetBuildPath() + "/share/cyclus_nuc_data.h5";
+  if (fs::exists(p)) {
+    return p;
   }
-  return "";
+
+  throw IOError("cyclus_nuc_data.h5 not found in "
+                " environment variable CYCLUS_NUC_DATA or "
+                + Env::GetInstallPath() + "/share or "
+                + Env::GetBuildPath() + "/share");
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-std::vector<std::string> Env::ListModules() {
-  std::vector<std::string> names;
-
-  std::vector<std::string> dirs;
-  boost::split(dirs, ModuleEnvVar(), boost::is_any_of(EnvDelimiter()),
-               boost::token_compress_on);
-  dirs.push_back(Env::module_install_path());
-  fs::recursive_directory_iterator end;
-  for (int i = 0; i < dirs.size(); ++i) {
-    if (dirs[i] == "") {
-      continue;
+const std::string Env::rng_schema(bool flat) {
+  std::string p = GetEnv("CYCLUS_RNG_SCHEMA");
+  if (p != "" && fs::exists(p)) {
+    return p;
+  }
+  
+  if (flat) {
+    p = GetInstallPath() + "/share/cyclus-flat.rng.in";
+    if (fs::exists(p)) {
+      return p;
     }
-
-    try {
-      for (fs::recursive_directory_iterator it(dirs[i]); it != end; ++it) {
-        fs::path p = it->path();
-        if (p.extension() == SUFFIX) {
-          std::string name = p.stem().string();
-          name = name.erase(0, 3);  // remove lib prefix
-          names.push_back(name);
-        }
-      }
-    } catch (boost::filesystem::filesystem_error err) {
-      continue;
+    p = GetBuildPath() + "/share/cyclus-flat.rng.in";
+    if (fs::exists(p)) {
+      return p;
     }
+    throw IOError("cyclus.rng.in not found in "
+                  " environment variable CYCLUS_RNG_SCHEMA or "
+                  + Env::GetInstallPath() + "/share or "
+                  + Env::GetBuildPath() + "/share");
+  } else {
+    p = GetInstallPath() + "/share/cyclus.rng.in";
+    if (fs::exists(p)) {
+      return p;
+    }
+    p = GetBuildPath() + "/share/cyclus.rng.in";
+    if (fs::exists(p)) {
+      return p;
+    }
+    throw IOError("cyclus-flat.rng.in not found in "
+                  " environment variable CYCLUS_RNG_SCHEMA or "
+                  + Env::GetInstallPath() + "/share or "
+                  + Env::GetBuildPath() + "/share");
   }
-
-  return names;
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-bool Env::FindModuleLib(const std::string name,
-                        boost::filesystem::path& path_found) {
-  // append env var dirs
-  std::vector<std::string> dirs;
-  boost::split(dirs, ModuleEnvVar(), boost::is_any_of(EnvDelimiter()),
-               boost::token_compress_on);
-
-  // check dirs other than install path if not found
-  std::vector<std::string>::iterator it = dirs.begin();
-  bool found = false;
-  while (!found && it != dirs.end()) {
-    found = FindFile(*it, name, path_found);
-    ++it;
-  }
-
-  if (!found) {
-    found = FindFile(module_install_path(), name, path_found);
-  }
-
-  return found;
+const std::vector<std::string> Env::cyclus_path() {
+  std::string s = GetEnv("CYCLUS_PATH");
+  std::vector<std::string> strs;
+  boost::split(strs, s, boost::is_any_of(EnvDelimiter()));
+  strs.push_back(GetInstallPath() + "/lib/cyclus");
+  strs.push_back(GetBuildPath() + "/lib/cyclus");
+  return strs;
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-bool Env::FindFile(const boost::filesystem::path& dir_path,
-                   const std::string& file_name,
-                   boost::filesystem::path& path_found) {
-  fs::recursive_directory_iterator it;
-  try {
-    it = fs::recursive_directory_iterator(dir_path);
-  } catch (boost::filesystem::filesystem_error err) {
-    return false;
-  }
+#define SHOW(X) \
+  std::cout << __FILE__ << ":" << __LINE__ << ": "#X" = " << X << "\n"
 
-  while (it != fs::recursive_directory_iterator()) {
-    if (it->path().filename() == file_name) {
-      path_found = it->path();
-      return true;
+std::string Env::FindModule(std::string path) {
+  std::vector<std::string> strs = cyclus_path();
+
+  for (int i = 0; i < strs.size(); ++i) {
+    fs::path full = fs::path(strs[i]) / path;
+    if (fs::exists(full)) {
+      return full.string();
     }
-    it++;
   }
-  return false;
+  throw IOError("No module found for path " + path);
 }
 
 }  // namespace cyclus

--- a/src/unix_helper_functions.h
+++ b/src/unix_helper_functions.h
@@ -12,7 +12,7 @@ namespace cyclus {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void DynamicModule::OpenLibrary() {
-  module_library_ = dlopen(abs_path_.c_str(), RTLD_LAZY);
+  module_library_ = dlopen(path_.c_str(), RTLD_LAZY);
 
   if (!module_library_) {
     std::string err_msg = "Unable to load agent shared object file: ";
@@ -25,10 +25,10 @@ void DynamicModule::OpenLibrary() {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void DynamicModule::SetConstructor() {
-  constructor_ = (AgentCtor*)
-                 dlsym(module_library_, constructor_name_.c_str());
+  ctor_ = (AgentCtor*)
+                 dlsym(module_library_, ctor_name_.c_str());
 
-  if (!constructor_) {
+  if (!ctor_) {
     std::string err_msg = "Unable to load module constructor: ";
     err_msg  += dlerror();
     throw IOError(err_msg);

--- a/src/windows_helper_functions.h
+++ b/src/windows_helper_functions.h
@@ -12,11 +12,10 @@ namespace cyclus {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void DynamicModule::OpenLibrary() {
-  module_library_ = LoadLibrary(abs_path_.c_str());
+  module_library_ = LoadLibrary(path_.c_str());
 
   if (!module_library_) {
     std::string err_msg = "Unable to load agent shared object file: ";
-    err_msg += agent_name;
     err_msg += ". Error code is: ";
     err_msg += GetLastError();
     throw IOError(err_msg);
@@ -25,10 +24,10 @@ void DynamicModule::OpenLibrary() {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void DynamicModule::SetConstructor() {
-  constructor_ = (AgentCtor*)
-                 GetProcAddress(module_library_, constructor_name_.c_str());
+  ctor_ = (AgentCtor*)
+                 GetProcAddress(module_library_, ctor_name_.c_str());
 
-  if (!constructor_) {
+  if (!ctor_) {
     string err_msg = "Unable to load agent constructor: ";
     err_msg += GetLastError();
     throw IOError(err_msg);

--- a/src/xml_file_loader.h
+++ b/src/xml_file_loader.h
@@ -21,10 +21,14 @@ class Context;
 /// Reads the given file path into the passed stream.
 void LoadStringstreamFromFile(std::stringstream& stream, std::string file);
 
+/// Returns a list of the full module+agent spec for all agents in the given
+/// input file.
+std::vector<AgentSpec> ParseModules(std::string infile);
+
 /// Builds and returns a master cyclus input xml schema that includes the
 /// sub-schemas defined by all installed cyclus modules (e.g. facility agents).
 /// This is used to validate simulation input files.
-std::string BuildMasterSchema(std::string schema_path);
+std::string BuildMasterSchema(std::string schema_path, std::string infile);
 
 /// Creates a composition from the recipe in the query engine.
 Composition::Ptr ReadRecipe(InfileTree* qe);

--- a/src/xml_flat_loader.h
+++ b/src/xml_flat_loader.h
@@ -10,7 +10,7 @@ namespace cyclus {
 /// prototype and instance structure that includes the sub-schemas defined by
 /// all installed cyclus modules (e.g. facility agents).  This is used to
 /// validate simulation input files.
-std::string BuildFlatMasterSchema(std::string schema_path);
+std::string BuildFlatMasterSchema(std::string schema_path, std::string infile);
 
 /// a class that encapsulates the methods needed to load input to
 /// a cyclus simulation from xml

--- a/tests/cyclus_unit_test_driver.cc
+++ b/tests/cyclus_unit_test_driver.cc
@@ -12,12 +12,11 @@ int main(int argc, char* argv[]) {
   using cyclus::Env;
   using cyclus::Logger;
   std::string path = Env::PathBase(argv[0]);
-  Env::SetCyclusRelPath(path);
   Logger::ReportLevel() = cyclus::LEV_ERROR;
 
   // add the build path to the environment for testing
-  std::string test_env = Env::ModuleEnvVarName() + "=" + Env::GetBuildPath();
-  std::string curr_var = Env::ModuleEnvVar();
+  std::string test_env = "CYCLUS_PATH=" + Env::GetBuildPath();
+  std::string curr_var = Env::GetEnv("CYCLUS_PATH");
   if (curr_var != "") {
     test_env += ":" + curr_var;
   }

--- a/tests/dynamic_loading_tests.cc
+++ b/tests/dynamic_loading_tests.cc
@@ -15,13 +15,14 @@
 
 namespace fs = boost::filesystem;
 using cyclus::DynamicModule;
+using cyclus::AgentSpec;
 using cyclus::Agent;
 
 TEST(DynamicLoadingTests, ConstructTestFacility) {
   cyclus::Recorder rec;
   cyclus::Timer ti;
   cyclus::Context* ctx = new cyclus::Context(&ti, &rec);
-  EXPECT_NO_THROW(DynamicModule::Make(ctx, "TestFacility"));
+  EXPECT_NO_THROW(DynamicModule::Make(ctx, AgentSpec("TestFacility:TestFacility:TestFacility")));
   EXPECT_NO_THROW(DynamicModule::CloseAll());
 }
 
@@ -29,14 +30,14 @@ TEST(DynamicLoadingTests, LoadLibError) {
   cyclus::Recorder rec;
   cyclus::Timer ti;
   cyclus::Context* ctx = new cyclus::Context(&ti, &rec);
-  EXPECT_THROW(DynamicModule::Make(ctx, "not_a_fac"), cyclus::IOError);
+  EXPECT_THROW(DynamicModule::Make(ctx, AgentSpec("foo:foo:not_a_fac")), cyclus::IOError);
 }
 
 TEST(DynamicLoadingTests, CloneTestFacility) {
   cyclus::Recorder rec;
   cyclus::Timer ti;
   cyclus::Context* ctx = new cyclus::Context(&ti, &rec);
-  EXPECT_NO_THROW(Agent* fac = DynamicModule::Make(ctx, "TestFacility");
+  EXPECT_NO_THROW(Agent* fac = DynamicModule::Make(ctx, AgentSpec("TestFacility:TestFacility:TestFacility"));
                   Agent* clone = fac->Clone(););
   DynamicModule::CloseAll();
 }

--- a/tests/environment_tests.cc
+++ b/tests/environment_tests.cc
@@ -9,29 +9,31 @@
 
 namespace fs = boost::filesystem;
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST(EnvironmentTests, ModuleEnvVar) {
-  // this works if the module path is added in the test driver app
-  //EXPECT_EQ(cyclus::Env::ModuleEnvVar(), cyclus::Env::GetBuildPath());
+using cyclus::Env;
 
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+TEST(EnvironmentTests, CyclusPath) {
   // get the path before changing it
-  std::string env_var = cyclus::Env::ModuleEnvVar();
+  std::string env_var = Env::GetEnv("CYCLUS_PATH");
 
   std::string path = "/my/nice/path";
-  std::string cmd = cyclus::Env::ModuleEnvVarName() + '=' + path;
+  std::string cmd = "CYCLUS_PATH=" + path;
   putenv((char*) cmd.c_str());
-  EXPECT_EQ(cyclus::Env::ModuleEnvVar(), path);
+  std::vector<std::string> ps = Env::cyclus_path();
+
+  ASSERT_EQ(3, ps.size());
+  EXPECT_EQ(path, ps[0]);
 
   // put the path back
-  cmd = cyclus::Env::ModuleEnvVarName() + '=' + env_var;
+  cmd = "CYCLUS_PATH=" + env_var;
   putenv(const_cast<char *>(cmd.c_str()));
-  ASSERT_EQ(cyclus::Env::ModuleEnvVar(), env_var);
+  ASSERT_EQ(env_var, Env::GetEnv("CYCLUS_PATH"));
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST(EnvironmentTests, FindNonStandardPath) {
   // get the path before changing it
-  std::string env_var = cyclus::Env::ModuleEnvVar();
+  std::string env_var = Env::GetEnv("CYCLUS_PATH");
 
   fs::path fname("libfoo.so");
   fs::path dir = fs::path(getenv("HOME")) / fs::path(".tmp-cyclus-test");
@@ -43,17 +45,17 @@ TEST(EnvironmentTests, FindNonStandardPath) {
   f.close();
 
   // add path to env
-  std::string cmd = cyclus::Env::ModuleEnvVarName() + '=' + dir.string();
+  std::string cmd = "CYCLUS_PATH=" + dir.string();
   putenv((char*) cmd.c_str());
 
-  fs::path actual_path;
-  ASSERT_TRUE(cyclus::Env::FindModuleLib(fname.string(), actual_path));
-  EXPECT_EQ(full, actual_path);
+  fs::path p;
+  ASSERT_NO_THROW(p = Env::FindModule(fname.string()));
+  EXPECT_EQ(full, p);
 
   fs::remove_all(dir);
 
   // put the path back
-  cmd = cyclus::Env::ModuleEnvVarName() + '=' + env_var;
+  cmd = "CYCLUS_PATH=" + env_var;
   putenv(const_cast<char *>(cmd.c_str()));
-  ASSERT_EQ(cyclus::Env::ModuleEnvVar(), env_var);
+  ASSERT_EQ(env_var, Env::GetEnv("CYCLUS_PATH"));
 }

--- a/tests/input/minimal_cycle.xml
+++ b/tests/input/minimal_cycle.xml
@@ -19,6 +19,10 @@
 
   <facility>
     <name>FacilityA</name>
+    <module>
+      <path>KFacility</path>
+      <agent>KFacility</agent>
+    </module>
     <agent>
       <KFacility>
         <in_commod_>commodityB</in_commod_>
@@ -34,6 +38,10 @@
 
   <facility>
     <name>FacilityB</name>
+    <module>
+      <path>KFacility</path>
+      <agent>KFacility</agent>
+    </module>
     <agent>
       <KFacility>
         <in_commod_>commodityA</in_commod_>
@@ -49,6 +57,10 @@
 
   <region>
     <name>SingleRegion</name>
+    <module>
+      <path>NullRegion</path>
+      <agent>NullRegion</agent>
+    </module>
     <allowedfacility>FacilityA</allowedfacility>
     <allowedfacility>FacilityB</allowedfacility>
     <agent>
@@ -56,6 +68,10 @@
     </agent>
     <institution>
       <name>SingleInstitution</name>
+      <module>
+        <path>NullInst</path>
+        <agent>NullInst</agent>
+      </module>
       <availableprototype>FacilityA</availableprototype>
       <availableprototype>FacilityB</availableprototype>
       <initialfacilitylist>

--- a/tests/input/null_sink.xml
+++ b/tests/input/null_sink.xml
@@ -15,6 +15,10 @@
 
   <facility>
     <name>Sink</name>
+    <module>
+      <path>Sink</path>
+      <agent>Sink</agent>
+    </module>
     <agent>
       <Sink>
         <in_commods_>
@@ -27,12 +31,20 @@
 
   <region>
     <name>SingleRegion</name>
+    <module>
+      <path>NullRegion</path>
+      <agent>NullRegion</agent>
+    </module>
     <allowedfacility>Sink</allowedfacility>
     <agent>
       <NullRegion/>
     </agent>
     <institution>
       <name>SingleInstitution</name>
+      <module>
+        <path>NullInst</path>
+        <agent>NullInst</agent>
+      </module>
       <availableprototype>Sink</availableprototype>
       <initialfacilitylist>
         <entry>

--- a/tests/input/source_to_sink.xml
+++ b/tests/input/source_to_sink.xml
@@ -15,6 +15,10 @@
 
   <facility>
     <name>Source</name>
+    <module>
+      <path>Source</path>
+      <agent>Source</agent>
+    </module>
     <agent>
       <Source>
         <commod_>commodity</commod_>
@@ -26,6 +30,10 @@
 
   <facility>
     <name>Sink</name>
+    <module>
+      <path>Sink</path>
+      <agent>Sink</agent>
+    </module>
     <agent>
       <Sink>
         <in_commods_>
@@ -38,6 +46,10 @@
 
   <region>
     <name>SingleRegion</name>
+    <module>
+      <path>NullRegion</path>
+      <agent>NullRegion</agent>
+    </module>
     <allowedfacility>Source</allowedfacility>
     <allowedfacility>Sink</allowedfacility>
     <agent>
@@ -45,6 +57,10 @@
     </agent>
     <institution>
       <name>SingleInstitution</name>
+      <module>
+        <path>NullInst</path>
+        <agent>NullInst</agent>
+      </module>
       <availableprototype>Source</availableprototype>
       <availableprototype>Sink</availableprototype>
       <initialfacilitylist>

--- a/tests/input/trivial_cycle.xml
+++ b/tests/input/trivial_cycle.xml
@@ -15,6 +15,10 @@
 
   <facility>
     <name>KFacility</name>
+    <module>
+      <path>KFacility</path>
+      <agent>KFacility</agent>
+    </module>
     <agent>
       <KFacility>
         <in_commod_>commodity</in_commod_>
@@ -30,12 +34,20 @@
 
   <region>
     <name>SingleRegion</name>
+    <module>
+      <path>NullRegion</path>
+      <agent>NullRegion</agent>
+    </module>
     <allowedfacility>KFacility</allowedfacility>
     <agent>
       <NullRegion/>
     </agent>
     <institution>
       <name>SingleInstitution</name>
+      <module>
+        <path>NullInst</path>
+        <agent>NullInst</agent>
+      </module>
       <availableprototype>KFacility</availableprototype>
       <initialfacilitylist>
         <entry>

--- a/tests/test_minimal_cycle.py
+++ b/tests/test_minimal_cycle.py
@@ -136,7 +136,7 @@ def test_minimal_cycle():
             agent_protos = agent_entry["Prototype"]
             duration = info["Duration"][0]
 
-            facility_id = find_ids("KFacility", agent_impl, agent_ids)
+            facility_id = find_ids("KFacility:KFacility:KFacility", agent_impl, agent_ids)
             # Test for two KFacility
             yield assert_equal, len(facility_id), 2
 

--- a/tests/test_null_sink.py
+++ b/tests/test_null_sink.py
@@ -44,7 +44,7 @@ def test_null_sink():
     agent_ids = agent_entry["AgentId"]
     agent_impl = agent_entry["Implementation"]
 
-    sink_id = find_ids("Sink", agent_impl, agent_ids)
+    sink_id = find_ids("Sink:Sink:Sink", agent_impl, agent_ids)
     # Test if one SimpleSink is deployed
     yield assert_equal, len(sink_id), 1
 

--- a/tests/test_source_to_sink.py
+++ b/tests/test_source_to_sink.py
@@ -47,8 +47,8 @@ def test_source_to_sink():
         agent_ids = agent_entry["AgentId"]
         agent_impl = agent_entry["Implementation"]
 
-        source_id = find_ids("Source", agent_impl, agent_ids)
-        sink_id = find_ids("Sink", agent_impl, agent_ids)
+        source_id = find_ids("Source:Source:Source", agent_impl, agent_ids)
+        sink_id = find_ids("Sink:Sink:Sink", agent_impl, agent_ids)
 
         # Test for only one source and one sink are deployed in the simulation
         yield assert_equal, len(source_id), 1

--- a/tests/test_trivial_cycle.py
+++ b/tests/test_trivial_cycle.py
@@ -60,7 +60,7 @@ def test_source_to_sink():
         agent_ids = agent_entry["AgentId"]
         agent_impl = agent_entry["Implementation"]
 
-        facility_id = find_ids("KFacility", agent_impl, agent_ids)
+        facility_id = find_ids("KFacility:KFacility:KFacility", agent_impl, agent_ids)
         # Test for only one KFacility
         yield assert_equal, len(facility_id), 1
 


### PR DESCRIPTION
- Cleans up Env class a lot
- added module section to master schema
- cleaned up schema - no more recipe book or catalogs (just use xml includes
  instead). Deleted all unused def/ref's that aren't needed for master schema.
- CYCLUS_MODULE_PATH->CYCLUS_PATH. and now it is a colon separated list of
  paths.
- Created AgentSpec class for dealing with agent spec parts.
- added func to manually add ref agents for dyn module Make. Useful for tests
  and other creative uses?

This has a cycamore companion PR
