### PR TITLE
Inst tock test tested the tick. Now the tock test tests the tock.

### DIFF
--- a/stubs/stub_inst_tests.cc
+++ b/stubs/stub_inst_tests.cc
@@ -48,7 +48,7 @@ TEST_F(StubInstTest, Tick) {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(StubInstTest, Tock) {
   int time = 1;
-  EXPECT_NO_THROW(src_inst_->Tick());
+  EXPECT_NO_THROW(src_inst_->Tock());
   // Test StubInst specific behaviors of the handleTock function here
 }
 


### PR DESCRIPTION
That is, the Tock test should test the Tock.
