### PR TITLE
Fix feed qty

### DIFF
--- a/cli/cycpp.py
+++ b/cli/cycpp.py
@@ -1491,7 +1491,7 @@ class AnnotationsFilter(CodeGeneratorFilter):
         jstr = json.dumps(ctx, separators=(',', ':'))
         if len(jstr) > 50:
             tw = textwrap.wrap(jstr, 50, drop_whitespace=False)
-            jstr = [j.replace('"', '\\"') for j in tw]
+            jstr = [j.replace('\\', '\\\\').replace('"', '\\"') for j in tw]
             jstr = ('"\n  ' + ind + '"').join(jstr)
             jstr = '\n  ' + ind + '"' + jstr + '"'
         else:

--- a/src/toolkit/enrichment.cc
+++ b/src/toolkit/enrichment.cc
@@ -75,6 +75,12 @@ double TailsQty(double product_qty, const Assays& assays) {
   return product_qty * factor;
 }
 
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+double NonFissileMultiplier(cyclus::Material::Ptr matl) {
+  cyclus::toolkit::MatQuery mq(matl);
+  return mq.qty()/(mq.mass(922350000) + mq.mass(922380000));
+}
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 double ValueFunc(double frac) {
   if (frac < 0) {

--- a/src/toolkit/enrichment.h
+++ b/src/toolkit/enrichment.h
@@ -31,7 +31,7 @@ class Assays {
 };
 
 /// @param mat the material inquired about
-/// @return the atom percent of U-235 w.r.t Uranium in a material
+/// @return the atom percent of U-235 w.r.t U-235+U-238 in a material
 double UraniumAssay(Material::Ptr mat);
 
 /// inline double UraniumAssay(Material::Ptr mat) {
@@ -45,7 +45,8 @@ double UraniumQty(Material::Ptr mat);
 
 /// inline double UraniumQty(Material::Ptr mat) { return UraniumQty(mat.get()); }
 
-/// @param product_qty the amount of product Uranium
+/// @param product_qty the amount of product Uranium,
+/// assuming feed is comprised of only fissile material (U-235,U-238)
 /// @param assays the assay of product, feed, and tails
 /// @return the quantity of feedstock required to make the product
 /// whose units match those of the given product
@@ -56,6 +57,14 @@ double FeedQty(double product_qty, const Assays& assays);
 /// @return the quantity of tails resulting from enriching the product
 /// whose units match those of the given product
 double TailsQty(double product_qty, const Assays& assays);
+
+/// @param feed_matl pointer to material
+/// @return ratio of (total mass)/(fissile mass)
+/// Can be used to convert amnt of necessary fissile material
+/// (from FeedQty) into necessary amount of raw material when
+/// non-fissile components are present.  Returns 1 when material
+/// is entirely comprised of U-235 + U-238
+double NonFissileMultiplier(cyclus::Material::Ptr matl);
 
 /// @param product_qty the amount of product Uranium
 /// @param assays the assay of product, feed, and tails

--- a/tests/toolkit/enrichment_tests.cc
+++ b/tests/toolkit/enrichment_tests.cc
@@ -26,7 +26,7 @@ void EnrichmentTests::SetUp() {
 
   assay_u_ = product_;
   mass_u_ = 10;
-
+  
   Timer ti;
   Recorder rec;
   Context ctx(&ti, &rec);
@@ -92,6 +92,30 @@ TEST_F(EnrichmentTests, enrichmentcalcs) {
   EXPECT_DOUBLE_EQ(tails_qty_, TailsQty(product_qty, assays));
   EXPECT_NEAR(swu_, SwuRequired(product_qty, assays), 1e-8);
 }
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+TEST_F(EnrichmentTests, nonfissilematl) {
+  // for testing material containing non-fissile components
+  double extra_ = 0.05;
+  double fissile_frac = (1-extra_);
 
+  CompMap v_extra;
+  v_extra[922350000] = assay_u_;
+  v_extra[922390000] = extra_ ;
+  v_extra[922380000] = 1 - assay_u_ - extra_;
+  Composition::Ptr comp_extra = Composition::CreateFromAtom(v_extra);
+  cyclus::Material::Ptr mat_extra_ =
+    Material::CreateUntracked(mass_u_, comp_extra);
+
+  Assays assays(feed_, UraniumAssay(mat_),
+		tails_);
+  double product_qty = UraniumQty(mat_);
+  
+  EXPECT_DOUBLE_EQ(feed_qty_ ,NonFissileMultiplier(mat_)
+	      * FeedQty(product_qty, assays));
+  EXPECT_NEAR(feed_qty_ / fissile_frac,
+		   NonFissileMultiplier(mat_extra_)
+	      * FeedQty(product_qty, assays), 0.05); 
+} 
+ 
 }  // namespace toolkit
 }  // namespace cyclus


### PR DESCRIPTION
Added a toolkit function NonFissileMultiplier that is the ratio of total fuel over fissile material.  This is used when calculating necessary feed quantities for input materials into the enrichment facility that include components beyond U-235 and U-238.  Needed for the new cycamore EnrichmentFacility.

Also updated documentation for UraniumAssay and FeedQty to clarify that they assume the material is entirely comprised of fissile isotopes of uranium.