### PR TITLE
Fix for cyclus -a for Brightlite et al.

### DIFF
--- a/src/discovery.cc
+++ b/src/discovery.cc
@@ -33,10 +33,7 @@ std::set<std::string> DiscoverSpecs(std::string p, std::string lib) {
   namespace fs = boost::filesystem;
   // find file
   string libpath = (fs::path(p) / fs::path("lib" + lib + SUFFIX)).string();
-  std::cout << "BEFORE: " << libpath << "\n";
   libpath = Env::FindModule(libpath);
-  std::cout << "AFTER: " << libpath << "\n";
-  std::cout << "\n";
 
   // read in file, pre-allocates space
   std::ifstream f (libpath.c_str());

--- a/src/unix_helper_functions.h
+++ b/src/unix_helper_functions.h
@@ -11,10 +11,8 @@ namespace cyclus {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void DynamicModule::OpenLibrary() {
-  std::cout << "LOADING: " << path_ << "\n";
-  //module_library_ = dlopen(path_.c_str(), RTLD_LAZY);
+  // Do not change this to RTLD_LAZY, because it randomly breaks modules discovery!
   module_library_ = dlopen(path_.c_str(), RTLD_NOW);
-  std::cout << "LOADED: " << path_ << "\n\n";
 
   if (!module_library_) {
     std::string err_msg = "Unable to load agent shared object file: ";


### PR DESCRIPTION
As you may recall, `cyclus -a` was failing for @FlanFlangan in any directory other than the Brightlite source directory. It returned the following rather unhelpful error message:

---

robert@merlin:~/lesstest$ cyclus -a
Inconsistency detected by ld.so: dl-lookup.c: 377: do_lookup_x: Assertion `!(({ __typeof (({ struct pthread *__self; asm ("mov %%fs:%c1,%0" : "=r" (__self) : "i" (__builtin_offsetof (struct pthread, header.self))); __self;})->header.rtld_must_xmm_save) __value; if (sizeof (__value) == 1) asm volatile ("movb %%fs:%P2,%b0" : "=q" (__value) : "0" (0), "i" (__builtin_offsetof (struct pthread, header.rtld_must_xmm_save))); else if (sizeof (__value) == 4) asm volatile ("movl %%fs:%P1,%0" : "=r" (__value) : "i" (__builtin_offsetof (struct pthread, header.rtld_must_xmm_save))); else { if (sizeof (__value) != 8) abort (); asm volatile ("movq %%fs:%P1,%q0" : "=r" (__value) : "i" (__builtin_offsetof (struct pthread, header.rtld_must_xmm_save))); } __value; }) != 0)' failed!

---

Oddly, Cem also experiences this error, though I could not reproduce it on my own machine, even though we are all on Ubuntu 14.04.  Though this was clearly a dynamic loading issue, it _is not_ related to any `*_PATH` settings since the file paths were absolute.  After an hour with Robert's machine, I still had no idea.

Then, reading [the documentation for dlopen()](http://tldp.org/HOWTO/Program-Library-HOWTO/dl-libraries.html), I found this interesting tidbit:

```
While you're debugging, you'll probably want to use RTLD_NOW; using RTLD_LAZY can create
inscrutable errors if there are unresolved references. Using RTLD_NOW makes opening the 
library take slightly longer (but it speeds up lookups later); if this causes a user interface 
problem you can switch to RTLD_LAZY later.
```

The above definitely seems like an 'inscrutable error'.  Switching from `RTLD_LAZY` to `RTLD_NOW` fixes the problem on Robert's machine and works on mine as well.  Any extra runtime effects seem negligible. Also, I would argue that archetype development is a debugging process, and so the cyclus kernel is right to 
use NOW.  Unfortunately, this is basically impossible to test as it has proven elusive to even externally reproduce.

This needs to go in very very soon.
