### PR TITLE
empty blob constructor

### DIFF
--- a/src/blob.h
+++ b/src/blob.h
@@ -8,6 +8,8 @@ namespace cyclus {
 /// output database.
 class Blob {
  public:
+  Blob() : str_("") {}
+
   explicit Blob(std::string s) : str_(s) {}
 
   const std::string& str() const {

--- a/tests/query_backend_tests.cc
+++ b/tests/query_backend_tests.cc
@@ -15,6 +15,12 @@ inline bool NotCmpConds(T* x, std::vector<cyclus::Cond*>* cond) {
   return !cyclus::CmpConds<T>(x, cond);
 }
 
+TEST(QueryBackendTest, EmptyBlob) {
+  using cyclus::Blob;
+  Blob x = Blob();
+  EXPECT_EQ(0, x.str().size());
+}
+
 TEST(QueryBackendTest, CmpCondOps) {
   using cyclus::Cond;
   using cyclus::CmpCond;


### PR DESCRIPTION
This adds an empty blob constructor that is needed for Cython, which declares types without defining them.
