### PR TITLE
modify resbuf code generation. Add missing ResCast funcs.

### DIFF
--- a/cli/cycpp.py
+++ b/cli/cycpp.py
@@ -949,11 +949,11 @@ class InitFromDbFilter(CodeGeneratorFilter):
             impl += ind + '{0} = qr.GetVal<{1}>("{0}");\n'.format(member, tstr)
         for b, info in cap_buffs.items():
             if isinstance(info['type'], STRING_TYPES):  # ResourceBuff
-                impl += ind + ('{0}.set_capacity(qr.GetVal<double>'
-                               '("{1}"));\n').format(b, info['capacity'])
+                impl += ind + ('{0}.set_capacity({1});\n'
+                               .format(b, info['capacity']))
             else:  # ResBuf
-                impl += ind + ('{0}.capacity(qr.GetVal<double>'
-                               '("{1}"));\n').format(b, info['capacity'])
+                impl += ind + ('{0}.capacity({1});\n'
+                               .format(b, info['capacity']))
         return impl
 
 class InfileToDbFilter(CodeGeneratorFilter):

--- a/src/toolkit/res_buf.h
+++ b/src/toolkit/res_buf.h
@@ -191,7 +191,7 @@ class ResBuf {
   }
 
   /// Same as PopN except returns the Resource-typed objects.
-  ResVec PopNRes(int n) { return ResCast<Resource>(PopN(n)); }
+  ResVec PopNRes(int n) { return ResCast(PopN(n)); }
 
   /// Returns the next resource in line to be popped from the buffer
   /// without actually removing it from the buffer.

--- a/src/toolkit/res_manip.cc
+++ b/src/toolkit/res_manip.cc
@@ -33,11 +33,11 @@ Resource::Ptr Squash(std::vector<Resource::Ptr> rs) {
     throw Error("cannot squash zero resources together");
   }
 
-  std::vector<Material::Ptr> mats = ResCast<Material>(rs);
+  std::vector<Material::Ptr> mats = ::cyclus::ResCast<Material>(rs);
   if (mats[0] != NULL) {
     return Squash(mats);
   }
-  std::vector<Product::Ptr> prods = ResCast<Product>(rs);
+  std::vector<Product::Ptr> prods = ::cyclus::ResCast<Product>(rs);
   if (prods[0] != NULL) {
     return Squash(prods);
   }
@@ -45,6 +45,22 @@ Resource::Ptr Squash(std::vector<Resource::Ptr> rs) {
   throw Error("cannot squash resource type " + rs[0]->type());
 }
   
+std::vector<Resource::Ptr> ResCast(std::vector<Material::Ptr> rs) {
+  std::vector<Resource::Ptr> casted;
+  for (int i = 0; i < rs.size(); ++i) {
+    casted.push_back(boost::dynamic_pointer_cast<Resource>(rs[i]));
+  }
+  return casted;
+}
+
+std::vector<Resource::Ptr> ResCast(std::vector<Product::Ptr> rs) {
+  std::vector<Resource::Ptr> casted;
+  for (int i = 0; i < rs.size(); ++i) {
+    casted.push_back(boost::dynamic_pointer_cast<Resource>(rs[i]));
+  }
+  return casted;
+}
+
 }  // namespace toolkit
 }  // namespace cyclus
 

--- a/src/toolkit/res_manip.h
+++ b/src/toolkit/res_manip.h
@@ -20,6 +20,12 @@ Material::Ptr Squash(std::vector<Material::Ptr> ms);
 /// resource.
 Resource::Ptr Squash(std::vector<Resource::Ptr> rs);
 
+/// Casts a vector of Materials into a vector of Resources.
+std::vector<Resource::Ptr> ResCast(std::vector<Material::Ptr> rs);
+
+/// Casts a vector of Products into a vector of Resources.
+std::vector<Resource::Ptr> ResCast(std::vector<Product::Ptr> rs);
+
 }  // namespace toolkit
 }  // namespace cyclus
 

--- a/tests/toolkit/res_manip_tests.cc
+++ b/tests/toolkit/res_manip_tests.cc
@@ -7,6 +7,7 @@ using cyclus::Material;
 using cyclus::Product;
 using cyclus::Resource;
 using cyclus::toolkit::Squash;
+using cyclus::toolkit::ResCast;
 
 
 Material::Ptr testmat() {
@@ -86,5 +87,21 @@ TEST(ResManipTests, Squash_Res) {
     tot += rs[i]->quantity();
   }
   EXPECT_DOUBLE_EQ(testprod()->quantity()*n, tot);
+}
+
+TEST(ResManipTests, ResCast_Material) {
+  std::vector<Material::Ptr> rs;
+  for (int i = 0; i < 2; i++) {
+    rs.push_back(testmat());
+  }
+  ASSERT_NO_THROW(std::vector<Resource::Ptr> foo = ResCast(rs));
+}
+
+TEST(ResManipTests, ResCast_Product) {
+  std::vector<Product::Ptr> rs;
+  for (int i = 0; i < 2; i++) {
+    rs.push_back(testprod());
+  }
+  ASSERT_NO_THROW(std::vector<Resource::Ptr> foo = ResCast(rs));
 }
 


### PR DESCRIPTION
ResBuf prior to this commit was broken.  It tried to use the an overload
of the ResCast function in resource.h that didn't exist.  Since the ResCast
overload needed isn't terribly likely to be needed outside of resource
buffer(s), I decided it fit well in the toolkit.

Previously, the code generated by cycpp for setting resource buffer capacities
in InitFrom (db) assumed that the 'capacity' key for the buffer member
dictionary was a literal value stored in the database explicitly.  This
relaxes that assumption and instead assumes the 'capacity' key is literal code
that should be pasted in.  Now arbitrary expressions, etc. can be used to
compute capacities based on other member variables.  The tradeoff is that all
referenced member variables in these expressions must be defined/pragma'd
prior/above the resource buffer.