### PR TITLE
New Simid fix

### DIFF
--- a/cli/cycpp.py
+++ b/cli/cycpp.py
@@ -95,7 +95,8 @@ WRANGLERS = {
 #
 # pass 1
 #
-def preprocess_file(filename, includes = [], cpp_path='cpp', cpp_args=('-xc++', '-pipe', '-E')):
+def preprocess_file(filename, includes=(), cpp_path='cpp', 
+                    cpp_args=('-xc++', '-pipe', '-E', '-DCYCPP')):
     """Preprocess a file using cpp.
 
     Parameters

--- a/src/context.h
+++ b/src/context.h
@@ -5,7 +5,13 @@
 #include <map>
 #include <set>
 #include <string>
+
+#ifndef CYCPP
+// The cyclus preprocessor cannot handle this file since there are two 
+// unmatch open braces '{' inside of strings that don't have cooresponding
+// closed braces '}'
 #include <boost/uuid/uuid_generators.hpp>
+#endif
 
 #include "composition.h"
 #include "agent.h"


### PR DESCRIPTION
This PR includes and supersedes #793 as well as 'fixes'  #792.

The issue with boost/uuid/uuid_generators.hpp is that the number of open curly braces in the files is two greater than the number of closed curly braces in the file.  The extra open braces are inside of strings.  This messes up cycpp's depth calculation.

Rather than trying to update the statement regex (which would have taken a long and unknown amount of time), the strategy here is to implement a special macro `CYCPP` that is only defined by cycpp when it runs cpp.  This is then used to include (or here, skip) certain parts of the code... Like the unparseable bit.  

In the future `CYCPP` may even be used as an optimization to have cycpp not parse things it doesn't need to.  But that is a task for a rainy day or undergrad!
