### PR TITLE
uncomment LoadTableTypes() in HDF5 backend

### DIFF
--- a/src/hdf5_back.cc
+++ b/src/hdf5_back.cc
@@ -904,7 +904,7 @@ QueryResult Hdf5Back::GetTableInfo(std::string title, hid_t dset, hid_t dt) {
   hsize_t ncols = H5Tget_nmembers(dt);
   std::string fieldname;
   std::string fieldtype;
-  //LoadTableTypes(title, dset, ncols);
+  LoadTableTypes(title, dset, ncols);
   DbTypes* dbtypes = schemas_[title];
 
   QueryResult qr;


### PR DESCRIPTION
I have no idea why this was commented out, probably from back when restart didn't have any tests. But it shouldn't be and was causing issues with querying from cymetric.
