### PR TITLE
make tests use in-memory sqlite db to run faster

### DIFF
--- a/tests/sim_init_tests.cc
+++ b/tests/sim_init_tests.cc
@@ -10,7 +10,8 @@
 #include "timer.h"
 #include "toolkit/resource_buff.h"
 
-static const char* dbpath = "testsiminit.sqlite";
+// special name to tell sqlite to use in-mem db
+static const char* dbpath = ":memory:";
 
 namespace cy = cyclus;
 using cy::Agent;
@@ -89,7 +90,6 @@ class SimInitTest : public ::testing::Test {
 
  protected:
   virtual void SetUp() {
-    remove(dbpath);
     resetnextids();
     cy::DynamicModule::man_ctors_[":Inver:Inver"] = ConstructInver;
 
@@ -139,7 +139,6 @@ class SimInitTest : public ::testing::Test {
     rec.Close();
     delete ctx;
     delete b;
-    remove(dbpath);
   }
 
   void resetnextids() {

--- a/tests/sqlite_back_tests.cc
+++ b/tests/sqlite_back_tests.cc
@@ -7,12 +7,12 @@
 
 #include "tools.h"
 
-static std::string const path = "testdb.sqlite";
+// special name to tell sqlite to use in-mem db
+static std::string const path = ":memory:";
 
 class SqliteBackTests : public ::testing::Test {
  public:
   virtual void SetUp() {
-    remove(path.c_str());
     b = new cyclus::SqliteBack(path);
     r.RegisterBackend(b);
   }
@@ -20,7 +20,6 @@ class SqliteBackTests : public ::testing::Test {
   virtual void TearDown() {
     r.Close();
     delete b;
-    remove(path.c_str());
   }
   cyclus::SqliteBack* b;
   cyclus::Recorder r;

--- a/tests/sqlite_db_tests.cc
+++ b/tests/sqlite_db_tests.cc
@@ -9,7 +9,7 @@
 class SqliteDbTests : public ::testing::Test {
  public:
   virtual void SetUp() {
-    path = "testdb.sqlite";
+    path = ":memory:"; // special name to tell sqlite to use in-mem db
     v1 = "stuff";
     v2 = "thing";
     db = new cyclus::SqliteDb(path);
@@ -22,7 +22,6 @@ class SqliteDbTests : public ::testing::Test {
   virtual void TearDown() {
     db->close();
     delete db;
-    remove(path.c_str());
   }
 
   cyclus::SqliteDb* db;

--- a/tests/timer_tests.cc
+++ b/tests/timer_tests.cc
@@ -10,7 +10,8 @@
 
 #include "tools.h"
 
-static std::string const path = "testdb.sqlite";
+// special name to tell sqlite to use in-mem db
+static std::string const path = ":memory:";
 
 class Dier : public cyclus::Facility {
  public:
@@ -63,8 +64,6 @@ TEST(TimerTests, BareSim) {
 }
 
 TEST(TimerTests, EarlyTermination) {
-  FileDeleter fd(path);
-
   cyclus::Recorder rec;
   cyclus::Timer ti;
   cyclus::Context ctx(&ti, &rec);
@@ -88,8 +87,6 @@ TEST(TimerTests, EarlyTermination) {
 }
 
 TEST(TimerTests, DefaultSnapshot) {
-  FileDeleter fd(path);
-
   cyclus::Recorder rec;
   cyclus::Timer ti;
   cyclus::Context ctx(&ti, &rec);
@@ -110,8 +107,6 @@ TEST(TimerTests, DefaultSnapshot) {
 }
 
 TEST(TimerTests, CustomSnapshot) {
-  FileDeleter fd(path);
-
   cyclus::Recorder rec;
   cyclus::Timer ti;
   cyclus::Context ctx(&ti, &rec);


### PR DESCRIPTION
`cyclus_unit_tests` previously took 60 sec.  Now takes 8 sec.
