### PR TITLE
adds a base class for mixin or composed classes managed by agents

### DIFF
--- a/src/toolkit/agent_managed.h
+++ b/src/toolkit/agent_managed.h
@@ -1,0 +1,24 @@
+#ifndef CYCLUS_SRC_TOOLKIT_AGENT_MANAGED_H_
+#define CYCLUS_SRC_TOOLKIT_AGENT_MANAGED_H_
+
+#include "agent.h"
+
+namespace cyclus {
+namespace toolkit {
+
+/// This is a mixin class that provides an interface to access the underlying
+/// agent that manages it.
+class AgentManaged {
+ public:
+  explicit AgentManaged(Agent* agent=NULL) : agent_(agent) {};
+  inline Agent* agent() const {return agent_;}
+
+ private:
+  /// the agent managing this instance
+  Agent* agent_;
+};
+  
+} // namespace toolkit
+} // namespace cyclus
+
+#endif // CYCLUS_SRC_TOOLKIT_AGENT_MANAGED_H_

--- a/src/toolkit/builder.h
+++ b/src/toolkit/builder.h
@@ -1,9 +1,9 @@
-#ifndef CYCLUS_SRC_BUILDER_H_
-#define CYCLUS_SRC_BUILDER_H_
+#ifndef CYCLUS_SRC_TOOLKIT_BUILDER_H_
+#define CYCLUS_SRC_TOOLKIT_BUILDER_H_
 
 #include <set>
 
-#include "agent.h"
+#include "agent_managed.h"
 #include "commodity_producer.h"
 
 namespace cyclus {
@@ -11,9 +11,9 @@ namespace toolkit {
 
 /// a mixin to provide information about commodity producers that can
 /// be built
-class Builder {
+class Builder: public AgentManaged {
  public:
-  Builder(Agent* agent=NULL) : agent_(agent) {};
+  Builder(Agent* agent=NULL) : AgentManaged(agent) {};
   virtual ~Builder() {};
 
   /// register a commodity producer with the agent
@@ -29,15 +29,11 @@ class Builder {
   }
 
   inline const std::set<CommodityProducer*>& producers() const {return producers_;}
-
-  inline Agent* agent() const {return agent_;}
   
  private:
-  /// the agent managing this instance
-  Agent* agent_;
   std::set<CommodityProducer*> producers_;
 };
 
 } // namespace toolkit
 } // namespace cyclus
-#endif  // CYCLUS_SRC_BUILDER_H_
+#endif  // CYCLUS_SRC_TOOLKIT_BUILDER_H_

--- a/src/toolkit/building_manager.h
+++ b/src/toolkit/building_manager.h
@@ -1,10 +1,10 @@
-#ifndef CYCLUS_SRC_BUILDING_MANAGER_H_
-#define CYCLUS_SRC_BUILDING_MANAGER_H_
+#ifndef CYCLUS_SRC_TOOLKIT_BUILDING_MANAGER_H_
+#define CYCLUS_SRC_TOOLKIT_BUILDING_MANAGER_H_
 
 #include <map>
 #include <vector>
 
-#include "agent.h"
+#include "agent_managed.h"
 #include "builder.h"
 #include "commodity_producer.h"
 #include "OsiCbcSolverInterface.hpp"
@@ -41,9 +41,9 @@ struct BuildOrder {
 /// cost to build the object of type i, \f$\phi_i\f$ is the nameplate
 /// capacity of the object, and \f$\Phi\f$ is the capacity demand. Here
 /// the set I corresponds to all producers of a given commodity.
-class BuildingManager {
+class BuildingManager: public AgentManaged {
  public:
-  BuildingManager(Agent* agent=NULL) : agent_(agent) {};
+  BuildingManager(Agent* agent=NULL) : AgentManaged(agent) {};
 
   /// register a builder with the manager
   /// @param builder the builder
@@ -67,11 +67,7 @@ class BuildingManager {
     return builders_;
   }
 
-  inline Agent* agent() const {return agent_;}
-
  private:
-  /// the agent managing this instance
-  Agent* agent_;
   std::set<Builder*> builders_;
 
   void SetUp_(OsiCbcSolverInterface& iface,
@@ -89,4 +85,4 @@ class BuildingManager {
 };
 } // namespace toolkit
 } // namespace cyclus
-#endif  // CYCLUS_SRC_BUILDING_MANAGER_H_
+#endif  // CYCLUS_SRC_TOOLKIT_BUILDING_MANAGER_H_

--- a/src/toolkit/commodity.h
+++ b/src/toolkit/commodity.h
@@ -1,5 +1,5 @@
-#ifndef CYCLUS_SRC_COMMODITY_H_
-#define CYCLUS_SRC_COMMODITY_H_
+#ifndef CYCLUS_SRC_TOOLKIT_COMMODITY_H_
+#define CYCLUS_SRC_TOOLKIT_COMMODITY_H_
 
 #include <string>
 
@@ -49,4 +49,4 @@ struct CommodityCompare {
 };
 } // namespace toolkit
 } // namespace cyclus
-#endif  // CYCLUS_SRC_COMMODITY_H_
+#endif  // CYCLUS_SRC_TOOLKIT_COMMODITY_H_

--- a/src/toolkit/commodity_producer.cc
+++ b/src/toolkit/commodity_producer.cc
@@ -11,9 +11,9 @@ CommodInfo::CommodInfo(double default_capacity,
 CommodityProducer::CommodityProducer(double default_capacity,
                                      double default_cost,
                                      Agent* agent)
-    : default_capacity_(default_capacity),
-      default_cost_(default_cost),
-      agent_(agent) {}
+    : AgentManaged(agent),
+      default_capacity_(default_capacity),
+      default_cost_(default_cost) {}
 
 CommodityProducer::~CommodityProducer() {}
 

--- a/src/toolkit/commodity_producer.h
+++ b/src/toolkit/commodity_producer.h
@@ -1,10 +1,10 @@
-#ifndef CYCLUS_SRC_COMMODITY_PRODUCER_H_
-#define CYCLUS_SRC_COMMODITY_PRODUCER_H_
+#ifndef CYCLUS_SRC_TOOLKIT_COMMODITY_PRODUCER_H_
+#define CYCLUS_SRC_TOOLKIT_COMMODITY_PRODUCER_H_
 
 #include <map>
 #include <set>
 
-#include "agent.h"
+#include "agent_managed.h"
 #include "cyc_limits.h"
 #include "commodity.h"
 
@@ -20,7 +20,7 @@ struct CommodInfo {
 };
 
 /// a mixin to provide information about produced commodities
-class CommodityProducer {
+class CommodityProducer: public AgentManaged {
  public:
   CommodityProducer(double default_capacity=0,
                     double default_cost=kModifierLimit,
@@ -86,12 +86,7 @@ class CommodityProducer {
   /// @param source the original commodity producer
   void Copy(CommodityProducer* source);
 
-  inline Agent* agent() const {return agent_;}
-
  private:
-  /// the agent managing this instance
-  Agent* agent_;
-
   /// a collection of commodities and their production capacities
   std::map<Commodity, CommodInfo, CommodityCompare> commodities_;
 
@@ -104,4 +99,5 @@ class CommodityProducer {
 
 } // namespace toolkit
 } // namespace cyclus
-#endif  // CYCLUS_SRC_COMMODITY_PRODUCER_H_
+
+#endif  // CYCLUS_SRC_TOOLKIT_COMMODITY_PRODUCER_H_

--- a/src/toolkit/commodity_producer_manager.h
+++ b/src/toolkit/commodity_producer_manager.h
@@ -1,9 +1,9 @@
-#ifndef CYCLUS_SRC_COMMODITY_PRODUCER_MANAGER_H_
-#define CYCLUS_SRC_COMMODITY_PRODUCER_MANAGER_H_
+#ifndef CYCLUS_SRC_TOOLKIT_COMMODITY_PRODUCER_MANAGER_H_
+#define CYCLUS_SRC_TOOLKIT_COMMODITY_PRODUCER_MANAGER_H_
 
 #include <set>
 
-#include "agent.h"
+#include "agent_managed.h"
 #include "commodity.h"
 #include "commodity_producer.h"
 
@@ -11,9 +11,9 @@ namespace cyclus {
 namespace toolkit {
 
 /// a mixin to provide information about commodity producers
-class CommodityProducerManager {
+class CommodityProducerManager: public AgentManaged {
  public: 
-  CommodityProducerManager(Agent* agent=NULL) : agent_(agent) {};
+  CommodityProducerManager(Agent* agent=NULL) : AgentManaged(agent) {};
   virtual ~CommodityProducerManager() {};
 
   /// @return the total production capacity for a commodity amongst producers
@@ -34,16 +34,11 @@ class CommodityProducerManager {
 
   inline const std::set<CommodityProducer*>& producers() const {return producers_;}
 
-  inline Agent* agent() const {return agent_;}
-
  private:
-  /// the agent managing this instance
-  Agent* agent_;
-
   /// the set of managed producers
   std::set<CommodityProducer*> producers_;
 };
 
 } // namespace toolkit
 } // namespace cyclus
-#endif  // CYCLUS_SRC_COMMODITY_PRODUCER_MANAGER_H_
+#endif  // CYCLUS_SRC_TOOLKIT_COMMODITY_PRODUCER_MANAGER_H_

--- a/src/toolkit/commodity_recipe_context.h
+++ b/src/toolkit/commodity_recipe_context.h
@@ -1,5 +1,5 @@
-#ifndef CYCLUS_SRC_COMMODITY_RECIPE_CONTEXT_H_
-#define CYCLUS_SRC_COMMODITY_RECIPE_CONTEXT_H_
+#ifndef CYCLUS_SRC_TOOLKIT_COMMODITY_RECIPE_CONTEXT_H_
+#define CYCLUS_SRC_TOOLKIT_COMMODITY_RECIPE_CONTEXT_H_
 
 #include <map>
 #include <string>
@@ -98,4 +98,4 @@ class CommodityRecipeContext : public StateWrangler {
 } // namespace toolkit
 } // namespace cyclus
 
-#endif  // CYCLUS_SRC_COMMODITY_RECIPE_CONTEXT_H_
+#endif  // CYCLUS_SRC_TOOLKIT_COMMODITY_RECIPE_CONTEXT_H_

--- a/src/toolkit/enrichment.h
+++ b/src/toolkit/enrichment.h
@@ -1,6 +1,6 @@
 // enrichment.h
-#ifndef CYCLUS_SRC_ENRICHMENT_H_
-#define CYCLUS_SRC_ENRICHMENT_H_
+#ifndef CYCLUS_SRC_TOOLKIT_ENRICHMENT_H_
+#define CYCLUS_SRC_TOOLKIT_ENRICHMENT_H_
 
 #include <set>
 
@@ -70,4 +70,4 @@ double ValueFunc(double frac);
 
 } // namespace toolkit
 } // namespace cyclus
-#endif  // CYCLUS_SRC_ENRICHMENT_H_
+#endif  // CYCLUS_SRC_TOOLKIT_ENRICHMENT_H_

--- a/src/toolkit/mat_query.h
+++ b/src/toolkit/mat_query.h
@@ -1,5 +1,5 @@
-#ifndef CYCLUS_SRC_MAT_QUERY_H_
-#define CYCLUS_SRC_MAT_QUERY_H_
+#ifndef CYCLUS_SRC_TOOLKIT_MAT_QUERY_H_
+#define CYCLUS_SRC_TOOLKIT_MAT_QUERY_H_
 
 #include "comp_math.h"
 #include "cyc_limits.h"
@@ -45,4 +45,4 @@ class MatQuery {
 } // namespace toolkit
 } // namespace cyclus
 
-#endif  // CYCLUS_SRC_MAT_QUERY_H_
+#endif  // CYCLUS_SRC_TOOLKIT_MAT_QUERY_H_

--- a/src/toolkit/supply_demand_manager.h
+++ b/src/toolkit/supply_demand_manager.h
@@ -4,7 +4,7 @@
 #include "commodity.h"
 #include "commodity_producer_manager.h"
 #include "symbolic_functions.h"
-#include "agent.h"
+#include "agent_managed.h"
 
 #include <map>
 #include <set>
@@ -20,9 +20,9 @@ namespace toolkit {
 /// provides the demand and supply of a commodity at a given time.
 /// What to do with this information is left to the user of the
 /// SupplyDemandManager.
-class SupplyDemandManager {
+class SupplyDemandManager: public AgentManaged {
  public:
-  SupplyDemandManager(Agent* agent=NULL) : agent_(agent) {};
+  SupplyDemandManager(Agent* agent=NULL) : AgentManaged(agent) {};
   virtual ~SupplyDemandManager() {};
   
   /// register a new commodity with the manager, along with all the
@@ -64,17 +64,12 @@ class SupplyDemandManager {
     return demand_functions_[commodity];
   }
 
-  inline Agent* agent() const {return agent_;}
-
   /// returns the current supply of a commodity
   /// @param commodity the commodity
   /// @return the current supply of the commodity
   double Supply(Commodity& commodity);
   
  private:
-  /// the agent managing this instance
-  Agent* agent_;
-
   /// a container of all demand functions known to the manager
   std::map<Commodity, SymFunction::Ptr, CommodityCompare> demand_functions_;
 


### PR DESCRIPTION
A number of toolkit classes had identical interfaces to reach the managing agent. This PR gives a base mixin class that provides the common interface. It can be used for future derived mixins or composition classes.

I'll note that this base class could be moved up into the kernel in the future if we desire (`Trader`s have very similar functionality).

I also took the opportunity to fix the include guards for toolkit classes.
