### PR TITLE
only agent tests link against gtest

### DIFF
--- a/agents/k_facility.cc
+++ b/agents/k_facility.cc
@@ -217,10 +217,3 @@ extern "C" cyclus::Agent* ConstructKFacility(cyclus::Context* ctx) {
 }
  
 }  // namespace cyclus
-
-// required to get functionality in cyclus agent unit tests library
-#ifndef CYCLUS_AGENT_TESTS_CONNECTED
-int ConnectAgentTests();
-static int cyclus_agent_tests_connected = ConnectAgentTests();
-#define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
-#endif // CYCLUS_AGENT_TESTS_CONNECTED

--- a/agents/k_facility_tests.cc
+++ b/agents/k_facility_tests.cc
@@ -31,6 +31,13 @@ cyclus::Agent* KFacilityConstructor(cyclus::Context* ctx) {
   return dynamic_cast<cyclus::Agent*>(new KFacility(ctx));
 }
 
+// required to get functionality in cyclus agent unit tests library
+#ifndef CYCLUS_AGENT_TESTS_CONNECTED
+int ConnectAgentTests();
+static int cyclus_agent_tests_connected = ConnectAgentTests();
+#define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
+#endif // CYCLUS_AGENT_TESTS_CONNECTED
+
 INSTANTIATE_TEST_CASE_P(KFac, FacilityTests,
                         ::testing::Values(&KFacilityConstructor));
 

--- a/agents/null_inst.cc
+++ b/agents/null_inst.cc
@@ -11,10 +11,3 @@ extern "C" cyclus::Agent* ConstructNullInst(cyclus::Context* ctx) {
 }
 
 }  // namespace cyclus
-
-// required to get functionality in cyclus agent unit tests library
-#ifndef CYCLUS_AGENT_TESTS_CONNECTED
-int ConnectAgentTests();
-static int cyclus_agent_tests_connected = ConnectAgentTests();
-#define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
-#endif // CYCLUS_AGENT_TESTS_CONNECTED

--- a/agents/null_inst_tests.cc
+++ b/agents/null_inst_tests.cc
@@ -57,6 +57,13 @@ cyclus::Agent* NullInstConstructor(cyclus::Context* ctx) {
   return new NullInst(ctx);
 }
 
+// required to get functionality in cyclus agent unit tests library
+#ifndef CYCLUS_AGENT_TESTS_CONNECTED
+int ConnectAgentTests();
+static int cyclus_agent_tests_connected = ConnectAgentTests();
+#define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
+#endif // CYCLUS_AGENT_TESTS_CONNECTED
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 INSTANTIATE_TEST_CASE_P(NullInst, InstitutionTests,
                         ::testing::Values(&NullInstConstructor));

--- a/agents/null_region.cc
+++ b/agents/null_region.cc
@@ -11,10 +11,3 @@ extern "C" cyclus::Agent* ConstructNullRegion(cyclus::Context* ctx) {
 }
 
 }  // namespce cyclus
-
-// required to get functionality in cyclus agent unit tests library
-#ifndef CYCLUS_AGENT_TESTS_CONNECTED
-int ConnectAgentTests();
-static int cyclus_agent_tests_connected = ConnectAgentTests();
-#define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
-#endif // CYCLUS_AGENT_TESTS_CONNECTED

--- a/agents/null_region_tests.cc
+++ b/agents/null_region_tests.cc
@@ -61,6 +61,13 @@ cyclus::Agent* NullRegionConstructor(cyclus::Context* ctx) {
   return new NullRegion(ctx);
 }
 
+// required to get functionality in cyclus agent unit tests library
+#ifndef CYCLUS_AGENT_TESTS_CONNECTED
+int ConnectAgentTests();
+static int cyclus_agent_tests_connected = ConnectAgentTests();
+#define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
+#endif // CYCLUS_AGENT_TESTS_CONNECTED
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 INSTANTIATE_TEST_CASE_P(NullRegion, RegionTests,
                         ::testing::Values(&NullRegionConstructor));

--- a/agents/predator.cc
+++ b/agents/predator.cc
@@ -120,10 +120,3 @@ extern "C" cyclus::Agent* ConstructPredator(cyclus::Context* ctx) {
 }
 
 }  // namespace cyclus
-
-// required to get functionality in cyclus agent unit tests library
-#ifndef CYCLUS_AGENT_TESTS_CONNECTED
-int ConnectAgentTests();
-static int cyclus_agent_tests_connected = ConnectAgentTests();
-#define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
-#endif // CYCLUS_AGENT_TESTS_CONNECTED

--- a/agents/prey.cc
+++ b/agents/prey.cc
@@ -118,10 +118,3 @@ extern "C" cyclus::Agent* ConstructPrey(cyclus::Context* ctx) {
 }
 
 }  // namespace cyclus
-
-// required to get functionality in cyclus agent unit tests library
-#ifndef CYCLUS_AGENT_TESTS_CONNECTED
-int ConnectAgentTests();
-static int cyclus_agent_tests_connected = ConnectAgentTests();
-#define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
-#endif // CYCLUS_AGENT_TESTS_CONNECTED

--- a/agents/sink.cc
+++ b/agents/sink.cc
@@ -122,10 +122,3 @@ extern "C" cyclus::Agent* ConstructSink(cyclus::Context* ctx) {
 }
 
 }  // namespace cyclus
-
-// required to get functionality in cyclus agent unit tests library
-#ifndef CYCLUS_AGENT_TESTS_CONNECTED
-int ConnectAgentTests();
-static int cyclus_agent_tests_connected = ConnectAgentTests();
-#define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
-#endif // CYCLUS_AGENT_TESTS_CONNECTED

--- a/agents/sink_tests.cc
+++ b/agents/sink_tests.cc
@@ -62,6 +62,13 @@ cyclus::Agent* SinkConstructor(cyclus::Context* ctx) {
   return new Sink(ctx);
 }
 
+// required to get functionality in cyclus agent unit tests library
+#ifndef CYCLUS_AGENT_TESTS_CONNECTED
+int ConnectAgentTests();
+static int cyclus_agent_tests_connected = ConnectAgentTests();
+#define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
+#endif // CYCLUS_AGENT_TESTS_CONNECTED
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 INSTANTIATE_TEST_CASE_P(SinkFac, FacilityTests,
                         ::testing::Values(&SinkConstructor));

--- a/agents/source.cc
+++ b/agents/source.cc
@@ -103,10 +103,3 @@ extern "C" cyclus::Agent* ConstructSource(cyclus::Context* ctx) {
 }
 
 }  // namespace cyclus
-
-// required to get functionality in cyclus agent unit tests library
-#ifndef CYCLUS_AGENT_TESTS_CONNECTED
-int ConnectAgentTests();
-static int cyclus_agent_tests_connected = ConnectAgentTests();
-#define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
-#endif // CYCLUS_AGENT_TESTS_CONNECTED

--- a/agents/source_tests.cc
+++ b/agents/source_tests.cc
@@ -55,12 +55,22 @@ TEST_F(SourceTest, Tock) {
   int time = 1;
   EXPECT_NO_THROW(src_facility_->Tock(time));
   // Test Source specific behaviors of the Tock function here
+  int a = 0;
 }
+
+};  // namespace cyclus
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 cyclus::Agent* SourceConstructor(cyclus::Context* ctx) {
-  return new Source(ctx);
+  return new cyclus::Source(ctx);
 }
+
+// required to get functionality in cyclus agent unit tests library
+#ifndef CYCLUS_AGENT_TESTS_CONNECTED
+int ConnectAgentTests();
+static int cyclus_agent_tests_connected = ConnectAgentTests();
+#define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
+#endif // CYCLUS_AGENT_TESTS_CONNECTED
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 INSTANTIATE_TEST_CASE_P(SourceFac, FacilityTests,
@@ -68,5 +78,3 @@ INSTANTIATE_TEST_CASE_P(SourceFac, FacilityTests,
 
 INSTANTIATE_TEST_CASE_P(SourceFac, AgentTests,
                         ::testing::Values(&SourceConstructor));
-
-};  // namespace cyclus

--- a/cmake/UseCyclus.cmake
+++ b/cmake/UseCyclus.cmake
@@ -226,7 +226,7 @@ ENDMACRO()
 MACRO(INSTALL_AGENT_LIB_ lib_name lib_src lib_h inst_dir)
   # add lib
   ADD_LIBRARY(${lib_name} ${lib_src})
-  TARGET_LINK_LIBRARIES(${lib_name} dl ${LIBS} ${CYCLUS_AGENT_TEST_LIBRARIES})
+  TARGET_LINK_LIBRARIES(${lib_name} dl ${LIBS})
   SET(CYCLUS_LIBRARIES ${CYCLUS_LIBRARIES} ${lib_root})
   ADD_DEPENDENCIES(${lib_name} ${lib_src} ${lib_h})
 

--- a/stubs/stub_facility.cc
+++ b/stubs/stub_facility.cc
@@ -23,10 +23,3 @@ extern "C" cyclus::Agent* ConstructStubFacility(cyclus::Context* ctx) {
 }
 
 }
-
-// required to get functionality in cyclus agent unit tests library
-#ifndef CYCLUS_AGENT_TESTS_CONNECTED
-int ConnectAgentTests();
-static int cyclus_agent_tests_connected = ConnectAgentTests();
-#define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
-#endif // CYCLUS_AGENT_TESTS_CONNECTED

--- a/stubs/stub_facility_tests.cc
+++ b/stubs/stub_facility_tests.cc
@@ -62,6 +62,13 @@ cyclus::Agent* StubFacilityConstructor(cyclus::Context* ctx) {
   return new StubFacility(ctx);
 }
 
+// required to get functionality in cyclus agent unit tests library
+#ifndef CYCLUS_AGENT_TESTS_CONNECTED
+int ConnectAgentTests();
+static int cyclus_agent_tests_connected = ConnectAgentTests();
+#define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
+#endif // CYCLUS_AGENT_TESTS_CONNECTED
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 INSTANTIATE_TEST_CASE_P(StubFac, FacilityTests,
                         ::testing::Values(&StubFacilityConstructor));

--- a/stubs/stub_inst.cc
+++ b/stubs/stub_inst.cc
@@ -18,10 +18,3 @@ std::string StubInst::str() {
 extern "C" cyclus::Agent* ConstructStubInst(cyclus::Context* ctx) {
   return new StubInst(ctx);
 }
-
-// required to get functionality in cyclus agent unit tests library
-#ifndef CYCLUS_AGENT_TESTS_CONNECTED
-int ConnectAgentTests();
-static int cyclus_agent_tests_connected = ConnectAgentTests();
-#define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
-#endif // CYCLUS_AGENT_TESTS_CONNECTED

--- a/stubs/stub_inst_tests.cc
+++ b/stubs/stub_inst_tests.cc
@@ -58,6 +58,13 @@ cyclus::Agent* StubInstitutionConstructor(cyclus::Context* ctx) {
   return new StubInst(ctx);
 }
 
+// required to get functionality in cyclus agent unit tests library
+#ifndef CYCLUS_AGENT_TESTS_CONNECTED
+int ConnectAgentTests();
+static int cyclus_agent_tests_connected = ConnectAgentTests();
+#define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
+#endif // CYCLUS_AGENT_TESTS_CONNECTED
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 INSTANTIATE_TEST_CASE_P(StubInst, InstitutionTests,
                         ::testing::Values(&StubInstitutionConstructor));

--- a/stubs/stub_region.cc
+++ b/stubs/stub_region.cc
@@ -18,10 +18,3 @@ std::string StubRegion::str() {
 extern "C" cyclus::Agent* ConstructStubRegion(cyclus::Context* ctx) {
   return new StubRegion(ctx);
 }
-
-// required to get functionality in cyclus agent unit tests library
-#ifndef CYCLUS_AGENT_TESTS_CONNECTED
-int ConnectAgentTests();
-static int cyclus_agent_tests_connected = ConnectAgentTests();
-#define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
-#endif // CYCLUS_AGENT_TESTS_CONNECTED

--- a/stubs/stub_region_tests.cc
+++ b/stubs/stub_region_tests.cc
@@ -61,6 +61,13 @@ cyclus::Agent* StubRegionConstructor(cyclus::Context* ctx) {
   return new StubRegion(ctx);
 }
 
+// required to get functionality in cyclus agent unit tests library
+#ifndef CYCLUS_AGENT_TESTS_CONNECTED
+int ConnectAgentTests();
+static int cyclus_agent_tests_connected = ConnectAgentTests();
+#define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
+#endif // CYCLUS_AGENT_TESTS_CONNECTED
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 INSTANTIATE_TEST_CASE_P(StubRegion, RegionTests,
                         ::testing::Values(&StubRegionConstructor));


### PR DESCRIPTION
This updates the build such that only agent tests are built against gtest libraries. This should hopefully supersede #911.  

```
08:53 ~/work/cyclus/cyclus [atbuild|…10]$ ldd ~/.local/bin/cyclus_unit_tests | grep test
    libbaseagentunittests.so => /home/gidden/.local/lib/cyclus/libbaseagentunittests.so (0x00007f68ca9f5000)
    libgtest.so => /home/gidden/.local/lib/libgtest.so (0x00007f68ca465000)
08:53 ~/work/cyclus/cyclus [atbuild|…10]$ ldd ~/.local/lib/cyclus/libagents.so | grep test
08:54 ~/work/cyclus/cyclus [atbuild|…10]$ ldd ~/.local/bin/cyclus | grep test
08:55 ~/work/cyclus/cyclus [atbuild|…10]$ 
```
