### PR TITLE
fixed Material::Absorb to not mistake mass comps for atom comps

### DIFF
--- a/src/material.cc
+++ b/src/material.cc
@@ -99,7 +99,7 @@ void Material::Absorb(Material::Ptr mat) {
     compmath::Normalize(&v, qty_);
     CompMap otherv(mat->comp()->mass());
     compmath::Normalize(&otherv, mat->quantity());
-    comp_ = Composition::CreateFromAtom(compmath::Add(v, otherv));
+    comp_ = Composition::CreateFromMass(compmath::Add(v, otherv));
   }
   qty_ += mat->qty_;
   mat->qty_ = 0;


### PR DESCRIPTION
And wrote a test to prevent it happening again.  This is a small fix, with a big effect on simulation correctness :/
