### PR TITLE
pass recipe nuclides through pyne::nucname::id()

### DIFF
--- a/share/cyclus-flat.rng.in
+++ b/share/cyclus-flat.rng.in
@@ -67,7 +67,7 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
       <element name="basis"><text/></element>
       <oneOrMore>
         <element name="nuclide">
-          <element name="id"><data type="integer"/></element>
+          <element name="id"><data type="string"/></element>
           <element name="comp"><data type="double"/></element>
         </element>
       </oneOrMore>

--- a/share/cyclus.rng.in
+++ b/share/cyclus.rng.in
@@ -96,7 +96,7 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
       <element name="basis"><text/></element>
       <oneOrMore>
         <element name="nuclide">
-          <element name="id"><data type="nonNegativeInteger"/></element>
+          <element name="id"><data type="string"/></element>
           <element name="comp"><data type="double"/></element>
         </element>
       </oneOrMore>

--- a/src/xml_file_loader.cc
+++ b/src/xml_file_loader.cc
@@ -120,7 +120,7 @@ Composition::Ptr ReadRecipe(InfileTree* qe) {
   CompMap v;
   for (int i = 0; i < nnucs; i++) {
     InfileTree* nuclide = qe->SubTree(query, i);
-    key = strtol(nuclide->GetString("id").c_str(), NULL, 10);
+    key = pyne::nucname::id(nuclide->GetString("id"));
     value = strtod(nuclide->GetString("comp").c_str(), NULL);
     v[key] = value;
     CLOG(LEV_DEBUG3) << "  Nuclide: " << key << " Value: " << v[key];

--- a/tests/input/source_to_sink.xml
+++ b/tests/input/source_to_sink.xml
@@ -60,7 +60,7 @@
     <name>commod_recipe</name>
     <basis>mass</basis>
     <nuclide>
-      <id>010010000</id>
+      <id>H1</id>
       <comp>1</comp>
     </nuclide>
   </recipe>

--- a/tests/xml_file_loader_tests.cc
+++ b/tests/xml_file_loader_tests.cc
@@ -69,7 +69,7 @@ std::string XMLFileLoaderTests::RecipeSequence() {
           "      <comp>0.01</comp>"
           "    </nuclide>"
           "    <nuclide>"
-          "      <id>922350000</id>"
+          "      <id>U-235</id>"
           "      <comp>0.02</comp>"
           "    </nuclide>"
           "    <nuclide>"


### PR DESCRIPTION
This is a small PR with a big user impact.  The idea here is to pass nuclide ids through pyne's id() function.  This will let users write recipes in a way that is human readable and natural rather than having to use the full ZAS format.
