### PR TITLE
implements schema types for cycpp and trims strings for numeric types

### DIFF
--- a/agents/k_facility.h
+++ b/agents/k_facility.h
@@ -138,16 +138,19 @@ class KFacility : public cyclus::Facility {
  private:
   /// This facility has one output commodity and one input commodity
   #pragma cyclus var {"tooltip": "input commodity", \
-                      "doc": "commodity that the k-facility consumes"}
+                      "doc": "commodity that the k-facility consumes", \
+                      "schematype": "token"}
   std::string in_commod;
 
   #pragma cyclus var {"tooltip": "output commodity", \
-                      "doc": "commodity that the k-facility supplies"}
+                      "doc": "commodity that the k-facility supplies", \
+                      "schematype": "token"}
   std::string out_commod;
 
   /// Name of the recipe this facility uses.
   #pragma cyclus var {"shape": [50], "tooltip": "in-commodity recipe name", \
-                      "doc": "recipe name for the k-facility's in-commodity"}
+                      "doc": "recipe name for the k-facility's in-commodity", \
+                      "schematype": "token"}
   std::string recipe_name;
 
   /// The capacity is defined in terms of the number of units of the

--- a/agents/predator.h
+++ b/agents/predator.h
@@ -54,11 +54,13 @@ class Predator : public cyclus::Facility  {
   
  private:
   #pragma cyclus var {"tooltip": "predator commodity", \
-                      "doc": "commodity that the predator supplies"}
+                      "doc": "commodity that the predator supplies", \
+                      "schematype": "token"}
   std::string commod;
 
   #pragma cyclus var {"tooltip": "predator's prey", \
-                      "doc": "prey that the predator hunts"}
+                      "doc": "prey that the predator hunts", \
+                      "schematype": "token"}
   std::string prey;
 
   /// how many prey until we're full

--- a/agents/prey.h
+++ b/agents/prey.h
@@ -50,7 +50,7 @@ class Prey : public cyclus::Facility {
   void GiveBirth();
   
  private:
-  #pragma cyclus var {}
+  #pragma cyclus var {"schematype": "token"}
   std::string commod;
 
   /// number of timsteps between having children

--- a/agents/sink.h
+++ b/agents/sink.h
@@ -57,7 +57,8 @@ class Sink : public cyclus::Facility  {
  private:
   #pragma cyclus var {"doc": "commodities that the sink facility " \
                              "accepts", \
-                      "tooltip": "input commodities"}
+                      "tooltip": "input commodities", \
+                      "schematype": "token"}
   std::vector<std::string> in_commods;
 
   #pragma cyclus var {"doc": "capacity the sink facility can " \

--- a/agents/source.h
+++ b/agents/source.h
@@ -89,12 +89,14 @@ class Source : public cyclus::Facility {
  private:
   #pragma cyclus var {"doc": "commodity that the source facility " \
                              "supplies", \
-                      "tooltip": "source commodity"}
+                      "tooltip": "source commodity", \
+                      "schematype": "token"}
   std::string commod;
 
   #pragma cyclus var {"doc": "recipe name for source facility's " \
                              "commodity", \
-                      "tooltip": "commodity recipe name"}
+                      "tooltip": "commodity recipe name", \
+                      "schematype": "token"}
   std::string recipe_name;
 
   /**

--- a/src/infile_tree.h
+++ b/src/infile_tree.h
@@ -7,6 +7,7 @@
 #include <set>
 
 #include <libxml++/libxml++.h>
+#include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 
 #include "xml_parser.h"
@@ -81,9 +82,31 @@ template <typename T>
     inline T Query(InfileTree* tree, std::string query, int index = 0) {
   return boost::lexical_cast<T>(tree->GetString(query, index).c_str());
 }
+
 template <>
     inline std::string Query(InfileTree* tree, std::string query, int index) {
   return tree->GetString(query, index);
+}
+
+template <>
+    inline int Query(InfileTree* tree, std::string query, int index) {
+  std::string s = tree->GetString(query, index);
+  boost::trim(s);
+  return boost::lexical_cast<int>(s.c_str());
+}
+
+template <>
+    inline float Query(InfileTree* tree, std::string query, int index) {
+  std::string s = tree->GetString(query, index);
+  boost::trim(s);
+  return boost::lexical_cast<float>(s.c_str());
+}
+
+template <>
+    inline double Query(InfileTree* tree, std::string query, int index) {
+  std::string s = tree->GetString(query, index);
+  boost::trim(s);
+  return boost::lexical_cast<double>(s.c_str());
 }
 
 /// @brief a query method for optional parameters
@@ -96,11 +119,44 @@ template <typename T>
     inline T OptionalQuery(InfileTree* tree, std::string query, T default_val) {
   T val;
   tree->NMatches(query) == 1 ?
-      val = boost::lexical_cast<T>(tree->GetString(query).c_str()) :
-      val = default_val;
+    val = boost::lexical_cast<T>(tree->GetString(query).c_str()) :
+    val = default_val;
   return val;
 }
   
+template <>
+    inline int OptionalQuery(InfileTree* tree, std::string query, int default_val) {
+  int val = default_val;
+  if (tree->NMatches(query) == 1) {
+    std::string s = tree->GetString(query);
+    boost::trim(s);
+    val = boost::lexical_cast<int>(s.c_str());
+  }
+  return val;
+}
+  
+template <>
+    inline float OptionalQuery(InfileTree* tree, std::string query, float default_val) {
+  float val = default_val;
+  if (tree->NMatches(query) == 1) {
+    std::string s = tree->GetString(query);
+    boost::trim(s);
+    val = boost::lexical_cast<float>(s.c_str());
+  }
+  return val;
+}
+
+template <>
+    inline double OptionalQuery(InfileTree* tree, std::string query, double default_val) {
+  double val = default_val;
+  if (tree->NMatches(query) == 1) {
+    std::string s = tree->GetString(query);
+    boost::trim(s);
+    val = boost::lexical_cast<double>(s.c_str());
+  }
+  return val;
+}
+
 }  // namespace cyclus
 
 #endif  // CYCLUS_SRC_INFILE_TREE_H_

--- a/tests/infile_tree_tests.cc
+++ b/tests/infile_tree_tests.cc
@@ -135,7 +135,7 @@ TEST_F(InfileTreeTest, optional_queries) {
   string str_other = "some_str";
   string str_str = "string";
   ss << "<root>"
-     << "<" << dbl_str << ">" << dbl_val << "</" << dbl_str << ">"
+     << "<" << dbl_str << "> " << dbl_val << " </" << dbl_str << ">"
      << "<" << int_str << ">" << int_val << "</" << int_str << ">"
      << "<" << str_str << ">" << str_val << "</" << str_str << ">"
      << "</root>";

--- a/tests/input/source_to_sink.xml
+++ b/tests/input/source_to_sink.xml
@@ -32,7 +32,7 @@
         <in_commods>
           <val>commodity</val>
         </in_commods>
-        <capacity>1.00</capacity>
+        <capacity>   1.00 </capacity>
       </Sink>
     </config>
   </facility>


### PR DESCRIPTION
This fixes #946 and the related issues that came up on the [mailing list](https://groups.google.com/d/topic/cyclus-dev/PK49ORa50yE/discussion).
