### PR TITLE
fixed prev_decay_time tracking bug. better comments.

### DIFF
--- a/src/material.h
+++ b/src/material.h
@@ -128,11 +128,20 @@ class Material: public Resource {
   /// a reactor.
   void Transmute(Composition::Ptr c);
 
-  /// A special case of Transmute where the new composition is calculated by
-  /// performing a decay calculation on the material's composition.  The time
-  /// delta is calculated as the difference between curr_time and the last time
-  /// Decay was invoked.
+  /// Updates the material's composition by performing a decay calculation.
+  /// This is a special case of Transmute where the new composition is
+  /// calculated automatically.  The time delta is calculated as the difference
+  /// between curr_time and the last time the material's composition was
+  /// updated with a decay calculation (i.e. prev_decay_time).  This may or may
+  /// not result in an updated material composition.  Does nothing if the
+  /// simulation decay mode is set to "never" or none of the nuclides' decay
+  /// constants are significant with respect to the time delta.
   void Decay(int curr_time);
+
+  /// Returns the last time step on which a decay calculation was performed
+  /// for the material.  This is not necessarily synonymous with the last time
+  /// step the material's Decay function was called.
+  int prev_decay_time() { return prev_decay_time_; }
 
   /// Returns the nuclide composition of this material.
   Composition::Ptr comp() const;

--- a/tests/material_tests.cc
+++ b/tests/material_tests.cc
@@ -10,14 +10,12 @@
 
 namespace cyclus {
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(MaterialTest, Constructors) {
   EXPECT_EQ(default_mat_->units(), "kg");
   EXPECT_EQ(default_mat_->type(), cyclus::Material::kType);
   EXPECT_GE(default_mat_->obj_id(), 0);
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(MaterialTest, Clone) {
   Resource::Ptr clone_mat;
   ASSERT_NO_THROW(clone_mat = test_mat_->Clone());
@@ -27,7 +25,6 @@ TEST_F(MaterialTest, Clone) {
   EXPECT_DOUBLE_EQ(test_mat_->quantity(), clone_mat->quantity());
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(MaterialTest, ExtractRes) {
   EXPECT_DOUBLE_EQ(test_size_, test_mat_->quantity());
   double other_size = test_size_ / 3;
@@ -37,7 +34,6 @@ TEST_F(MaterialTest, ExtractRes) {
   EXPECT_DOUBLE_EQ(other_size, other->quantity());
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(MaterialTest, SimpleAbsorb) {
   double val = 1.5 * units::kg;
   Material::Ptr m1 = Material::CreateUntracked(val, test_comp_);
@@ -52,7 +48,6 @@ TEST_F(MaterialTest, SimpleAbsorb) {
   /// EXPECT_EQ(m2->quantity(), 2 * val);
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(MaterialTest, AbsorbLikeMaterial) {
   Material::Ptr mat1;
   Material::Ptr mat2;
@@ -79,7 +74,6 @@ TEST_F(MaterialTest, AbsorbLikeMaterial) {
   EXPECT_DOUBLE_EQ(test_mat_->quantity(), factor * orig);
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(MaterialTest, AbsorbUnLikeMaterial) {
   // make a number of materials masses 1, 2, and 10
   Material::Ptr same_as_orig_test_mat = Material::CreateUntracked(0,
@@ -125,21 +119,18 @@ TEST_F(MaterialTest, AbsorbUnLikeMaterial) {
   EXPECT_DOUBLE_EQ(orig + origdiff, default_mat_->quantity());
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(MaterialTest, AbsorbZeroMaterial) {
   Material::Ptr same_as_test_mat = Material::CreateUntracked(0, test_comp_);
   EXPECT_NO_THROW(test_mat_->Absorb(same_as_test_mat));
   EXPECT_FLOAT_EQ(test_size_, test_mat_->quantity());
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(MaterialTest, AbsorbIntoZeroMaterial) {
   Material::Ptr same_as_test_mat = Material::CreateUntracked(0, test_comp_);
   EXPECT_NO_THROW(same_as_test_mat->Absorb(test_mat_));
   EXPECT_FLOAT_EQ(test_size_, same_as_test_mat->quantity());
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(MaterialTest, ExtractMass) {
   double amt = test_size_ / 3;
   double diff = test_size_ - amt;
@@ -153,7 +144,6 @@ TEST_F(MaterialTest, ExtractMass) {
                Error);
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(MaterialTest, ExtractComplete) {
   Material::Ptr m1;
   EXPECT_NO_THROW(m1 = test_mat_->ExtractComp(test_size_, test_comp_));
@@ -162,7 +152,6 @@ TEST_F(MaterialTest, ExtractComplete) {
   EXPECT_DOUBLE_EQ(test_size_, m1->quantity());
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(MaterialTest, ExtractOverQty) {
   EXPECT_THROW(diff_mat_->ExtractComp(2 * test_size_, test_comp_),
                ValueError);
@@ -170,7 +159,6 @@ TEST_F(MaterialTest, ExtractOverQty) {
                ValueError);
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(MaterialTest, ExtractOverComp) {
   Material::Ptr m;
 
@@ -182,13 +170,11 @@ TEST_F(MaterialTest, ExtractOverComp) {
                ValueError);
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(MaterialTest, ExtractHalf) {
   Material::Ptr m1 = two_test_mat_->ExtractComp(test_size_, test_comp_);
   EXPECT_DOUBLE_EQ(test_size_, m1->quantity());
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(MaterialTest, AbsorbThenExtract) {
   Composition::Ptr comp_to_rem = Composition::Ptr(test_comp_);
   double kg_to_rem = 0.25 * test_size_;
@@ -204,7 +190,6 @@ TEST_F(MaterialTest, AbsorbThenExtract) {
   EXPECT_DOUBLE_EQ(test_size_ - kg_to_rem, default_mat_->quantity());
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(MaterialTest, ExtractInGrams) {
   Composition::Ptr comp_to_rem = Composition::Ptr(test_comp_);
   double kg_to_rem = 0.25 * test_size_;
@@ -221,7 +206,6 @@ TEST_F(MaterialTest, ExtractInGrams) {
   EXPECT_DOUBLE_EQ(test_size_ - kg_to_rem, default_mat_->quantity());
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(MaterialTest, DecayManual) {
   // prequeries
   cyclus::toolkit::MatQuery orig(tracked_mat_);
@@ -244,9 +228,7 @@ TEST_F(MaterialTest, DecayManual) {
   EXPECT_NE(am241_qty, mq.mass(am241_));
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(MaterialTest, DecayNever) {
-
   // prequeries
   cyclus::toolkit::MatQuery orig(tracked_mat_no_decay_);
   double u235_qty = orig.mass(u235_);
@@ -268,7 +250,6 @@ TEST_F(MaterialTest, DecayNever) {
   EXPECT_DOUBLE_EQ(orig_mass, tracked_mat_no_decay_->quantity());
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(MaterialTest, DecayShortcut) {
   CompMap mp;
   mp[922350000] = 1;
@@ -280,6 +261,39 @@ TEST_F(MaterialTest, DecayShortcut) {
   double threshold = -1 * std::log(1-eps) / u235_decay_const;
   m->Decay(threshold * 0.9);
   EXPECT_EQ(c, m->comp());
+}
+
+TEST_F(MaterialTest, ExtractPrevDecay) {
+  tracked_mat_->Decay(10);
+  double qty = tracked_mat_->quantity() / 2;
+  cyclus::Material::Ptr x = tracked_mat_->ExtractQty(qty);
+
+  EXPECT_EQ(tracked_mat_->prev_decay_time(), x->prev_decay_time());
+}
+
+TEST_F(MaterialTest, AbsorbPrevDecay) {
+  // The behavior this test checks for is subject to change and is not part of
+  // the Cyclus API.  It is testing "undefined" implementation detail behavior
+  // as coded.  We may decide to change the behavior in the future breaking
+  // this test; the test will need to be modified accordingly.
+  //
+  // This test checks to see that, when materials are absorbed together, the
+  // previous decay time for the larger quantity material is used as the value
+  // for the new, combined material.
+
+  Material::Ptr m1 = Material::Create(fac, 1, diff_comp_);
+  Material::Ptr m2 = Material::Create(fac, 1, diff_comp_);
+  Material::Ptr m3 = Material::Create(fac, 1000, diff_comp_);
+  m3->Decay(10);
+
+  EXPECT_EQ(0, m1->prev_decay_time());
+  EXPECT_EQ(0, m2->prev_decay_time());
+  EXPECT_EQ(10, m3->prev_decay_time());
+
+  m1->Absorb(m3);
+  EXPECT_EQ(10, m1->prev_decay_time());
+  m1->Absorb(m2);
+  EXPECT_EQ(10, m1->prev_decay_time());
 }
 
 }  // namespace cyclus


### PR DESCRIPTION
- extracted materials now inherit prev_decay_time properly from originating
  material.  Test for this was added.
- when being absorbed, use prev_decay_time of the material with the larger
  quantity.
- added prev_decay_time public accessor to facilitate testing and other
  potential uses by archetypes.
