### PR TITLE
Support more types in SqliteBack. Improved SqliteBackTests.

### DIFF
--- a/src/query_backend.h
+++ b/src/query_backend.h
@@ -473,10 +473,22 @@ class Sha1 {
       hash_.process_bytes(&(*it), sizeof(int));
   };
 
+  inline void Update(const std::set<std::string>& x) { 
+    std::set<std::string>::iterator it = x.begin();
+    for(; it != x.end(); ++it)
+      hash_.process_bytes(it->c_str(), it->size());
+  };
+
   inline void Update(const std::list<int>& x) { 
     std::list<int>::const_iterator it = x.begin();
     for(; it != x.end(); ++it)
       hash_.process_bytes(&(*it), sizeof(int));
+  };
+
+  inline void Update(const std::list<std::string>& x) { 
+    std::list<std::string>::const_iterator it = x.begin();
+    for(; it != x.end(); ++it)
+      hash_.process_bytes(it->c_str(), it->size());
   };
 
   inline void Update(const std::pair<int, int>& x) { 
@@ -489,6 +501,46 @@ class Sha1 {
     for (; it != x.end(); ++it) {
       hash_.process_bytes(&(it->first), sizeof(int));
       hash_.process_bytes(&(it->second), sizeof(int));
+    }
+  };
+
+  inline void Update(const std::map<int, double>& x) {
+    std::map<int, double>::const_iterator it = x.begin();
+    for (; it != x.end(); ++it) {
+      hash_.process_bytes(&(it->first), sizeof(int));
+      hash_.process_bytes(&(it->second), sizeof(double));
+    }
+  };
+
+  inline void Update(const std::map<int, std::string>& x) {
+    std::map<int, std::string>::const_iterator it = x.begin();
+    for (; it != x.end(); ++it) {
+      hash_.process_bytes(&(it->first), sizeof(int));
+      hash_.process_bytes(it->second.c_str(), it->second.size());
+    }
+  };
+
+  inline void Update(const std::map<std::string, int>& x) {
+    std::map<std::string, int>::const_iterator it = x.begin();
+    for (; it != x.end(); ++it) {
+      hash_.process_bytes(it->first.c_str(), it->first.size());
+      hash_.process_bytes(&(it->second), sizeof(int));
+    }
+  };
+
+  inline void Update(const std::map<std::string, double>& x) {
+    std::map<std::string, double>::const_iterator it = x.begin();
+    for (; it != x.end(); ++it) {
+      hash_.process_bytes(it->first.c_str(), it->first.size());
+      hash_.process_bytes(&(it->second), sizeof(double));
+    }
+  };
+
+  inline void Update(const std::map<std::string, std::string>& x) {
+    std::map<std::string, std::string>::const_iterator it = x.begin();
+    for (; it != x.end(); ++it) {
+      hash_.process_bytes(it->first.c_str(), it->first.size());
+      hash_.process_bytes(it->second.c_str(), it->second.size());
     }
   };
   /// \}

--- a/src/sqlite_back.h
+++ b/src/sqlite_back.h
@@ -79,6 +79,30 @@ class SqliteBack: public FullBackend {
   SqlStatement::Ptr vect_str_get_;
   std::set<Digest> vect_str_keys_;
 
+  SqlStatement::Ptr map_int_double_ins_;
+  SqlStatement::Ptr map_int_double_get_;
+  std::set<Digest> map_int_double_keys_;
+
+  SqlStatement::Ptr map_int_int_ins_;
+  SqlStatement::Ptr map_int_int_get_;
+  std::set<Digest> map_int_int_keys_;
+
+  SqlStatement::Ptr map_int_str_ins_;
+  SqlStatement::Ptr map_int_str_get_;
+  std::set<Digest> map_int_str_keys_;
+
+  SqlStatement::Ptr map_str_int_ins_;
+  SqlStatement::Ptr map_str_int_get_;
+  std::set<Digest> map_str_int_keys_;
+
+  SqlStatement::Ptr map_str_double_ins_;
+  SqlStatement::Ptr map_str_double_get_;
+  std::set<Digest> map_str_double_keys_;
+
+  SqlStatement::Ptr map_str_str_ins_;
+  SqlStatement::Ptr map_str_str_get_;
+  std::set<Digest> map_str_str_keys_;
+
   /// A class to help with hashing variable length datatypes
   Sha1 hasher_;
 };

--- a/tests/sqlite_back_tests.cc
+++ b/tests/sqlite_back_tests.cc
@@ -9,14 +9,246 @@
 
 static std::string const path = "testdb.sqlite";
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST(SqliteBackTest, Regression) {
-  using cyclus::Recorder;
-  FileDeleter fd(path);
-  Recorder m;
-  cyclus::SqliteBack back(path);
-  m.RegisterBackend(&back);
+class SqliteBackTests : public ::testing::Test {
+ public:
+  virtual void SetUp() {
+    remove(path.c_str());
+    b = new cyclus::SqliteBack(path);
+    r.RegisterBackend(b);
+  }
 
+  virtual void TearDown() {
+    r.Close();
+    delete b;
+    remove(path.c_str());
+  }
+  cyclus::SqliteBack* b;
+  cyclus::Recorder r;
+};
+
+TEST_F(SqliteBackTests, MapStrDouble) {
+  std::map<std::string, double> m;
+  m["one"] = 1.1;
+  m["two"] = 2.2;
+  m["three"] = 5.5;
+
+  r.NewDatum("monty")
+  ->AddVal("count", m)
+  ->Record();
+
+  r.Close();
+  cyclus::QueryResult qr = b->Query("monty", NULL);
+  m = qr.GetVal<std::map<std::string, double> >("count", 0);
+
+  EXPECT_EQ(1.1, m["one"]);
+  EXPECT_EQ(2.2, m["two"]);
+  EXPECT_EQ(5.5, m["three"]);
+}
+
+TEST_F(SqliteBackTests, MapStrInt) {
+  std::map<std::string, int> m;
+  m["one"] = 1;
+  m["two"] = 2;
+  m["three"] = 5;
+
+  r.NewDatum("monty")
+  ->AddVal("count", m)
+  ->Record();
+
+  r.Close();
+  cyclus::QueryResult qr = b->Query("monty", NULL);
+  m = qr.GetVal<std::map<std::string, int> >("count", 0);
+
+  EXPECT_EQ(1, m["one"]);
+  EXPECT_EQ(2, m["two"]);
+  EXPECT_EQ(5, m["three"]);
+}
+
+TEST_F(SqliteBackTests, MapStrStr) {
+  std::map<std::string, std::string> m;
+  m["one"] = "1";
+  m["two"] = "2";
+  m["three"] = "5";
+
+  r.NewDatum("monty")
+  ->AddVal("count", m)
+  ->Record();
+
+  r.Close();
+  cyclus::QueryResult qr = b->Query("monty", NULL);
+  m = qr.GetVal<std::map<std::string, std::string> >("count", 0);
+
+  EXPECT_EQ("1", m["one"]);
+  EXPECT_EQ("2", m["two"]);
+  EXPECT_EQ("5", m["three"]);
+}
+
+TEST_F(SqliteBackTests, MapIntDouble) {
+  std::map<int, double> m;
+  m[1] = 1.1;
+  m[2] = 2.2;
+  m[3] = 5.5;
+
+  r.NewDatum("monty")
+  ->AddVal("count", m)
+  ->Record();
+
+  r.Close();
+  cyclus::QueryResult qr = b->Query("monty", NULL);
+  m = qr.GetVal<std::map<int, double> >("count", 0);
+
+  EXPECT_EQ(1.1, m[1]);
+  EXPECT_EQ(2.2, m[2]);
+  EXPECT_EQ(5.5, m[3]);
+}
+
+TEST_F(SqliteBackTests, MapIntInt) {
+  std::map<int, int> m;
+  m[1] = 1;
+  m[2] = 2;
+  m[3] = 5;
+
+  r.NewDatum("monty")
+  ->AddVal("count", m)
+  ->Record();
+
+  r.Close();
+  cyclus::QueryResult qr = b->Query("monty", NULL);
+  m = qr.GetVal<std::map<int, int> >("count", 0);
+
+  EXPECT_EQ(1, m[1]);
+  EXPECT_EQ(2, m[2]);
+  EXPECT_EQ(5, m[3]);
+}
+
+TEST_F(SqliteBackTests, MapIntStr) {
+  std::map<int, std::string> m;
+  m[1] = "one";
+  m[2] = "two";
+  m[3] = "five";
+
+  r.NewDatum("monty")
+  ->AddVal("count", m)
+  ->Record();
+
+  r.Close();
+  cyclus::QueryResult qr = b->Query("monty", NULL);
+  m = qr.GetVal<std::map<int, std::string> >("count", 0);
+
+  EXPECT_EQ("one", m[1]);
+  EXPECT_EQ("two", m[2]);
+  EXPECT_EQ("five", m[3]);
+}
+
+TEST_F(SqliteBackTests, SetInt) {
+  std::set<int> s;
+  s.insert(4);
+  s.insert(2);
+
+  r.NewDatum("foo")
+  ->AddVal("bar", s)
+  ->Record();
+
+  r.Close();
+  cyclus::QueryResult qr = b->Query("foo", NULL);
+  s = qr.GetVal<std::set<int> >("bar", 0);
+
+  EXPECT_EQ(1, s.count(4));
+  EXPECT_EQ(1, s.count(2));
+}
+
+TEST_F(SqliteBackTests, SetString) {
+  std::set<std::string> s;
+  s.insert("four");
+  s.insert("two");
+
+  r.NewDatum("foo")
+  ->AddVal("bar", s)
+  ->Record();
+
+  r.Close();
+  cyclus::QueryResult qr = b->Query("foo", NULL);
+  s = qr.GetVal<std::set<std::string> >("bar", 0);
+
+  EXPECT_EQ(1, s.count("four"));
+  EXPECT_EQ(1, s.count("two"));
+}
+
+TEST_F(SqliteBackTests, ListInt) {
+  std::list<int> l;
+  l.push_back(4);
+  l.push_back(2);
+
+  r.NewDatum("foo")
+  ->AddVal("bar", l)
+  ->Record();
+
+  r.Close();
+  cyclus::QueryResult qr = b->Query("foo", NULL);
+  l = qr.GetVal<std::list<int> >("bar", 0);
+
+  ASSERT_EQ(2, l.size());
+  EXPECT_EQ(4, l.front());
+  EXPECT_EQ(2, l.back());
+}
+
+TEST_F(SqliteBackTests, ListString) {
+  std::vector<std::string> l;
+  l.push_back("four");
+  l.push_back("two");
+
+
+  r.NewDatum("foo")
+  ->AddVal("bar", l)
+  ->Record();
+
+  r.Close();
+  cyclus::QueryResult qr = b->Query("foo", NULL);
+  l = qr.GetVal<std::vector<std::string> >("bar", 0);
+
+  ASSERT_EQ(2, l.size());
+  EXPECT_EQ("four", l.front());
+  EXPECT_EQ("two", l.back());
+}
+
+TEST_F(SqliteBackTests, VectorInt) {
+  std::vector<int> vect;
+  vect.push_back(4);
+  vect.push_back(2);
+
+  r.NewDatum("foo")
+  ->AddVal("bar", vect)
+  ->Record();
+
+  r.Close();
+  cyclus::QueryResult qr = b->Query("foo", NULL);
+  vect = qr.GetVal<std::vector<int> >("bar", 0);
+
+  ASSERT_EQ(2, vect.size());
+  EXPECT_EQ(4, vect[0]);
+  EXPECT_EQ(2, vect[1]);
+}
+
+TEST_F(SqliteBackTests, VectorString) {
+  std::vector<std::string> vect;
+  vect.push_back("four");
+  vect.push_back("two");
+
+
+  r.NewDatum("foo")
+  ->AddVal("bar", vect)
+  ->Record();
+
+  r.Close();
+  cyclus::QueryResult qr = b->Query("foo", NULL);
+  vect = qr.GetVal<std::vector<std::string> >("bar", 0);
+
+  ASSERT_EQ(2, vect.size());
+  EXPECT_EQ("four", vect[0]);
+  EXPECT_EQ("two", vect[1]);
+}
+
+TEST_F(SqliteBackTests, AllTogether) {
   std::vector<int> vect;
   vect.push_back(4);
   vect.push_back(2);
@@ -24,7 +256,7 @@ TEST(SqliteBackTest, Regression) {
   svect.push_back("one");
   svect.push_back("two");
 
-  m.NewDatum("DumbTitle")
+  r.NewDatum("DumbTitle")
       ->AddVal("animal", std::string("monkey"))
       ->AddVal("weight", 10)
       ->AddVal("height", 5.5)
@@ -37,7 +269,7 @@ TEST(SqliteBackTest, Regression) {
   vect[1] = 3;
   svect[1] = "three";
 
-  m.NewDatum("DumbTitle")
+  r.NewDatum("DumbTitle")
       ->AddVal("animal", std::string("elephant"))
       ->AddVal("weight", 1000)
       ->AddVal("height", 4.2)
@@ -47,9 +279,9 @@ TEST(SqliteBackTest, Regression) {
       ->AddVal("data", cyclus::Blob("a very large mammal"))
       ->Record();
 
-  m.Close();
+  r.Close();
 
-  cyclus::QueryResult qr = back.Query("DumbTitle", NULL);
+  cyclus::QueryResult qr = b->Query("DumbTitle", NULL);
 
   std::string animal = qr.GetVal<std::string>("animal", 0);
   int weight = qr.GetVal<int>("weight", 0);


### PR DESCRIPTION
Added sqlite backend support for:
- `set<int>`
- `set<string>`
- `list<int>`
- `list<string>`
- `map<int,double>`
- `map<int,int>`
- `map<int,string>`
- `map<string,int>`
- `map<string,double>`
- `map<string,string>`
