### PR TITLE
more robust find lib cyclus behavior in test abi

### DIFF
--- a/tests/test_abi.py
+++ b/tests/test_abi.py
@@ -17,18 +17,34 @@ try:
 except ImportError:
     smbchk = None
 
+def find_libcyc():
+    libcyc = os.path.join(cycdir, 'build', 'lib', 'libcyclus.so')
+    if os.path.exists(libcyc):
+        return libcyc
+
+    cmd = "find / -type f -name libcyclus.so -executable 2>/dev/null"
+    try:
+        output = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as e:
+        output = e.output
+
+    print('output:', output)
+    return output.split('\n')[0]
+
 def test_abi_stability():
     if smbchk is None:
         raise SkipTest('Could not import smbchk!')
     if os.name != 'posix':
         raise SkipTest('can only check for ABI stability on posix systems.')
-    libcyc = os.path.join(cycdir, 'build', 'lib', 'libcyclus.so')
+    libcyc = find_libcyc()
     if not os.path.exists(libcyc):
         raise SkipTest('libcyclus could not be found, '
                        'cannot check for ABI stability')
-    args = '--update -t HEAD --no-save --check'.split()
+    prefix = os.path.join(os.path.dirname(libcyc), '..')
+    args = '--update -t HEAD --no-save --check --prefix {}'.format(prefix).split()
     with tools.indir(reldir):
         obs = smbchk.main(args=args)
+    print('obs ' + obs)
     assert_true(obs)
 
 if __name__ == "__main__":

--- a/tests/test_abi.py
+++ b/tests/test_abi.py
@@ -29,7 +29,6 @@ def find_libcyc():
     except subprocess.CalledProcessError as e:
         output = e.output
 
-    print('output:', output)
     return output.split('\n')[0]
 
 def test_abi_stability():
@@ -46,7 +45,6 @@ def test_abi_stability():
     args = args.format(prefix).split()
     with tools.indir(reldir):
         obs = smbchk.main(args=args)
-    print('obs ' + obs)
     assert_true(obs)
 
 if __name__ == "__main__":

--- a/tests/test_abi.py
+++ b/tests/test_abi.py
@@ -20,8 +20,18 @@ except ImportError:
 def find_libcyc():
     libcyc = os.path.join(cycdir, 'build', 'lib', 'libcyclus.so')
     if os.path.exists(libcyc):
-        print('lib cyc exists in build: ', libcyc)
+        print('lib cyclus exists: ', libcyc)
         return libcyc
+
+    try:
+        base = subprocess.check_output('which cyclus'.split()).strip()
+        libcyc = os.path.join(os.path.dirname(base), 
+                              '..', 'lib', 'libcyclus.so')
+        if os.path.exists(libcyc):
+            print('lib cyclus exists: ', libcyc)
+            return libcyc
+    except subprocess.CalledProcessError:
+        pass
 
     cmd = "find / -type f -name libcyclus.so -executable 2>/dev/null"
     try:

--- a/tests/test_abi.py
+++ b/tests/test_abi.py
@@ -26,9 +26,9 @@ def find_libcyc():
 
     try:
         base = subprocess.check_output('which cyclus'.split()).strip()
-        tried.append(libcyc)
         libcyc = os.path.join(os.path.dirname(base), 
                               '..', 'lib', 'libcyclus.so')
+        tried.append(libcyc)
         if os.path.exists(libcyc):
             print('lib cyclus exists: ', libcyc)
             return libcyc, tried
@@ -36,13 +36,11 @@ def find_libcyc():
         pass
 
     base = os.path.expanduser('~/anaconda/envs/_build')
-    print('base', base)
     libcyc = os.path.join(os.path.dirname(base), 'lib', 'libcyclus.so')
     tried.append(libcyc)
     if os.path.exists(libcyc):
         print('lib cyclus exists: ', libcyc)
         return libcyc, tried
-    tried.append(libcyc)
     
     cmd = "find / -type f -name libcyclus.so -executable 2>/dev/null"
     try:

--- a/tests/test_abi.py
+++ b/tests/test_abi.py
@@ -20,6 +20,7 @@ except ImportError:
 def find_libcyc():
     libcyc = os.path.join(cycdir, 'build', 'lib', 'libcyclus.so')
     if os.path.exists(libcyc):
+        print('lib cyc exists in build: ', libcyc)
         return libcyc
 
     cmd = "find / -type f -name libcyclus.so -executable 2>/dev/null"
@@ -29,6 +30,7 @@ def find_libcyc():
     except subprocess.CalledProcessError as e:
         output = e.output
 
+    print('lib cyc found with find: ', output)
     return output.split('\n')[0]
 
 def test_abi_stability():

--- a/tests/test_abi.py
+++ b/tests/test_abi.py
@@ -18,15 +18,15 @@ except ImportError:
     smbchk = None
 
 def find_libcyc():
-    tried = []
     libcyc = os.path.join(cycdir, 'build', 'lib', 'libcyclus.so')
+    tried = [libcyc]
     if os.path.exists(libcyc):
         print('lib cyclus exists: ', libcyc)
         return libcyc, tried
-    tried.append(libcyc)
 
     try:
         base = subprocess.check_output('which cyclus'.split()).strip()
+        tried.append(libcyc)
         libcyc = os.path.join(os.path.dirname(base), 
                               '..', 'lib', 'libcyclus.so')
         if os.path.exists(libcyc):
@@ -34,11 +34,11 @@ def find_libcyc():
             return libcyc, tried
     except subprocess.CalledProcessError:
         pass
-    tried.append(libcyc)
 
     base = os.path.expanduser('~/anaconda/envs/_build')
     print('base', base)
     libcyc = os.path.join(os.path.dirname(base), 'lib', 'libcyclus.so')
+    tried.append(libcyc)
     if os.path.exists(libcyc):
         print('lib cyclus exists: ', libcyc)
         return libcyc, tried

--- a/tests/test_abi.py
+++ b/tests/test_abi.py
@@ -24,7 +24,8 @@ def find_libcyc():
 
     cmd = "find / -type f -name libcyclus.so -executable 2>/dev/null"
     try:
-        output = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT)
+        output = subprocess.check_output(cmd, shell=True, 
+                                         stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
         output = e.output
 
@@ -41,7 +42,8 @@ def test_abi_stability():
         raise SkipTest('libcyclus could not be found, '
                        'cannot check for ABI stability')
     prefix = os.path.join(os.path.dirname(libcyc), '..')
-    args = '--update -t HEAD --no-save --check --prefix {}'.format(prefix).split()
+    args = '--update -t HEAD --no-save --check --prefix {}'
+    args = args.format(prefix).split()
     with tools.indir(reldir):
         obs = smbchk.main(args=args)
     print('obs ' + obs)

--- a/tests/test_abi.py
+++ b/tests/test_abi.py
@@ -33,6 +33,13 @@ def find_libcyc():
     except subprocess.CalledProcessError:
         pass
 
+    base = os.path.expanduser('~/anaconda/envs/_build')
+    print('base', base)
+    libcyc = os.path.join(os.path.dirname(base), 'lib', 'libcyclus.so')
+    if os.path.exists(libcyc):
+        print('lib cyclus exists: ', libcyc)
+        return libcyc
+    
     cmd = "find / -type f -name libcyclus.so -executable 2>/dev/null"
     try:
         output = subprocess.check_output(cmd, shell=True, 

--- a/tests/test_abi.py
+++ b/tests/test_abi.py
@@ -54,15 +54,14 @@ def find_libcyc():
     print('lib cyc found with find: ', output)
     return libcyc, tried
 
-def test_failure():
-    assert_true(False)
-
 def test_abi_stability():
     if smbchk is None:
         raise SkipTest('Could not import smbchk!')
     if os.name != 'posix':
         raise SkipTest('can only check for ABI stability on posix systems.')
     libcyc, tried = find_libcyc()
+    print('libcyc', libcyc)
+    print('tried', tried)
     if not os.path.exists(libcyc):
         msg = 'libcyclus could not be found, cannot check for ABI stability '
         msg += 'Final libcyc: {} Tried: {} HOME: {}'.format(

--- a/tests/test_abi.py
+++ b/tests/test_abi.py
@@ -61,8 +61,8 @@ def test_abi_stability():
         raise SkipTest('can only check for ABI stability on posix systems.')
     libcyc, tried = find_libcyc()
     if not os.path.exists(libcyc):
-        msg = 'libcyclus could not be found, cannot check for ABI stability\n'
-        msg += 'Final libcyc: {}\nTried: {}\nHOME: {}'.format(
+        msg = 'libcyclus could not be found, cannot check for ABI stability '
+        msg += 'Final libcyc: {} Tried: {} HOME: {}'.format(
             libcyc, tried, os.environ['HOME']) 
         raise SkipTest(msg)
     prefix = os.path.join(os.path.dirname(libcyc), '..')

--- a/tests/test_abi.py
+++ b/tests/test_abi.py
@@ -54,6 +54,9 @@ def find_libcyc():
     print('lib cyc found with find: ', output)
     return libcyc, tried
 
+def test_failure():
+    assert_true(False)
+
 def test_abi_stability():
     if smbchk is None:
         raise SkipTest('Could not import smbchk!')


### PR DESCRIPTION
After many trials and tribulations, this is the beginning of some work to try and fix our abi stability tests on batlab.

It turns out that the `SkipTest` we see is not related to `smbchk`, but rather to finding `libcyclus`. This PR allows us to actually find `libcyclus` outside of the assumed location.

Currently, this test is failing for reasons unknown to me (`git log` appears to return non-zero), and I have other things to get to today. @scopatz will likely have to assist here.