### PR TITLE
XML Include

### DIFF
--- a/src/xml_parser.cc
+++ b/src/xml_parser.cc
@@ -44,7 +44,17 @@ void XMLParser::Validate(const std::stringstream& xml_schema_snippet) {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 xmlpp::Document* XMLParser::Document() {
   xmlpp::Document* doc = parser_->get_document();
+  // This adds the capability to have nice include semantics
   doc->process_xinclude();
+  // This removes the stupid xml:base attribute that including adds,
+  // but which is unvalidatable. The web is truly cobbled together
+  // by a race of evil gnomes.
+  xmlpp::Element* root = doc->get_root_node();
+  xmlpp::NodeSet have_base = root->find("//*[@xml:base]");
+  xmlpp::NodeSet::iterator it = have_base.begin();
+  for (; it != have_base.end(); ++it) {
+    reinterpret_cast<xmlpp::Element*>(*it)->remove_attribute("base", "xml");
+  }
   return doc;
 }
 }  // namespace cyclus

--- a/tests/input/include_recipe.xml
+++ b/tests/input/include_recipe.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<!-- 1 Sink -->
+
+<simulation xmlns:xi="http://www.w3.org/2001/XInclude">
+  <control>
+    <duration>100</duration>
+    <startmonth>1</startmonth>
+    <startyear>2000</startyear>
+    <decay>0</decay>
+  </control>
+
+  <commodity>
+    <name>commodity</name>
+  </commodity>
+
+  <facility>
+    <name>Sink</name>
+    <module>
+      <path>Sink</path>
+      <agent>Sink</agent>
+    </module>
+    <agent>
+      <Sink>
+        <in_commods_>
+          <val>commodity</val>
+        </in_commods_>
+        <capacity_>1.00</capacity_>
+      </Sink>
+    </agent>
+  </facility>
+
+  <region>
+    <name>SingleRegion</name>
+    <module>
+      <path>NullRegion</path>
+      <agent>NullRegion</agent>
+    </module>
+    <allowedfacility>Sink</allowedfacility>
+    <agent>
+      <NullRegion/>
+    </agent>
+    <institution>
+      <name>SingleInstitution</name>
+      <module>
+        <path>NullInst</path>
+        <agent>NullInst</agent>
+      </module>
+      <availableprototype>Sink</availableprototype>
+      <initialfacilitylist>
+        <entry>
+          <prototype>Sink</prototype>
+          <number>1</number>
+        </entry>
+      </initialfacilitylist>
+      <agent>
+        <NullInst/>
+      </agent>
+    </institution>
+  </region>
+
+  <xi:include href="input/recipe.xml" />
+
+</simulation>

--- a/tests/input/recipe.xml
+++ b/tests/input/recipe.xml
@@ -1,0 +1,8 @@
+<recipe>
+  <name>commod_recipe</name>
+  <basis>mass</basis>
+  <nuclide>
+    <id>010010000</id>
+    <comp>1</comp>
+  </nuclide>
+</recipe>

--- a/tests/test_include_recipe.py
+++ b/tests/test_include_recipe.py
@@ -1,0 +1,24 @@
+#! /usr/bin/env python
+
+from nose.tools import assert_false, assert_true, assert_equal
+import os
+import tables
+import numpy as np
+from tools import check_cmd
+from helper import tables_exist, find_ids, exit_times, \
+    h5out, sqliteout, clean_outs
+
+"""Tests"""
+def test_include_recipe():
+    """Testing for including of other XML files.
+    """
+    clean_outs()
+    # Cyclus simulation input for recipe including
+    sim_input = "./input/include_recipe.xml"
+    holdsrtn = [1]  # needed because nose does not send() to test generator
+    cmd = ["cyclus", "-o", h5out, "--input-file", sim_input]
+    yield check_cmd, cmd, '.', holdsrtn
+    rtn = holdsrtn[0]
+    if rtn != 0:
+        return  # don't execute further commands
+    clean_outs()

--- a/tests/xml_parser_tests.cc
+++ b/tests/xml_parser_tests.cc
@@ -92,7 +92,7 @@ TEST_F(XMLParserTests, XInclude) {
   using std::ofstream;
   using std::stringstream;
   // setup file on disk and in-memory snippet
-  FileDeleter fd("includ_me.xml");
+  FileDeleter fd("include_me.xml");
   stringstream fss("");
   FillSnippet(fss);
   ofstream f;


### PR DESCRIPTION
This adds support for the XInclude capability.  This will allow us to separate the various cookbooks into their own files and then include them using the standard xml mechanism.
