### PR TITLE
ResourceBuff improvements and better error handling.

### DIFF
--- a/cli/cyclus.cc
+++ b/cli/cyclus.cc
@@ -195,7 +195,12 @@ int main(int argc, char* argv[]) {
     si.recorder()->RegisterBackend(fback);
   }
 
-  si.timer()->RunSim();
+  try {
+    si.timer()->RunSim();
+  } catch (cyclus::Error err) {
+    std::cerr << err.what() << "\n";
+    return 1;
+  }
 
   rec.Flush();
 

--- a/src/toolkit/resource_buff.h
+++ b/src/toolkit/resource_buff.h
@@ -79,15 +79,19 @@ class ResourceBuff {
   };
 
   /// PopQty pops the specified quantity of resources from the
-  /// store.
+  /// buffer.
   ///
   /// Resources are split if necessary in order to pop the exact quantity
   /// specified (within eps_rsrc()).  Resources are retrieved in the order they were
   /// pushed (i.e. oldest first).
   ///
-  /// @throws ValueError the specified pop quantity is larger (by
-  /// eps_rsrc()) than the store's current quantity.
+  /// @throws ValueError the specified pop quantity is larger than the
+  /// buffer's current quantity.
   Manifest PopQty(double qty);
+  
+  /// Same behavior as PopQty(double) except a non-zero eps may be specified
+  /// for cases where qty might be larger than the buffer's current quantity.
+  Manifest PopQty(double qty, double eps);
 
   /// PopN pops the specified number or count of resource objects from the
   /// store.


### PR DESCRIPTION
- added overloaded PopQty with eps arg to ResourceBuff
- ResourceBuff re-zeros qty_ member if all resources have been popped - to
  better deal with floating point issues.
- better error messages for ResourceBuff exceptions
- try-catch around RunSim to avoid core dumps when exceptions are thrown
