### PR TITLE
Raw Recorder

### DIFF
--- a/src/datum.h
+++ b/src/datum.h
@@ -14,6 +14,7 @@ namespace cyclus {
 /// Recorder for recording.
 class Datum {
   friend class Recorder;
+  friend class RawRecorder;
 
  public:
   typedef std::pair<const char*, boost::spirit::hold_any> Entry;

--- a/src/datum.h
+++ b/src/datum.h
@@ -36,6 +36,7 @@ class Datum {
   /// shape for this field. This is only useful for variable length data types
   /// such as string and blob. If a shape is provided, this field and value
   /// is interpreted as having a fixed length (of the value given). If the
+
   /// pointer is NULL or the entry is less than one (<1), the field is interpreted
   /// as inherently variable length, which may affect persistance. This is a
   /// vector of ints (a shape) rather than an int (a length) to accomodate

--- a/src/datum.h
+++ b/src/datum.h
@@ -14,7 +14,6 @@ namespace cyclus {
 /// Recorder for recording.
 class Datum {
   friend class Recorder;
-  friend class RawRecorder;
 
  public:
   typedef std::pair<const char*, boost::spirit::hold_any> Entry;

--- a/src/hdf5_back.h
+++ b/src/hdf5_back.h
@@ -89,6 +89,8 @@ class Hdf5Back : public FullBackend {
 
   virtual QueryResult Query(std::string table, std::vector<Cond>* conds);
 
+  virtual std::map<std::string, DbTypes> ColumnTypes(std::string table);
+
  private:
   /// Creates a QueryResult from a table description.
   QueryResult GetTableInfo(std::string title, hid_t dset, hid_t dt);

--- a/src/query_backend.h
+++ b/src/query_backend.h
@@ -275,6 +275,10 @@ class QueryableBackend {
   /// Return a set of rows from the specificed table that match all given
   /// conditions.  Conditions are AND'd together.  conds may be NULL.
   virtual QueryResult Query(std::string table, std::vector<Cond>* conds) = 0;
+
+  /// Return a map of column names of the specified table to the associated 
+  /// database type.
+  virtual std::map<std::string, DbTypes> ColumnTypes(std::string table) = 0;
 };
 
 /// Interface implemented by backends that support recording and querying.
@@ -303,6 +307,10 @@ class CondInjector: public QueryableBackend {
     return b_->Query(table, &c);
   }
 
+  virtual std::map<std::string, DbTypes> ColumnTypes(std::string table) {
+    return b_->ColumnTypes(table);
+  }
+
  private:
   QueryableBackend* b_;
   std::vector<Cond> to_inject_;
@@ -320,6 +328,10 @@ class PrefixInjector: public QueryableBackend {
 
   virtual QueryResult Query(std::string table, std::vector<Cond>* conds) {
     return b_->Query(prefix_ + table, conds);
+  }
+
+  virtual std::map<std::string, DbTypes> ColumnTypes(std::string table) {
+    return b_->ColumnTypes(table);
   }
 
  private:

--- a/src/recorder.cc
+++ b/src/recorder.cc
@@ -10,17 +10,23 @@
 
 namespace cyclus {
 
-Recorder::Recorder() : index_(0) {
+Recorder::Recorder() : index_(0), inject_sim_id_(true) {
   uuid_ = boost::uuids::random_generator()();
   set_dump_count(kDefaultDumpCount);
 }
 
-Recorder::Recorder(unsigned int dump_count) : index_(0) {
+Recorder::Recorder(bool inject_sim_id) : index_(0), inject_sim_id_(inject_sim_id) {
+  uuid_ = boost::uuids::random_generator()();
+  set_dump_count(kDefaultDumpCount);
+}
+
+Recorder::Recorder(unsigned int dump_count) : index_(0), inject_sim_id_(true) {
   uuid_ = boost::uuids::random_generator()();
   set_dump_count(dump_count);
 }
 
-Recorder::Recorder(boost::uuids::uuid simid) : index_(0), uuid_(simid) {
+Recorder::Recorder(boost::uuids::uuid simid) : index_(0), uuid_(simid), \
+                                               inject_sim_id_(true) {
   set_dump_count(kDefaultDumpCount);
 }
 
@@ -52,7 +58,9 @@ void Recorder::set_dump_count(unsigned int count) {
   data_.reserve(count);
   for (int i = 0; i < count; ++i) {
     Datum* d = new Datum(this, "");
-    d->AddVal("SimId", uuid_);
+    if (inject_sim_id_) {
+      d->AddVal("SimId", uuid_);
+    }
     data_.push_back(d);
   }
   dump_count_ = count;
@@ -61,8 +69,13 @@ void Recorder::set_dump_count(unsigned int count) {
 Datum* Recorder::NewDatum(std::string title) {
   Datum* d = data_[index_];
   d->title_ = title;
-  d->vals_.resize(1);
-  d->shapes_.resize(1);
+  if (inject_sim_id_) {
+    d->vals_.resize(1);
+    d->shapes_.resize(1);
+  } else {
+    d->vals_.resize(0);
+    d->shapes_.resize(0);
+  }
 
   index_++;
   return d;
@@ -102,39 +115,6 @@ void Recorder::RegisterBackend(RecBackend* b) {
 void Recorder::Close() {
   Flush();
   backs_.clear();
-}
-
-//
-// Raw Recorder
-//
-
-RawRecorder::RawRecorder() {
-  index_ = 0;
-  uuid_ = boost::uuids::nil_uuid();
-  set_dump_count(kDefaultDumpCount);
-}
-
-void RawRecorder::set_dump_count(unsigned int count) {
-  for (int i = 0; i < data_.size(); ++i) {
-    delete data_[i];
-  }
-  data_.clear();
-  data_.reserve(count);
-  for (int i = 0; i < count; ++i) {
-    Datum* d = new Datum(this, "");
-    data_.push_back(d);
-  }
-  dump_count_ = count;
-}
-
-Datum* RawRecorder::NewDatum(std::string title) {
-  Datum* d = data_[index_];
-  d->title_ = title;
-  d->vals_.resize(0);
-  d->shapes_.resize(0);
-
-  index_++;
-  return d;
 }
 
 }  // namespace cyclus

--- a/src/recorder.cc
+++ b/src/recorder.cc
@@ -102,4 +102,37 @@ void Recorder::Close() {
   backs_.clear();
 }
 
+//
+// Raw Recorder
+//
+
+RawRecorder::RawRecorder() {
+  index_ = 0;
+  uuid_ = boost::uuids::nil_uuid();
+  set_dump_count(kDefaultDumpCount);
+}
+
+void RawRecorder::set_dump_count(unsigned int count) {
+  for (int i = 0; i < data_.size(); ++i) {
+    delete data_[i];
+  }
+  data_.clear();
+  data_.reserve(count);
+  for (int i = 0; i < count; ++i) {
+    Datum* d = new Datum(this, "");
+    data_.push_back(d);
+  }
+  dump_count_ = count;
+}
+
+Datum* RawRecorder::NewDatum(std::string title) {
+  Datum* d = data_[index_];
+  d->title_ = title;
+  d->vals_.resize(0);
+  d->shapes_.resize(0);
+
+  index_++;
+  return d;
+}
+
 }  // namespace cyclus

--- a/src/recorder.cc
+++ b/src/recorder.cc
@@ -75,6 +75,8 @@ void Recorder::AddDatum(Datum* d) {
 }
 
 void Recorder::Flush() {
+  if (index_ == 0)
+    return;
   DatumList tmp = data_;
   tmp.resize(index_);
   index_ = 0;

--- a/src/recorder.h
+++ b/src/recorder.h
@@ -83,8 +83,8 @@ class Recorder {
   bool inject_sim_id() { return inject_sim_id_; };
 
   /// sets whether or not the unique simulation id will be injected.
-  void set_inject_sim_id(bool x) { inject_sim_id_ = x; };
-
+  void inject_sim_id(bool x) { inject_sim_id_ = x; };
+ 
   /// Creates a new datum namespaced under the specified title.
   ///
   /// @warning choose title carefully to not conflict with Datum objects from other

--- a/src/recorder.h
+++ b/src/recorder.h
@@ -70,7 +70,7 @@ class Recorder {
   ///
   /// @param count # Datum objects to buffer before flushing to backends.
   /// @warning this deletes all buffered data from the recorder.
-  void set_dump_count(unsigned int count);
+  virtual void set_dump_count(unsigned int count);
 
   /// returns the unique id associated with this cyclus simulation.
   boost::uuids::uuid sim_id();
@@ -81,7 +81,7 @@ class Recorder {
   /// agents. Also note that a static title (e.g. an unchanging string) will
   /// result in multiple instances of this agent storing datum data together
   /// (e.g. the same table).
-  Datum* NewDatum(std::string title);
+  virtual Datum* NewDatum(std::string title);
 
   /// Registers b to receive Datum notifications for all Datum objects collected
   /// by the Recorder and to receive a flush notification when there
@@ -97,7 +97,7 @@ class Recorder {
   /// Unregisters all backends and resets.
   void Close();
 
- private:
+ protected:
   void NotifyBackends();
   void AddDatum(Datum* d);
 
@@ -106,6 +106,34 @@ class Recorder {
   std::list<RecBackend*> backs_;
   unsigned int dump_count_;
   boost::uuids::uuid uuid_;
+};
+
+/// Collects and manages output data bases. This is like the Recorded class
+/// except that the simulation id is not automatically injected into the Datum.
+/// The simulation id is always nil.
+class RawRecorder : Recorder {
+  friend class Datum;
+
+ public:
+  /// create a new raw recorder with default dump frequency and random
+  /// simulation id.
+  RawRecorder();
+
+  /// Set the Recorder to flush its collected Datum objects to registered
+  /// backends every [count] Datum objects. If count == 0 then Datum objects
+  /// will be flushed immediately as they come.
+  ///
+  /// @param count # Datum objects to buffer before flushing to backends.
+  /// @warning this deletes all buffered data from the recorder.
+  virtual void set_dump_count(unsigned int count);
+
+  /// Creates a new datum with the specified title.
+  ///
+  /// @warning choose title carefully to not conflict with Datum objects from other
+  /// agents. Also note that a static title (e.g. an unchanging string) will
+  /// result in multiple instances of this agent storing datum data together
+  /// (e.g. the same table).
+  virtual Datum* NewDatum(std::string title);
 };
 
 }  // namespace cyclus

--- a/src/recorder.h
+++ b/src/recorder.h
@@ -111,7 +111,7 @@ class Recorder {
 /// Collects and manages output data bases. This is like the Recorded class
 /// except that the simulation id is not automatically injected into the Datum.
 /// The simulation id is always nil.
-class RawRecorder : Recorder {
+class RawRecorder : public Recorder {
   friend class Datum;
 
  public:

--- a/src/recorder.h
+++ b/src/recorder.h
@@ -107,7 +107,7 @@ class Recorder {
   /// Unregisters all backends and resets.
   void Close();
 
- protected:
+ private:
   void NotifyBackends();
   void AddDatum(Datum* d);
 

--- a/src/recorder.h
+++ b/src/recorder.h
@@ -83,7 +83,14 @@ class Recorder {
   bool inject_sim_id() { return inject_sim_id_; };
 
   /// sets whether or not the unique simulation id will be injected.
-  void inject_sim_id(bool x) { inject_sim_id_ = x; };
+  void inject_sim_id(bool x) {
+    if (x == inject_sim_id_) {
+      return;
+    }
+    Flush();
+    inject_sim_id_ = x;
+    set_dump_count(dump_count_);
+  };
  
   /// Creates a new datum namespaced under the specified title.
   ///

--- a/src/recorder.h
+++ b/src/recorder.h
@@ -46,16 +46,20 @@ class Recorder {
   friend class Datum;
 
  public:
-  /// create a new recorder with default dump frequency and random
-  /// simulation id.
+  /// create a new recorder with default dump frequency, random
+  /// simulation id, and simulation id injection.
   Recorder();
+
+  /// create a new recorder with the given dump count, random
+  /// simulation id, and given flag for injecting the simulation id.
+  Recorder(bool inject_sim_id);
 
   /// create a new recorder with the given dump count and random
   /// simulation id.
   Recorder(unsigned int dump_count);
 
-  /// create a new recorder with default dump frequency and the specified
-  /// simulation id.
+  /// create a new recorder with default dump frequency. the specified
+  /// simulation id, and simulation id injection.
   Recorder(boost::uuids::uuid simid);
 
   ~Recorder();
@@ -70,10 +74,16 @@ class Recorder {
   ///
   /// @param count # Datum objects to buffer before flushing to backends.
   /// @warning this deletes all buffered data from the recorder.
-  virtual void set_dump_count(unsigned int count);
+  void set_dump_count(unsigned int count);
 
   /// returns the unique id associated with this cyclus simulation.
   boost::uuids::uuid sim_id();
+
+  /// returns whether or not the unique simulation id will be injected.
+  bool inject_sim_id() { return inject_sim_id_; };
+
+  /// sets whether or not the unique simulation id will be injected.
+  void set_inject_sim_id(bool x) { inject_sim_id_ = x; };
 
   /// Creates a new datum namespaced under the specified title.
   ///
@@ -81,7 +91,7 @@ class Recorder {
   /// agents. Also note that a static title (e.g. an unchanging string) will
   /// result in multiple instances of this agent storing datum data together
   /// (e.g. the same table).
-  virtual Datum* NewDatum(std::string title);
+  Datum* NewDatum(std::string title);
 
   /// Registers b to receive Datum notifications for all Datum objects collected
   /// by the Recorder and to receive a flush notification when there
@@ -106,34 +116,7 @@ class Recorder {
   std::list<RecBackend*> backs_;
   unsigned int dump_count_;
   boost::uuids::uuid uuid_;
-};
-
-/// Collects and manages output data bases. This is like the Recorded class
-/// except that the simulation id is not automatically injected into the Datum.
-/// The simulation id is always nil.
-class RawRecorder : public Recorder {
-  friend class Datum;
-
- public:
-  /// create a new raw recorder with default dump frequency and random
-  /// simulation id.
-  RawRecorder();
-
-  /// Set the Recorder to flush its collected Datum objects to registered
-  /// backends every [count] Datum objects. If count == 0 then Datum objects
-  /// will be flushed immediately as they come.
-  ///
-  /// @param count # Datum objects to buffer before flushing to backends.
-  /// @warning this deletes all buffered data from the recorder.
-  virtual void set_dump_count(unsigned int count);
-
-  /// Creates a new datum with the specified title.
-  ///
-  /// @warning choose title carefully to not conflict with Datum objects from other
-  /// agents. Also note that a static title (e.g. an unchanging string) will
-  /// result in multiple instances of this agent storing datum data together
-  /// (e.g. the same table).
-  virtual Datum* NewDatum(std::string title);
+  bool inject_sim_id_;
 };
 
 }  // namespace cyclus

--- a/src/sqlite_back.cc
+++ b/src/sqlite_back.cc
@@ -230,6 +230,14 @@ QueryResult SqliteBack::Query(std::string table, std::vector<Cond>* conds) {
   return q;
 }
 
+std::map<std::string, DbTypes> SqliteBack::ColumnTypes(std::string table) {
+  QueryResult qr = GetTableInfo(table);
+  std::map<std::string, DbTypes> rtn;
+  for (int i = 0; i < qr.fields.size(); ++i)
+    rtn[qr.fields[i]] = qr.types[i];
+  return rtn;
+}
+
 QueryResult SqliteBack::GetTableInfo(std::string table) {
   std::string sql = "SELECT Field,Type FROM FieldTypes WHERE TableName = '" +
                     table + "';";

--- a/src/sqlite_back.h
+++ b/src/sqlite_back.h
@@ -35,6 +35,8 @@ class SqliteBack: public FullBackend {
 
   virtual QueryResult Query(std::string table, std::vector<Cond>* conds);
 
+  virtual std::map<std::string, DbTypes> ColumnTypes(std::string table);
+
  private:
   void Bind(boost::spirit::hold_any v, DbTypes type, SqlStatement::Ptr stmt, int index);
 

--- a/tests/hdf5_back_tests.cc
+++ b/tests/hdf5_back_tests.cc
@@ -913,3 +913,27 @@ TEST(Hdf5BackTest, ReadWriteAll) {
   qr = back.Query("DumbTitle", &conds);
   EXPECT_EQ(qr.rows.size(), 1);
 }
+
+
+TEST(Hdf5BackTest, ColumnTypes) {
+  using std::map;
+  using std::string;
+  using cyclus::Recorder;
+  using cyclus::Hdf5Back;
+  FileDeleter fd(path);
+
+  int i = 42;
+
+  // creation
+  Recorder m;
+  Hdf5Back back(path);
+  m.RegisterBackend(&back);
+  m.NewDatum("IntTable")
+      ->AddVal("intcol", i)
+      ->Record();
+  m.Close();
+
+  map<string, cyclus::DbTypes> coltypes = back.ColumnTypes("IntTable");
+  EXPECT_EQ(2, coltypes.size());  // injects simid
+  EXPECT_EQ(cyclus::INT, coltypes["intcol"]);
+}

--- a/tests/recorder_tests.cc
+++ b/tests/recorder_tests.cc
@@ -56,6 +56,15 @@ TEST(RecorderTest, Manager_GetSetDumpFreq) {
   EXPECT_EQ(m.dump_count(), cyclus::kDefaultDumpCount);
 }
 
+TEST(RecorderTest, InjectSimId) {
+  using cyclus::Recorder;
+  Recorder m;
+  EXPECT_TRUE(m.inject_sim_id());
+
+  m.set_inject_sim_id(false);
+  EXPECT_FALSE(m.inject_sim_id());
+}
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST(RecorderTest, Manager_Closing) {
   using cyclus::Recorder;
@@ -193,22 +202,23 @@ TEST(RecorderTest, Datum_addVal) {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST(RawRecorderTest, Manager_NewDatum) {
-  cyclus::RawRecorder m;
+  using cyclus::Recorder;
+  Recorder m (false);
   cyclus::Datum* d = m.NewDatum("DumbTitle");
   EXPECT_EQ(d->title(), "DumbTitle");
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST(RawRecorderTest, Manager_CreateDefault) {
-  using cyclus::RawRecorder;
-  RawRecorder m;
+  using cyclus::Recorder;
+  Recorder m (false);
   EXPECT_EQ(m.dump_count(), cyclus::kDefaultDumpCount);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST(RawRecorderTest, Manager_GetSetDumpFreq) {
-  using cyclus::RawRecorder;
-  RawRecorder m;
+  using cyclus::Recorder;
+  Recorder m (false);
   m.set_dump_count(1);
   EXPECT_EQ(m.dump_count(), 1);
 
@@ -216,10 +226,19 @@ TEST(RawRecorderTest, Manager_GetSetDumpFreq) {
   EXPECT_EQ(m.dump_count(), cyclus::kDefaultDumpCount);
 }
 
+TEST(RawRecorderTest, InjectSimId) {
+  using cyclus::Recorder;
+  Recorder m (false);
+  EXPECT_FALSE(m.inject_sim_id());
+
+  m.set_inject_sim_id(true);
+  EXPECT_TRUE(m.inject_sim_id());
+}
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST(RawRecorderTest, Manager_Closing) {
-  using cyclus::RawRecorder;
-  RawRecorder m;
+  using cyclus::Recorder;
+  Recorder m (false);
   TestBack back1;
   TestBack back2;
   m.RegisterBackend(&back1);
@@ -231,7 +250,7 @@ TEST(RawRecorderTest, Manager_Closing) {
   ASSERT_FALSE(back1.flushed);
   ASSERT_FALSE(back2.flushed);
 
-  RawRecorder n;
+  Recorder n (false);
   TestBack back3;
   TestBack back4;
   n.RegisterBackend(&back3);
@@ -248,10 +267,10 @@ TEST(RawRecorderTest, Manager_Closing) {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST(RawRecorderTest, Manager_Buffering) {
-  using cyclus::RawRecorder;
+  using cyclus::Recorder;
   TestBack back1;
 
-  RawRecorder m;
+  Recorder m (false);
   m.set_dump_count(2);
   m.RegisterBackend(&back1);
 
@@ -272,10 +291,10 @@ TEST(RawRecorderTest, Manager_Buffering) {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST(RawRecorderTest, Manager_CloseFlushing) {
-  using cyclus::RawRecorder;
+  using cyclus::Recorder;
   TestBack back1;
 
-  RawRecorder m;
+  Recorder m (false);
   m.set_dump_count(2);
   m.RegisterBackend(&back1);
 
@@ -295,9 +314,9 @@ TEST(RawRecorderTest, Manager_CloseFlushing) {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST(RawRecorderTest, Datum_record) {
   using cyclus::Datum;
-  using cyclus::RawRecorder;
+  using cyclus::Recorder;
   TestBack back;
-  RawRecorder m;
+  Recorder m (false);
   m.set_dump_count(1);
   m.RegisterBackend(&back);
 
@@ -313,9 +332,9 @@ TEST(RawRecorderTest, Datum_record) {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST(RawRecorderTest, Datum_addVal) {
   using cyclus::Datum;
-  using cyclus::RawRecorder;
+  using cyclus::Recorder;
   TestBack back;
-  RawRecorder m;
+  Recorder m (false);
   m.RegisterBackend(&back);
 
   cyclus::Datum* d = m.NewDatum("DumbTitle");

--- a/tests/recorder_tests.cc
+++ b/tests/recorder_tests.cc
@@ -57,12 +57,32 @@ TEST(RecorderTest, Manager_GetSetDumpFreq) {
 }
 
 TEST(RecorderTest, InjectSimId) {
+  using cyclus::Datum;
   using cyclus::Recorder;
   Recorder m;
+  // with injection
   EXPECT_TRUE(m.inject_sim_id());
+  Datum* d = m.NewDatum("DumbTitle");
+  d->AddVal("animal", std::string("monkey"))
+   ->Record();
+  ASSERT_EQ(d->vals().size(), 2);
+  cyclus::Datum::Vals::const_iterator it = d->vals().begin();
+  EXPECT_STREQ(it->first, "SimId");
+  EXPECT_EQ(it->second.cast<boost::uuids::uuid>(), m.sim_id());
+  ++it;
+  EXPECT_STREQ(it->first, "animal");
+  EXPECT_EQ(it->second.cast<std::string>(), "monkey");
 
+  // without injection
   m.inject_sim_id(false);
   EXPECT_FALSE(m.inject_sim_id());
+  d = m.NewDatum("OtherTitle");
+  d->AddVal("music", std::string("funkey"))
+   ->Record();
+  ASSERT_EQ(d->vals().size(), 1);
+  it = d->vals().begin();
+  EXPECT_STREQ(it->first, "music");
+  EXPECT_EQ(it->second.cast<std::string>(), "funkey");
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -227,12 +247,32 @@ TEST(RawRecorderTest, Manager_GetSetDumpFreq) {
 }
 
 TEST(RawRecorderTest, InjectSimId) {
+  using cyclus::Datum;
   using cyclus::Recorder;
   Recorder m (false);
+  // Without injection
   EXPECT_FALSE(m.inject_sim_id());
+  Datum* d = m.NewDatum("DumbTitle");
+  d->AddVal("music", std::string("funkey"))
+   ->Record();
+  ASSERT_EQ(d->vals().size(), 1);
+  cyclus::Datum::Vals::const_iterator it = d->vals().begin();
+  EXPECT_STREQ(it->first, "music");
+  EXPECT_EQ(it->second.cast<std::string>(), "funkey");
 
+  // with injections
   m.inject_sim_id(true);
   EXPECT_TRUE(m.inject_sim_id());
+  d = m.NewDatum("OtherTitle");
+  d->AddVal("animal", std::string("monkey"))
+   ->Record();
+  ASSERT_EQ(d->vals().size(), 2);
+  it = d->vals().begin();
+  EXPECT_STREQ(it->first, "SimId");
+  EXPECT_EQ(it->second.cast<boost::uuids::uuid>(), m.sim_id());
+  ++it;
+  EXPECT_STREQ(it->first, "animal");
+  EXPECT_EQ(it->second.cast<std::string>(), "monkey");
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/tests/recorder_tests.cc
+++ b/tests/recorder_tests.cc
@@ -67,11 +67,23 @@ TEST(RecorderTest, Manager_Closing) {
 
   ASSERT_FALSE(back1.flushed);
   ASSERT_FALSE(back2.flushed);
-
   m.Close();
+  ASSERT_FALSE(back1.flushed);
+  ASSERT_FALSE(back2.flushed);
 
-  EXPECT_TRUE(back1.flushed);
-  EXPECT_TRUE(back2.flushed);
+  Recorder n;
+  TestBack back3;
+  TestBack back4;
+  n.RegisterBackend(&back3);
+  n.RegisterBackend(&back4);
+  ASSERT_FALSE(back3.flushed);
+  ASSERT_FALSE(back4.flushed);
+  n.NewDatum("DumbTitle")
+      ->AddVal("animal", std::string("monkey"))
+      ->Record();
+  n.Close();
+  EXPECT_TRUE(back3.flushed);
+  EXPECT_TRUE(back4.flushed);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -215,11 +227,23 @@ TEST(RawRecorderTest, Manager_Closing) {
 
   ASSERT_FALSE(back1.flushed);
   ASSERT_FALSE(back2.flushed);
-
   m.Close();
+  ASSERT_FALSE(back1.flushed);
+  ASSERT_FALSE(back2.flushed);
 
-  EXPECT_TRUE(back1.flushed);
-  EXPECT_TRUE(back2.flushed);
+  RawRecorder n;
+  TestBack back3;
+  TestBack back4;
+  n.RegisterBackend(&back3);
+  n.RegisterBackend(&back4);
+  ASSERT_FALSE(back3.flushed);
+  ASSERT_FALSE(back4.flushed);
+  n.NewDatum("DumbTitle")
+      ->AddVal("animal", std::string("monkey"))
+      ->Record();
+  n.Close();
+  EXPECT_TRUE(back3.flushed);
+  EXPECT_TRUE(back4.flushed);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/tests/recorder_tests.cc
+++ b/tests/recorder_tests.cc
@@ -61,7 +61,7 @@ TEST(RecorderTest, InjectSimId) {
   Recorder m;
   EXPECT_TRUE(m.inject_sim_id());
 
-  m.set_inject_sim_id(false);
+  m.inject_sim_id(false);
   EXPECT_FALSE(m.inject_sim_id());
 }
 
@@ -231,7 +231,7 @@ TEST(RawRecorderTest, InjectSimId) {
   Recorder m (false);
   EXPECT_FALSE(m.inject_sim_id());
 
-  m.set_inject_sim_id(true);
+  m.inject_sim_id(true);
   EXPECT_TRUE(m.inject_sim_id());
 }
 

--- a/tests/sim_init_tests.cc
+++ b/tests/sim_init_tests.cc
@@ -86,7 +86,7 @@ Agent* ConstructInver(cy::Context* ctx) {
 
 class SimInitTest : public ::testing::Test {
  public:
-  SimInitTest() : rec(300) {}
+  SimInitTest() : rec((unsigned int) 300) {}
 
  protected:
   virtual void SetUp() {

--- a/tests/sqlite_back_tests.cc
+++ b/tests/sqlite_back_tests.cc
@@ -339,3 +339,22 @@ TEST_F(SqliteBackTests, AllTogether) {
   EXPECT_EQ("one", svget[0]);
   EXPECT_EQ("three", svget[1]);
 }
+
+TEST_F(SqliteBackTests, ColumnTypes) {
+  using std::map;
+  using std::string;
+  FileDeleter fd(path);
+
+  int i = 42;
+
+  // creation
+  r.NewDatum("IntTable")
+      ->AddVal("intcol", i)
+      ->Record();
+  r.Close();
+
+  map<string, cyclus::DbTypes> coltypes = b->ColumnTypes("IntTable");
+  EXPECT_EQ(2, coltypes.size());  // injects simid
+  EXPECT_EQ(cyclus::INT, coltypes["intcol"]);
+}
+


### PR DESCRIPTION
This adds a subclass of recorder that does not inject the SimId and gives you raw table writing. This is needed for the more general case of writing to the database, and in particular for cymetric or any other analysis tool. In such situations SimIds are not necessarily semantically meaningful. For example, aggregation over many simulations will make any SimId field meaningless. Since folks may want to store any kind of data a raw recorder is needed. A subclass API turned out to be cleaner than adding new member functions.

This is dependent on #1061, which should be merged in first.