### PR TITLE
adds helpers for running mock simulations to test archetypes.

### DIFF
--- a/agents/sink.cc
+++ b/agents/sink.cc
@@ -21,7 +21,12 @@ Sink::GetMatlRequests() {
   std::set<RequestPortfolio<Material>::Ptr> ports;
   RequestPortfolio<Material>::Ptr port(new RequestPortfolio<Material>());
   double amt = Capacity();
+
   Material::Ptr mat = cyclus::NewBlankMaterial(amt);
+  if (recipe_name != "") {
+    Composition::Ptr c = context()->GetRecipe(recipe_name);
+    mat = Material::CreateUntracked(amt, c);
+  }
 
   if (amt > cyclus::eps()) {
     CapacityConstraint<Material> cc(amt);

--- a/agents/sink.cc
+++ b/agents/sink.cc
@@ -23,7 +23,7 @@ Sink::GetMatlRequests() {
   double amt = Capacity();
 
   Material::Ptr mat = cyclus::NewBlankMaterial(amt);
-  if (recipe_name != "") {
+  if (!recipe_name.empty()) {
     Composition::Ptr c = context()->GetRecipe(recipe_name);
     mat = Material::CreateUntracked(amt, c);
   }

--- a/agents/sink.h
+++ b/agents/sink.h
@@ -54,7 +54,31 @@ class Sink : public cyclus::Facility  {
   /// @brief determines the amount to request
   inline double Capacity() const { return capacity; }
 
+  inline void Capacity(double cap) { capacity = cap; }
+
+  void AddIncommod(std::string commod) {in_commods.push_back(commod);};
+
+  /// sets the name of the recipe to be requested
+  inline void recipe(std::string name) { recipe_name = name; }
+
+  /// the name of the input recipe to request
+  inline std::string recipe() const { return recipe_name; }
+
+  virtual void Build(cyclus::Agent* parent) {
+    Facility::Build(parent);
+    if (lifetime() >= 0) {
+      context()->SchedDecom(this, enter_time() + lifetime());
+    }
+  }
+
  private:
+  #pragma cyclus var {"doc": "name of recipe to request for all in commodities", \
+                      "tooltip": "input/request recipe name", \
+                      "schematype": "token", \
+                      "default": "", \
+                      "uitype": "recipe"}
+  std::string recipe_name;
+
   #pragma cyclus var {"doc": "commodities that the sink facility " \
                              "accepts", \
                       "tooltip": "input commodities for the sink", \

--- a/agents/sink.h
+++ b/agents/sink.h
@@ -72,11 +72,14 @@ class Sink : public cyclus::Facility  {
   }
 
  private:
-  #pragma cyclus var {"doc": "name of recipe to request for all in commodities", \
-                      "tooltip": "input/request recipe name", \
-                      "schematype": "token", \
-                      "default": "", \
-                      "uitype": "recipe"}
+  #pragma cyclus var { \
+    "tooltip": "input/request recipe name", \
+    "doc": "Name of recipe to request." \
+           "If empty, sink requests material no particular composition.", \
+    "schematype": "token", \
+    "default": "", \
+    "uitype": "recipe", \
+  }
   std::string recipe_name;
 
   #pragma cyclus var {"doc": "commodities that the sink facility " \

--- a/agents/source.cc
+++ b/agents/source.cc
@@ -35,7 +35,7 @@ cyclus::Material::Ptr Source::GetOffer(
     const cyclus::Material::Ptr target) const {
   using cyclus::Material;
   double qty = std::min(target->quantity(), capacity);
-  if (recipe_name == "") {
+  if (recipe_name.empty()) {
     return target;
   } else {
     return Material::CreateUntracked(qty, context()->GetRecipe(recipe_name));
@@ -88,7 +88,7 @@ void Source::GetMatlTrades(
     provided += qty;
     // @TODO we need a policy on negatives..
     Material::Ptr response;
-    if (recipe_name == "") {
+    if (recipe_name.empty()) {
       response = Material::Create(this, qty, it->request->target()->comp());
     } else {
       response = Material::Create(this, qty, context()->GetRecipe(recipe_name));

--- a/agents/source.cc
+++ b/agents/source.cc
@@ -35,7 +35,11 @@ cyclus::Material::Ptr Source::GetOffer(
     const cyclus::Material::Ptr target) const {
   using cyclus::Material;
   double qty = std::min(target->quantity(), capacity);
-  return Material::CreateUntracked(qty, context()->GetRecipe(recipe_name));
+  if (recipe_name == "") {
+    return target;
+  } else {
+    return Material::CreateUntracked(qty, context()->GetRecipe(recipe_name));
+  }
 }
 
 std::set<cyclus::BidPortfolio<cyclus::Material>::Ptr>
@@ -83,8 +87,12 @@ void Source::GetMatlTrades(
     current_capacity -= qty;
     provided += qty;
     // @TODO we need a policy on negatives..
-    Material::Ptr response = Material::Create(this, qty,
-                                              context()->GetRecipe(recipe_name));
+    Material::Ptr response;
+    if (recipe_name == "") {
+      response = Material::Create(this, qty, it->request->target()->comp());
+    } else {
+      response = Material::Create(this, qty, context()->GetRecipe(recipe_name));
+    }
     responses.push_back(std::make_pair(*it, response));
     LOG(cyclus::LEV_INFO5, "SrcFac") << prototype() << " just received an order"
                                      << " for " << qty

--- a/agents/source.h
+++ b/agents/source.h
@@ -78,6 +78,13 @@ class Source : public cyclus::Facility {
   /// @return the name of the output recipe
   inline std::string recipe() const { return recipe_name; }
 
+  virtual void Build(cyclus::Agent* parent) {
+    Facility::Build(parent);
+    if (lifetime() >= 0) {
+      context()->SchedDecom(this, enter_time() + lifetime());
+    }
+  }
+
  private:
   #pragma cyclus var {"doc": "commodity that the source facility " \
                              "supplies", \
@@ -90,6 +97,7 @@ class Source : public cyclus::Facility {
                              "commodity", \
                       "tooltip": "commodity recipe name", \
                       "schematype": "token", \
+                      "default": "", \
                       "uitype": "recipe"}
   std::string recipe_name;
 

--- a/agents/source.h
+++ b/agents/source.h
@@ -93,12 +93,14 @@ class Source : public cyclus::Facility {
                       "uitype": "outcommodity"}
   std::string commod;
 
-  #pragma cyclus var {"doc": "recipe name for source facility's " \
-                             "commodity", \
-                      "tooltip": "commodity recipe name", \
-                      "schematype": "token", \
-                      "default": "", \
-                      "uitype": "recipe"}
+  #pragma cyclus var { \
+    "doc": "Recipe name for source facility's commodity." \
+           "If empty, source supplies material with requested compositions.", \
+    "tooltip": "commodity recipe name", \
+    "schematype": "token", \
+    "default": "", \
+    "uitype": "recipe", \
+  }
   std::string recipe_name;
 
   /// The capacity is defined in terms of the number of units of the

--- a/src/cyclus.h
+++ b/src/cyclus.h
@@ -22,6 +22,7 @@
 #include "institution.h"
 #include "logger.h"
 #include "material.h"
+#include "mock_sim.h"
 #include "agent.h"
 #include "pyne.h"
 #include "pyne_decay.h"

--- a/src/mock_sim.cc
+++ b/src/mock_sim.cc
@@ -1,0 +1,155 @@
+#include "mock_sim.h"
+
+#include "cyclus.h"
+#include <sstream>
+
+namespace cyclus {
+
+// The code for this function was copied with minor adjustements from
+// XMLFileLoader::LoadInitialAgents
+void InitAgent(Agent* a, std::stringstream& config, Recorder* rec,
+               SqliteBack* back) {
+  XMLParser parser_;
+  parser_.Init(config);
+  InfileTree xqe(parser_);
+
+  a->Agent::InfileToDb(&xqe, DbInit(a, true));
+  a->InfileToDb(&xqe, DbInit(a));
+  rec->Flush();
+
+  std::vector<Cond> conds;
+  conds.push_back(Cond("SimId", "==", rec->sim_id()));
+  conds.push_back(Cond("SimTime", "==", static_cast<int>(0)));
+  conds.push_back(Cond("AgentId", "==", a->id()));
+  CondInjector ci(back, conds);
+
+  // call manually without agent impl injected
+  PrefixInjector pi(&ci, "AgentState");
+  a->Agent::InitFrom(&pi);
+
+  pi = PrefixInjector(&ci, "AgentState" + AgentSpec(a->spec()).Sanitize());
+  a->InitFrom(&pi);
+}
+
+///////// MockAgent ////////////
+
+int MockAgent::nextid_ = 0;
+
+MockAgent::MockAgent(Context* ctx, Recorder* rec, SqliteBack* b, bool is_source)
+    : ctx_(ctx),
+      rec_(rec),
+      back_(b),
+      source_(is_source),
+      cap_(1e299),
+      lifetime_(-1),
+      start_(0) {
+  std::stringstream ss;
+  if (is_source) {
+    ss << "source";
+  } else {
+    ss << "sink";
+  }
+  ss << nextid_++;
+  proto_ = ss.str();
+}
+
+MockAgent MockAgent::commod(std::string commod) {
+  commod_ = commod;
+  return *this;
+}
+MockAgent MockAgent::recipe(std::string recipe) {
+  recipe_ = recipe;
+  return *this;
+}
+MockAgent MockAgent::capacity(double cap) {
+  cap_ = cap;
+  return *this;
+}
+MockAgent MockAgent::start(int t) {
+  start_ = t;
+  return *this;
+}
+MockAgent MockAgent::lifetime(int duration) {
+  lifetime_ = duration;
+  return *this;
+}
+
+std::string MockAgent::Finalize() {
+  AgentSpec spec(":agents:Sink");
+  if (source_) {
+    spec = AgentSpec(":agents:Source");
+  }
+
+  std::stringstream xml;
+  xml << "<facility><name>" << proto_ << "</name><lifetime>" << lifetime_
+      << "</lifetime><config><SrcSnkAgent>";
+
+  if (source_) {
+    xml << "<commod>" << commod_ << "</commod>";
+  } else {
+    xml << "<in_commods><val>" << commod_ << "</val></in_commods>";
+  }
+  xml << "<capacity>" << cap_ << "</capacity>";
+  if (recipe_ != "") {
+    xml << "<recipe_name>" << recipe_ << "</recipe_name>";
+  }
+  xml << "</SrcSnkAgent></config></facility>";
+
+  Agent* a = DynamicModule::Make(ctx_, spec);
+  InitAgent(a, xml, rec_, back_);
+
+  ctx_->AddPrototype(proto_, a);
+
+  if (start_ == 0) {
+    a = ctx_->CreateAgent<Agent>(proto_);
+    a->Build(NULL);
+  } else {
+    ctx_->SchedBuild(NULL, proto_, start_);
+  }
+  return proto_;
+}
+
+///////// MockSim ////////////
+
+MockSim::MockSim(AgentSpec spec, std::string config, int duration)
+    : ctx_(&ti_, &rec_), back_(NULL) {
+  back_ = new SqliteBack(":memory:");
+  rec_.RegisterBackend(back_);
+  ti_.Initialize(&ctx_, SimInfo(duration));
+
+  Agent* a = DynamicModule::Make(&ctx_, spec);
+
+  std::stringstream xml;
+  xml << "<facility><name>agent_being_tested</name><config><foo>" << config
+      << "</foo></config></facility>";
+  InitAgent(a, xml, &rec_, back_);
+
+  ctx_.AddPrototype(a->prototype(), a);
+  a = ctx_.CreateAgent<Agent>(a->prototype());
+  a->Build(NULL);
+}
+
+MockAgent MockSim::AddSource(std::string commod) {
+  MockAgent ms(&ctx_, &rec_, back_, true);
+  ms.commod(commod);
+  return ms;
+}
+
+MockAgent MockSim::AddSink(std::string commod) {
+  MockAgent ms(&ctx_, &rec_, back_, false);
+  ms.commod(commod);
+  return ms;
+}
+
+void MockSim::AddRecipe(std::string name, Composition::Ptr c) {
+  ctx_.AddRecipe(name, c);
+}
+
+void MockSim::Run() {
+  ti_.RunSim();
+  rec_.Flush();
+}
+
+SqliteBack& MockSim::db() { return *back_; }
+
+}  // namespace cyclus

--- a/src/mock_sim.cc
+++ b/src/mock_sim.cc
@@ -145,9 +145,13 @@ void MockSim::AddRecipe(std::string name, Composition::Ptr c) {
   ctx_.AddRecipe(name, c);
 }
 
-void MockSim::Run() {
+int MockSim::Run() {
   ti_.RunSim();
   rec_.Flush();
+  std::vector<Cond> conds;
+  conds.push_back(Cond("Prototype", "==", "agent_being_tested"));
+  QueryResult qr = back_->Query("AgentEntry", &conds);
+  return qr.GetVal<int>("AgentId");
 }
 
 SqliteBack& MockSim::db() { return *back_; }

--- a/src/mock_sim.h
+++ b/src/mock_sim.h
@@ -10,42 +10,175 @@ namespace cyclus {
 class Source;
 class Sink;
 
+/// MockAgent is a template for accumulating configuration information used to
+/// generate a source or sink facility in a MockSimulation.  All parameters
+/// other than commod have defaults. After all desired configuration is
+/// completed, the Finalize function MUST be called.  All configure functions
+/// return the MockAgent itself to enable chaining.  Default configuration is:
+///
+/// * no recipe - sources provide requested material, sinks take anything
+/// * infinite per time step capacity
+/// * start/deploy on time step zero
+/// * infinite lifetime.
+///
+/// For examples on how to use MockAgent, see the MockSim API documentation.
 class MockAgent {
-  public:
-    MockAgent(Context* ctx, Recorder* rec, SqliteBack* b, bool is_source);
+ public:
+  
+  /// Initializes a MockAgent to create a source (is_source == true) or a
+  /// sink (is_source == false) in the provided simulation context.  rec must be
+  /// the recorder used to initialize ctx and b must be a backend registered
+  /// with rec.
+  MockAgent(Context* ctx, Recorder* rec, SqliteBack* b, bool is_source);
 
-    MockAgent commod(std::string commod);
-    MockAgent recipe(std::string recipe);
-    MockAgent capacity(double cap);
-    MockAgent start(int timestep);
-    MockAgent lifetime(int duration);
-    // returns the name of the created prototype
-    std::string Finalize();
-   
-  private:
-    static int nextid_;
-    bool source_;
-    std::string commod_;
-    std::string recipe_;
-    double cap_;
-    int start_;
-    int lifetime_;
-    std::string proto_;
-    Context* ctx_;
-    Recorder* rec_;
-    SqliteBack* back_;
+  /// Sets the commodity to be offered/requested by the source/sink.
+  MockAgent commod(std::string commod);
+
+  /// Sets the recipe to be offered/requested by the source/sink.
+  MockAgent recipe(std::string recipe);
+
+  /// Sets the per time step capacity/throughput limit for provided/received
+  /// material in kg for the source/sink.
+  MockAgent capacity(double cap);
+
+  /// Sets the time step in the simulation that the source/sink should be
+  /// deployed.
+  MockAgent start(int timestep);
+
+  /// Sets the lifetime in time steps of the source/sink before it is
+  /// decommissioned.
+  MockAgent lifetime(int duration);
+
+  /// Finalize MUST be called after configuration is complete to actually
+  /// create the source/sink agent (or schedule it to be built). The
+  /// auto-generated name of the created prototype is returned to support
+  /// querying based on specific sources/sinks.
+  std::string Finalize();
+
+ private:
+  static int nextid_;
+  bool source_;
+  std::string commod_;
+  std::string recipe_;
+  double cap_;
+  int start_;
+  int lifetime_;
+  std::string proto_;
+  Context* ctx_;
+  Recorder* rec_;
+  SqliteBack* back_;
 };
 
+/// MockSim is a helper for running full simulations entirely in-code to test
+/// archetypes/agents without having to deal with input files, output database
+/// files, and other pieces of the full Cyclus stack.  This is especially
+/// convenient for writing unit-like tests (e.g. using gtest) for your
+/// archetype's in-simulation behavior.   Initialize the MockSim indicating the
+/// archetype you want to test and the simulation duration.  Then add any
+/// number of sources and/or sinks to transact with your agent.  They can have
+/// specific recipes (or not) and their deployment and lifetime (before
+/// decommissioning) can be specified too.  Here is an example using the
+/// agents:Source archetype in Cyclus as the tested agent:
+///
+/// @code
+///
+/// cyclus::CompMap m;
+/// m[922350000] = .05;
+/// m[922380000] = .95;
+/// cyclus::Composition::Ptr fresh = cyclus::Composition::CreateFromMass(m);
+///
+/// std::string config =
+///     "<commod>enriched_u</commod>"
+///     "<recipe_name>fresh_fuel</recipe_name>"
+///     "<capacity>10</capacity>";
+///
+/// int dur = 10;
+/// cyclus::MockSim sim(cyclus::AgentSpec(":agents:Source"), config, dur);
+/// sim.AddSink("enriched_u").Finalize();
+/// sim.AddRecipe("fresh_fuel", fresh);
+/// sim.Run();
+///
+/// @endcode
+///
+/// Querying the results can be accomplished by getting a reference to the
+/// in-memory database generated.  Not all data that is present in normal
+/// full-stack simulations is available.  However, most of the key core tables
+/// are fully available.  Namely, the Transactions, Composition, Resources,
+/// ResCreators, AgentEntry, and AgentExit tables are available.  Any
+/// custom-tables created by the tested archetype will also be available.  Here
+/// is a sample query and test you might write if using the googletest
+/// framework:
+///
+/// @code
+///
+///  cyclus::QueryResult qr = sim.db().Query("Transactions", NULL);
+///  int n_trans = qr.rows.size();
+///  EXPECT_EQ(10, n_trans) << "expected 10 transactions, got " << n_trans;
+///
+/// @endcode
 class MockSim {
  public:
+
+  /// Creates and initializes a new mock simulation environment to test the
+  /// archetype identified by spec.  config should contain the
+  /// archetype-specific xml snippet excluding the wrapping "<config>" and
+  /// "<[AgentName]>" tags.  duration is the length of the simulation in time
+  /// steps.
   MockSim(AgentSpec spec, std::string config, int duration);
 
+  /// AddSource adds a source facility that can offer/provide material to the
+  /// archetype being tested.  commod specifies the commodity the source will
+  /// offer on. AddSource can be called multiple times to generate many sources
+  /// for the simulation.  The returned MockAgent object has several functions
+  /// that can be called to configure the source's behavior further.  Don't
+  /// forget to call the MockAgent object's "Finalize" function when you are
+  /// done configuring it.  MockAgent's functions support chaining:
+  ///
+  /// @code
+  ///
+  /// cyclus::MockSim sim(...);
+  /// sim.AddSource("fresh_mox")
+  ///    .start(7).lifetime(3).recipe("mox_fuel")
+  ///    .Finalize();
+  ///
+  /// @endcode
   MockAgent AddSource(std::string commod);
+
+  /// AddSink adds a sink facility that can request+receive material from the
+  /// archetype being tested.  commod specifies the commodity the sink will
+  /// request on. AddSink can be called multiple times to generate many sinks
+  /// for the simulation.  The returned MockAgent object has several functions
+  /// that can be called to configure the sink's behavior further.  Don't
+  /// forget to call the MockAgent object's "Finalize" function when you are
+  /// done configuring it.  MockAgent's functions support chaining:
+  ///
+  /// @code
+  ///
+  /// cyclus::MockSim sim(...);
+  /// sim.AddSink("spent_mox")
+  ///    .start(7).lifetime(3).recipe("spent_fresh_mox")
+  ///    .Finalize();
+  ///
+  /// @endcode
   MockAgent AddSink(std::string commod);
+
+  /// AddRecipe adds a recipe to the mock simulation environment (i.e. to the
+  /// simulation context).  Any recipes that your archetype expects to find in
+  /// the simulation context must be added this way; if the xml configuration
+  /// snippet for the archetype being tested contains a recipe name, add it
+  /// with this function.
   void AddRecipe(std::string name, Composition::Ptr c);
+
+  /// Run the simulation.  This can only be called once.  After the simulation
+  /// has been run, this MockSim object CANNOT be reused to run other
+  /// simulations.
   void Run();
+
+  /// Returns the underlying in-memory database containing results for
+  /// the simulation.  Run must be called before the database will contain
+  /// anything.
   SqliteBack& db();
-  
+
  private:
   Context ctx_;
   Timer ti_;

--- a/src/mock_sim.h
+++ b/src/mock_sim.h
@@ -51,8 +51,8 @@ class MockAgent {
 
   /// Finalize MUST be called after configuration is complete to actually
   /// create the source/sink agent (or schedule it to be built). The
-  /// auto-generated name of the created prototype is returned to support
-  /// querying based on specific sources/sinks.
+  /// auto-generated prototype name of the created prototype is returned to
+  /// support querying based on specific sources/sinks.
   std::string Finalize();
 
  private:
@@ -171,8 +171,9 @@ class MockSim {
 
   /// Run the simulation.  This can only be called once.  After the simulation
   /// has been run, this MockSim object CANNOT be reused to run other
-  /// simulations.
-  void Run();
+  /// simulations.  Run returns the agent ID for the agent being tested for
+  /// use in queries.
+  int Run();
 
   /// Returns the underlying in-memory database containing results for
   /// the simulation.  Run must be called before the database will contain

--- a/src/mock_sim.h
+++ b/src/mock_sim.h
@@ -1,0 +1,58 @@
+#ifndef CYCLUS_SRC_MOCK_SIM_H_
+#define CYCLUS_SRC_MOCK_SIM_H_
+
+#include "cyclus.h"
+#include "sqlite_back.h"
+#include "timer.h"
+
+namespace cyclus {
+
+class Source;
+class Sink;
+
+class MockAgent {
+  public:
+    MockAgent(Context* ctx, Recorder* rec, SqliteBack* b, bool is_source);
+
+    MockAgent commod(std::string commod);
+    MockAgent recipe(std::string recipe);
+    MockAgent capacity(double cap);
+    MockAgent start(int timestep);
+    MockAgent lifetime(int duration);
+    // returns the name of the created prototype
+    std::string Finalize();
+   
+  private:
+    static int nextid_;
+    bool source_;
+    std::string commod_;
+    std::string recipe_;
+    double cap_;
+    int start_;
+    int lifetime_;
+    std::string proto_;
+    Context* ctx_;
+    Recorder* rec_;
+    SqliteBack* back_;
+};
+
+class MockSim {
+ public:
+  MockSim(AgentSpec spec, std::string config, int duration);
+
+  MockAgent AddSource(std::string commod);
+  MockAgent AddSink(std::string commod);
+  void AddRecipe(std::string name, Composition::Ptr c);
+  void Run();
+  SqliteBack& db();
+  
+ private:
+  Context ctx_;
+  Timer ti_;
+  Recorder rec_;
+  SqliteBack* back_;
+};
+
+}  // namespace cyclus
+
+#endif  // CYCLUS_SRC_MOCK_SIM_H_

--- a/src/sqlite_back.cc
+++ b/src/sqlite_back.cc
@@ -251,6 +251,10 @@ std::set<std::string> SqliteBack::Tables() {
   return rtn;
 }
 
+SqliteDb& SqliteBack::db() {
+  return db_;
+}
+
 QueryResult SqliteBack::GetTableInfo(std::string table) {
   std::string sql = "SELECT Field,Type FROM FieldTypes WHERE TableName = '" +
                     table + "';";

--- a/src/sqlite_back.h
+++ b/src/sqlite_back.h
@@ -39,6 +39,10 @@ class SqliteBack: public FullBackend {
 
   virtual std::set<std::string> Tables();
 
+  /// Returns the underlying sqlite database. Only use this if you really know
+  /// what you are doing.
+  SqliteDb& db();
+
  private:
   void Bind(boost::spirit::hold_any v, DbTypes type, SqlStatement::Ptr stmt, int index);
 

--- a/tests/mock_sim_tests.cc
+++ b/tests/mock_sim_tests.cc
@@ -1,0 +1,76 @@
+
+#include "cyclus.h"
+#include <gtest/gtest.h>
+
+using pyne::nucname::id;
+
+namespace cyclus {
+
+TEST(MockTests, Source) {
+  cyclus::CompMap m;
+  m[id("U235")] = .05;
+  m[id("U238")] = .95;
+  Composition::Ptr fresh = Composition::CreateFromMass(m);
+
+  std::string config =
+      "<commod>enriched_u</commod>"
+      "<recipe_name>fresh_fuel</recipe_name>"
+      "<capacity>10</capacity>";
+
+  int dur = 10;
+  cyclus::MockSim sim(cyclus::AgentSpec(":agents:Source"), config, dur);
+  sim.AddSink("enriched_u").Finalize();
+  sim.AddRecipe("fresh_fuel", fresh);
+
+  EXPECT_NO_THROW(sim.Run());
+
+  SqliteBack b = sim.db();
+
+  QueryResult qr = b.Query("AgentEntry", NULL);
+  EXPECT_EQ(2, qr.rows.size()) << "expected 2 agents, got " << qr.rows.size();
+  EXPECT_EQ(":agents:Source", qr.GetVal<std::string>("Spec", 0));
+  EXPECT_EQ(":agents:Sink", qr.GetVal<std::string>("Spec", 1));
+
+  qr = b.Query("Transactions", NULL);
+  EXPECT_EQ(dur, qr.rows.size()) << "expected " << dur << " transactions, got "
+                                 << qr.rows.size();
+  for (int i = 0; i < qr.rows.size(); i++) {
+    int transaction_t = qr.GetVal<int>("Time", i);
+    EXPECT_EQ(i, transaction_t);
+  }
+}
+
+TEST(MockTests, Sink) {
+  cyclus::CompMap m;
+  m[id("U235")] = .05;
+  m[id("U238")] = .95;
+  Composition::Ptr fresh = Composition::CreateFromMass(m);
+
+  std::string config =
+      "<in_commods><val>enriched_u</val></in_commods>"
+      "<recipe_name>fresh_fuel</recipe_name>"
+      "<capacity>10</capacity>";
+
+  int dur = 10;
+  cyclus::MockSim sim(cyclus::AgentSpec(":agents:Sink"), config, dur);
+  sim.AddSource("enriched_u").Finalize();
+  sim.AddRecipe("fresh_fuel", fresh);
+
+  EXPECT_NO_THROW(sim.Run());
+  SqliteBack b = sim.db();
+
+  QueryResult qr = b.Query("AgentEntry", NULL);
+  EXPECT_EQ(2, qr.rows.size()) << "expected 2 agents, got " << qr.rows.size();
+  EXPECT_EQ(":agents:Sink", qr.GetVal<std::string>("Spec", 0));
+  EXPECT_EQ(":agents:Source", qr.GetVal<std::string>("Spec", 1));
+
+  qr = b.Query("Transactions", NULL);
+  EXPECT_EQ(dur, qr.rows.size()) << "expected " << dur << " transactions, got "
+                                 << qr.rows.size();
+  for (int i = 0; i < qr.rows.size(); i++) {
+    int transaction_t = qr.GetVal<int>("Time", i);
+    EXPECT_EQ(i, transaction_t);
+  }
+}
+
+}  // namespace cyclus


### PR DESCRIPTION
This isn't done yet - it still needs api docs and dev guide docs.  But I wanted to hear thoughts/suggestions before I start polishing it up.  It allows someone to write code like this:

```c++
cyclus::CompMap m;
m[id("U238")] = 1.0;
Composition::Ptr depleted = Composition::CreateFromMass(m);

std::string config =
    "<commod>enriched_u</commod>"
    "<recipe_name>depleted</recipe_name>"
    "<capacity>10</capacity>";

int dur = 10;
cyclus::MockSim sim(cyclus::AgentSpec(":agents:Source"), config, dur);
sim.AddSink("enriched_u").Finalize();
sim.AddRecipe("depleted", depleted);
sim.Run();
```

And then you can write gtest tests like this:

```c++
QueryResult qr = sim.db().Query("Transactions", NULL);
EXPECT_EQ(10, qr.rows.size()) << "expected 10 transactions, got " << qr.rows.size();
```

You can add as many sources and sinks as you like all on different commodities.  They can also be specified to be deployed+decommissioned at arbitrary times throughout the simulation.  In this way you can simulated capacity and recipe changes over time of sources/sinks.  I had to make a couple of mods to cyclus source and sink to accommodate this.  Since we want this to be useful for testing all archetypes, not just cycamore, it seemed appropriate to use the cyclus source and sink - after all we originally created them  to serve testing purposes.