### PR TITLE
fix for make_pair() on C++11

### DIFF
--- a/src/decayer.cc
+++ b/src/decayer.cc
@@ -65,8 +65,7 @@ void Decayer::AddNucToMaps(int nuc) {
   for (d = daughters.begin(); d != daughters.end(); ++d) {
     daughter = *d;
     AddNucToMaps(daughter);
-    dvec[i] = std::make_pair<int, double>(daughter,
-                                          pyne::branch_ratio(nuc, daughter));
+    dvec[i] = std::make_pair(daughter, pyne::branch_ratio(nuc, daughter));
     i++;
   }
   daughters_[col] = dvec;


### PR DESCRIPTION
Seems to work on earlier versions of C++ as well. Also I think that this is going to be #1000!
