### PR TITLE
add back old Material::comp() const for abi stability. It throws.

### DIFF
--- a/src/material.cc
+++ b/src/material.cc
@@ -189,6 +189,11 @@ void Material::Decay(int curr_time) {
   Transmute(decayed);
 }
 
+Composition::Ptr Material::comp() const {
+  throw Error("comp() const is deprecated - use non-const comp() function."
+              " Recompilation should fix the problem.");
+}
+
 Composition::Ptr Material::comp() {
   if (ctx_ != NULL && ctx_->sim_info().decay == "lazy") {
     Decay(-1);

--- a/src/material.h
+++ b/src/material.h
@@ -146,6 +146,9 @@ class Material: public Resource {
   /// Returns the nuclide composition of this material.
   Composition::Ptr comp();
 
+  /// DEPRECATED - use non-const comp() function.
+  Composition::Ptr comp() const;
+
  protected:
   Material(Context* ctx, double quantity, Composition::Ptr c);
 


### PR DESCRIPTION
fixes #1069 