### PR TITLE
lazy decay option and misc cleanups and tweaks

### DIFF
--- a/src/material.h
+++ b/src/material.h
@@ -144,7 +144,7 @@ class Material: public Resource {
   int prev_decay_time() { return prev_decay_time_; }
 
   /// Returns the nuclide composition of this material.
-  Composition::Ptr comp() const;
+  Composition::Ptr comp();
 
  protected:
   Material(Context* ctx, double quantity, Composition::Ptr c);

--- a/tests/sim_init_tests.cc
+++ b/tests/sim_init_tests.cc
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include "comp_math.h"
 #include "composition.h"
 #include "context.h"
 #include "facility.h"
@@ -224,12 +225,14 @@ TEST_F(SimInitTest, InitRecipes) {
   cy::Context* init_ctx = si.context();
 
   cy::CompMap orig1 = ctx->GetRecipe("recipe1")->mass();
+  cy::compmath::Normalize(&orig1);
   cy::CompMap init1 = init_ctx->GetRecipe("recipe1")->mass();
   EXPECT_EQ(ctx->GetRecipe("recipe1")->id(), init_ctx->GetRecipe("recipe1")->id());
   EXPECT_FLOAT_EQ(orig1[922350000], init1[922350000]);
   EXPECT_FLOAT_EQ(orig1[922380000], init1[922380000]);
 
   cy::CompMap orig2 = ctx->GetRecipe("recipe1")->mass();
+  cy::compmath::Normalize(&orig2);
   cy::CompMap init2 = init_ctx->GetRecipe("recipe1")->mass();
   EXPECT_EQ(ctx->GetRecipe("recipe2")->id(), init_ctx->GetRecipe("recipe2")->id());
   EXPECT_FLOAT_EQ(orig2[922350000], init2[922350000]);


### PR DESCRIPTION
* lazy decay option decays materials every time the Material::comp function is
  called.

* Added ability to call Material::Decay with a negative time argument that
  causes the decay operation to run with the material's context's current
  time.  Throws if the material has a NULL context.

* fixed sim_init tests - they previously counted on optional normalization for
  material compositions that has now changed.  Note that API is identical -
  the doc comments for the relevant functions explicitly states that returned
  composition are not normalized.