### PR TITLE
Add optional schematype tag for schema autodetection

### DIFF
--- a/share/cyclus-flat.rng.in
+++ b/share/cyclus-flat.rng.in
@@ -2,6 +2,7 @@
 datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
 <start>
 <element name="simulation">
+  <optional><element name="schematype"><text/></element></optional>
 <interleave>
 
   <element name ="control">

--- a/share/cyclus.rng.in
+++ b/share/cyclus.rng.in
@@ -2,7 +2,9 @@
 datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
 <start>
 
-<element name="simulation"> <interleave>
+<element name="simulation">
+  <optional><element name="schematype"><text/></element></optional>
+<interleave>
   
   <element name ="control">
     <interleave>


### PR DESCRIPTION
- Add <schematype> tag. If set to "flat", the flat schema is used.
- fix bug where custom user-set schema was being ignored.
- clean up cli verbosity flag help msg
