### PR TITLE
updates decommisioning behavior such that an agent with a lifetime of 1 ...

### DIFF
--- a/agents/sink.h
+++ b/agents/sink.h
@@ -67,7 +67,7 @@ class Sink : public cyclus::Facility  {
   virtual void Build(cyclus::Agent* parent) {
     Facility::Build(parent);
     if (lifetime() >= 0) {
-      context()->SchedDecom(this, enter_time() + lifetime());
+      context()->SchedDecom(this, exit_time());
     }
   }
 

--- a/agents/source.h
+++ b/agents/source.h
@@ -81,7 +81,7 @@ class Source : public cyclus::Facility {
   virtual void Build(cyclus::Agent* parent) {
     Facility::Build(parent);
     if (lifetime() >= 0) {
-      context()->SchedDecom(this, enter_time() + lifetime());
+      context()->SchedDecom(this, exit_time());
     }
   }
 

--- a/src/agent.h
+++ b/src/agent.h
@@ -381,12 +381,12 @@ class Agent : public StateWrangler, virtual public Ider {
 
   /// Returns the default time step at which this agent will exit the
   /// simulation (-1 if the agent has an infinite lifetime).
-  //
-  // The "- 1" is because deomissioning happens at the end of a time step.
-  // For a lifetime of 1, we expect an agent to go through only 1 entire
-  // time step.  In this case, the agent should be decommissioned on the
-  // same time step it was created.  So we need "- 1" for lifetime to have
-  // this correct meaning.
+  ///
+  /// Deomissioning happens at the end of a time step. With a lifetime of 1, we
+  /// expect an agent to go through only 1 entire time step. In this case, the
+  /// agent should be decommissioned on the same time step it was
+  /// created. Therefore, for agents with non-infinite lifetimes, the exit_time
+  /// will be the enter time plus its lifetime less 1.
   inline const int exit_time() const {
     if (lifetime() == -1)
       return -1;

--- a/src/agent.h
+++ b/src/agent.h
@@ -379,6 +379,20 @@ class Agent : public StateWrangler, virtual public Ider {
   /// decommissioning (-1 if the agent has an infinite lifetime).
   inline const int lifetime() const { return lifetime_; }
 
+  /// Returns the default time step at which this agent will exit the
+  /// simulation (-1 if the agent has an infinite lifetime).
+  //
+  // The "- 1" is because deomissioning happens at the end of a time step.
+  // For a lifetime of 1, we expect an agent to go through only 1 entire
+  // time step.  In this case, the agent should be decommissioned on the
+  // same time step it was created.  So we need "- 1" for lifetime to have
+  // this correct meaning.
+  inline const int exit_time() const {
+    if (lifetime() == -1)
+      return -1;
+    return enter_time_ + lifetime_ - 1;
+  }
+
   /// Returns a list of children this agent has
   inline const std::set<Agent*>& children() const { return children_; }
 

--- a/src/institution.cc
+++ b/src/institution.cc
@@ -52,7 +52,7 @@ void Institution::Tock() {
   for (it = children().begin(); it != children().end(); ++it) {
     Facility* child = dynamic_cast<Facility*>(*it);
     int lifetime = child->lifetime();
-    if (lifetime != -1 && context()->time() >= child->enter_time() + lifetime) {
+    if (lifetime != -1 && context()->time() >= child->exit_time()) {
       CLOG(LEV_INFO3) << child->prototype()
                       << " has reached the end of its lifetime";
       if (child->CheckDecommissionCondition()) {


### PR DESCRIPTION
...built at t_0 will also be decommissioned at t_0, such that it will experience one full time step

This adds to the agent API an `exit_time` function. `-1` is returned if the agent has an 'infinite' lifetime. Otherwise, the total number of time steps - 1 is returned, per the associated [discussion](https://groups.google.com/forum/#!topic/cyclus-dev/jt29aJGkIdM).