### PR TITLE
recursive container support for cycpp

### DIFF
--- a/agents/sink.h
+++ b/agents/sink.h
@@ -76,7 +76,6 @@ class Sink : public cyclus::Facility  {
     "tooltip": "input/request recipe name", \
     "doc": "Name of recipe to request." \
            "If empty, sink requests material no particular composition.", \
-    "schematype": "token", \
     "default": "", \
     "uitype": "recipe", \
   }
@@ -85,8 +84,7 @@ class Sink : public cyclus::Facility  {
   #pragma cyclus var {"doc": "commodities that the sink facility " \
                              "accepts", \
                       "tooltip": "input commodities for the sink", \
-                      "schematype": "token", \
-                      "uitype": "incommodity"}
+                      "uitype": ["oneormore", "incommodity"]}
   std::vector<std::string> in_commods;
 
   #pragma cyclus var {"doc": "capacity the sink facility can " \

--- a/cli/cycpp.py
+++ b/cli/cycpp.py
@@ -123,15 +123,9 @@ def escape_xml(s, ind='    '):
     lines = s.splitlines()
     lines = lines[1:] # remove initial xml version tag
 
-    clean = []
-    for line in lines:
-        if line.strip() != '':
-            clean.append(line)
-
-    for i, line in enumerate(clean):
-        clean[i] = '{0}"{1}\\n"'.format(ind, line.rstrip())
-
-    return '\n'.join(clean)
+    clean = [line for line in lines if len(line.strip()) != 0]
+    cleaner = ['{0}"{1}\\n"'.format(ind, line.rstrip()) for line in clean]
+    return '\n'.join(cleaner)
 
 def prepare_type(cpptype, othertype):
     """Updates othertype to conform to the length of cpptype using None's.

--- a/cli/cycpp.py
+++ b/cli/cycpp.py
@@ -1976,35 +1976,6 @@ class Proxy(MutableMapping):
     def __contains__(self, key):
         return key in self.__dict__['_d']
 
-class Indenter(object):
-    def __init__(self, n=2, level=0):
-        str.__init__(self)
-        self._n = int(n)
-        self._level = int(level)
-
-    def __add__(self, other):
-        return '{0}{1}'.format(self, other)
-
-    def __radd__(self, other):
-        return '{0}{1}'.format(self, other)
-
-    def __concat__(self, other):
-        return '{0}{1}'.format(self, other)
-
-    def __str__(self):
-        return ' '*self._n*self._level
-
-    def __repr__(self):
-        return ' '*self._n*self._level
-
-    def up(self):
-        self._level += 1
-        return Indenter(n=self._n, level=self._level-1)
-
-    def down(self):
-        self._level -= 1
-        return Indenter(n=self._n, level=self._level)
-
 def outter_split(s, open_brace='(', close_brace=')', separator=','):
     """Takes a string and only split the outter most level."""
     outter = []

--- a/cli/cycpp.py
+++ b/cli/cycpp.py
@@ -1568,7 +1568,6 @@ class SchemaFilter(CodeGeneratorFilter):
         xml += '</interleave>'
 
         del self._member
-        print(xml)
         return ind + 'return ""\n' + escape_xml(xml, ind=ind+'  ') + ';\n'
 
 

--- a/cli/cycpp.py
+++ b/cli/cycpp.py
@@ -1395,10 +1395,10 @@ class InfileToDbFilter(CodeGeneratorFilter):
                     ind += '  '
 
                 mname = member + '_val'
-                impl += '{'
-                impl += reader(mname, labels, t, uitype, ind)
-                impl += '{0} = {1};'.format(member, mname)
-                impl += '}'
+                impl += ind + '{\n'
+                impl += reader(mname, labels, t, uitype, ind+'  ')
+                impl += ind + '  {0} = {1};\n'.format(member, mname)
+                impl += ind + '}\n'
 
                 # generate code to assign default val if no other is specified
                 if d is not None:
@@ -1406,9 +1406,8 @@ class InfileToDbFilter(CodeGeneratorFilter):
                     impl += ind + '} else {\n'
                     ind += '  '
                     mname = member + '_tmp'
-                    val = self._val(t, val=d, name=mname, uitype=uitype)
-                    val += '{0} = {1};'.format(member, mname)
-                    impl += ind + val.replace('\n', '\n' + ind)
+                    impl += self._val(t, val=d, name=mname, uitype=uitype, ind=ind)
+                    impl += ind + '{0} = {1};\n'.format(member, mname)
                     ind = ind[:-2]
                     impl += ind + '}\n'
 

--- a/cli/cycpp.py
+++ b/cli/cycpp.py
@@ -141,12 +141,9 @@ def prepare_type(cpptype, othertype):
             othertype = [othertype]
 
         if othertype is None:
-            othertype = []
-            for v in cpptype:
-                othertype.append(None)
+            othertype = [None] * len(cpptype)
         elif len(othertype) < len(cpptype):
-            for i in range(len(cpptype)-len(othertype)):
-                othertype.append(None)
+            othertype.extend([None] * (len(cpptype) - len(othertype)))
         return othertype
     else:
         return othertype
@@ -1110,7 +1107,7 @@ class InfileToDbFilter(CodeGeneratorFilter):
         if isinstance(val, STRING_TYPES):
             v += '"{0}"'.format(val)
         elif isinstance(val, uuid.UUID):
-            l = [x+y for x,y in zip(val.hex[::1], val.hex[1::2])]
+            l = [x+y for x, y in zip(val.hex[::1], val.hex[1::2])]
             v += '{0x' + ', 0x'.join(l) + '}'
         else:
             msg = "could not interpret UUID type of {0}"
@@ -1486,15 +1483,12 @@ class SchemaFilter(CodeGeneratorFilter):
             name = 'map'
             if names[0] is not None:
                 name = names[0]
-
             keynames = 'key' if isinstance(cpptype[1], STRING_TYPES) else ['key']
             if names[1] is not None:
                 keynames = names[1]
-
             valnames = 'val' if isinstance(cpptype[2], STRING_TYPES) else ['val']
             if names[1] is not None:
                 valnames = names[2]
-
             impl += '<element name="{0}">'.format(name)
             impl += '<oneOrMore>'
             impl += self._buildschema(cpptype[1], schematype[1], uitype[1], keynames)
@@ -1505,15 +1499,12 @@ class SchemaFilter(CodeGeneratorFilter):
             name = 'pair'
             if names[0] is not None:
                 name = names[0]
-
             firstname = 'first' if isinstance(cpptype[1], STRING_TYPES) else ['first']
             if names[1] is not None:
                 firstname = names[1]
-
             secondname = 'second' if isinstance(cpptype[2], STRING_TYPES) else ['second']
             if names[2] is not None:
                 secondname = names[2]
-
             impl += '<element name="{0}">'.format(name)
             impl += self._buildschema(cpptype[1], schematype[1], uitype[1], firstname)
             impl += self._buildschema(cpptype[2], schematype[2], uitype[2], secondname)

--- a/cli/cycpp.py
+++ b/cli/cycpp.py
@@ -117,7 +117,7 @@ def escape_xml(s, ind='    '):
     """Escapes xml string s, prettifies it and puts in c++ string lit form."""
 
     s = xml.dom.minidom.parseString(s)
-    s = s.toprettyxml()
+    s = s.toprettyxml(indent='    ')
     s = s.replace('"', '\\"')
 
     lines = s.splitlines()
@@ -129,8 +129,6 @@ def escape_xml(s, ind='    '):
             clean.append(line)
 
     for i, line in enumerate(clean):
-        if line.strip() == '':
-            continue
         clean[i] = '{0}"{1}\\n"'.format(ind, line.rstrip())
 
     return '\n'.join(clean)
@@ -1167,8 +1165,11 @@ class InfileToDbFilter(CodeGeneratorFilter):
         fname, sname = 'first', 'second'
         first = self._val(ftype, val=val[0], uitype=uitype[1], name=fname)
         second = self._val(stype, val=val[1], uitype=uitype[2], name=sname)
-        v = '{0} {1} {2} {3}({4}, {5});'.format(
-                first, second, type_to_str(t), name, fname, sname)
+        v = '{0} {1};'.format(type_to_str(t), name)
+        v += '{'
+        v += '{0} {1} {2}.first = {3}; {2}.second = {4};'.format(
+                first, second, name, fname, sname)
+        v += '}'
         return v
 
     def _val_map(self, t, val=None, name=None, uitype=None):

--- a/tests/cycpp_tests.py
+++ b/tests/cycpp_tests.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import uuid
+import pprint
 from collections import OrderedDict
 
 import nose
@@ -591,6 +592,37 @@ def test_schemafilter_buildschema():
     want = '"<element name=\\"streams\\">\\n"\n"<oneOrMore>\\n"\n"<element name=\\"name\\">\\n"\n"<data type=\\"string\\" />\\n"\n"</element>\\n"\n"<element name=\\"efficiencies\\">\\n"\n"<oneOrMore>\\n"\n"<element name=\\"val\\">\\n"\n"<data type=\\"double\\" />\\n"\n"</element>\\n"\n"</oneOrMore>\\n"\n"</element>\\n"\n"</oneOrMore>\\n"\n"</element>\\n"\n'
     got = f._buildschema(cpptype, schematype, uitype, names)
     yield assert_equal, want, got
+
+def test_infiletodb_read_member():
+    m = MockCodeGenMachine()
+    m.context = {"MyFactory": OrderedDict([('vars', OrderedDict([
+            ('x', {'type': 'int', 'uitype': 'nuclide'}),
+            ]))
+            ])}
+    f = InfileToDbFilter(m)
+
+    print('gen:')
+    cpptype = ('std::map', 'std::string', ('std::vector', ('std::vector', ('std::pair', 'double', ('std::pair', 'int', ('std::list', 'bool'))))))
+    alias = ['streams', 'name', ['efficiencies', 'val']]
+    gen = f.read_member('mymap', alias, cpptype, uitype=None)
+    print('foobarbaz')
+    pprint.pprint(gen)
+    assert_equal(False, True)
+
+def test_infiletodb_val():
+    m = MockCodeGenMachine()
+    m.context = {"MyFactory": OrderedDict([('vars', OrderedDict([
+            ('x', {'type': 'int', 'uitype': 'nuclide'}),
+            ]))
+            ])}
+    f = InfileToDbFilter(m)
+
+    cpptype = ('std::map', 'std::string', ('std::vector', 'double'))
+    val = {'one': [1, 1, 1], 'two': [2, 2, 2], 'three':[]}
+    gen = f._val(cpptype, val=val, name='mymap', uitype=None)
+    print('gen:')
+    pprint.pprint(gen)
+    assert_equal(False, True)
 
 def test_nuclide_uitype():
     m = MockCodeGenMachine()

--- a/tests/cycpp_tests.py
+++ b/tests/cycpp_tests.py
@@ -568,6 +568,30 @@ def test_defpragmafilter():
     m = MockCodeGenMachine()
     f = DefaultPragmaFilter(m)
 
+def test_schemafilter_buildschema():
+    m = MockCodeGenMachine()
+    m.context = {"MyFactory": OrderedDict([('vars', OrderedDict([
+            ('x', {'type': 'int', 'uitype': 'nuclide'}),
+            ]))
+            ])}
+    f = SchemaFilter(m)
+
+    schematype = None
+    uitype = None
+    names = None
+
+    cpptype = ['std::map', 'std::string', ['std::vector', 'double']]
+    names = ['streams']
+    want = '"<element name=\\"streams\\">\\n"\n"<oneOrMore>\\n"\n"<element name=\\"key\\">\\n"\n"<data type=\\"string\\" />\\n"\n"</element>\\n"\n"<element name=\\"val\\">\\n"\n"<oneOrMore>\\n"\n"<element name=\\"val\\">\\n"\n"<data type=\\"double\\" />\\n"\n"</element>\\n"\n"</oneOrMore>\\n"\n"</element>\\n"\n"</oneOrMore>\\n"\n"</element>\\n"\n'
+    got = f._buildschema(cpptype, schematype, uitype, names)
+    yield assert_equal, want, got
+
+    cpptype = ['std::map', 'std::string', ['std::vector', 'double']]
+    names = ['streams', 'name', ['efficiencies', 'val']]
+    want = '"<element name=\\"streams\\">\\n"\n"<oneOrMore>\\n"\n"<element name=\\"name\\">\\n"\n"<data type=\\"string\\" />\\n"\n"</element>\\n"\n"<element name=\\"efficiencies\\">\\n"\n"<oneOrMore>\\n"\n"<element name=\\"val\\">\\n"\n"<data type=\\"double\\" />\\n"\n"</element>\\n"\n"</oneOrMore>\\n"\n"</element>\\n"\n"</oneOrMore>\\n"\n"</element>\\n"\n'
+    got = f._buildschema(cpptype, schematype, uitype, names)
+    yield assert_equal, want, got
+
 def test_nuclide_uitype():
     m = MockCodeGenMachine()
     m.context = {"MyFactory": OrderedDict([('vars', OrderedDict([

--- a/tests/cycpp_tests.py
+++ b/tests/cycpp_tests.py
@@ -24,6 +24,8 @@ from cycpp import CloneFilter, InitFromCopyFilter, \
         InitFromDbFilter, InfileToDbFilter, SchemaFilter, SnapshotFilter, \
         SnapshotInvFilter, InitInvFilter, DefaultPragmaFilter, AnnotationsFilter
 
+import cycpp
+
 class MockMachine(object):
     def __init__(self):
         self.depth = 0
@@ -592,6 +594,24 @@ def test_schemafilter_buildschema():
     want = '"<element name=\\"streams\\">\\n"\n"<oneOrMore>\\n"\n"<element name=\\"name\\">\\n"\n"<data type=\\"string\\" />\\n"\n"</element>\\n"\n"<element name=\\"efficiencies\\">\\n"\n"<oneOrMore>\\n"\n"<element name=\\"val\\">\\n"\n"<data type=\\"double\\" />\\n"\n"</element>\\n"\n"</oneOrMore>\\n"\n"</element>\\n"\n"</oneOrMore>\\n"\n"</element>\\n"\n'
     got = f._buildschema(cpptype, schematype, uitype, names)
     yield assert_equal, want, got
+
+def test_escape_xml():
+    """Test escape_xml"""
+    xml = '<element name="mymap">' \
+          '<element name="key"><text1/></element><element name="val"><text2/></element>' \
+          '</element>'
+    got = cycpp.escape_xml(xml)
+
+    s = '    "<element name=\\"mymap\\">\\n"\n' \
+        '    "	<element name=\\"key\\">\\n"\n' \
+        '    "		<text1/>\\n"\n' \
+        '    "	</element>\\n"\n' \
+        '    "	<element name=\\"val\\">\\n"\n' \
+        '    "		<text2/>\\n"\n' \
+        '    "	</element>\\n"\n' \
+        '    "</element>\\n"'
+
+    yield assert_equal, s, got
 
 def test_infiletodb_read_member():
     m = MockCodeGenMachine()

--- a/tests/cycpp_tests.py
+++ b/tests/cycpp_tests.py
@@ -406,13 +406,6 @@ def test_itdbfilter():
                 '  ->Record();\n')
     yield assert_equal, exp_impl, impl
 
-def check_itdbfilter_val(exp, f, t, v, name, uitype):
-    obs = f._val(t, val=v, name=name, uitype=uitype)
-    print('gotted:')
-    pprint.pprint(obs)
-    print('')
-    assert_equal(exp, obs)
-
 def test_itdbfilter_val():
     """Test InfileToDbFilter._val() Defaults"""
     m = MockCodeGenMachine()
@@ -559,9 +552,10 @@ def test_itdbfilter_val():
              '}\n'),
             ),
         ]
-    for t, v, name, uitype, exp in cases:
-        yield check_itdbfilter_val, exp, f, t, v, name, uitype
 
+    for t, v, name, uitype, exp in cases:
+        obs = f._val(t, val=v, name=name, uitype=uitype)
+        yield assert_equal, exp, obs
 
 def test_schemafilter():
     """Test SchemaFilter"""
@@ -729,59 +723,111 @@ def test_infiletodb_read_member():
     gen = f.read_member('mymap', alias, cpptype, uitype=None)
 
     exp_gen = (
-        'std::map< std::string, std::vector< std::vector< std::pair< double, std::pair< int, std::list< std::set< bool > > > > > > > mymap;{cyclus::InfileTree* bub = sub->SubTree("streams");\n'
-        'cyclus::InfileTree* sub = bub;\n'
-        'int n = sub->NMatches("name");\n'
-        '    std::map< std::string, std::vector< std::vector< std::pair< double, std::pair< int, std::list< std::set< bool > > > > > > > mymap_in;\n'
+        '  std::map< std::string, std::vector< std::vector< std::pair< double, '
+        'std::pair< int, std::list< std::set< bool > > > > > > > mymap;\n'
+        '  {\n'
+        '    cyclus::InfileTree* bub = sub->SubTree("streams");\n'
+        '    cyclus::InfileTree* sub = bub;\n'
+        '    int n = sub->NMatches("name");\n'
+        '    std::map< std::string, std::vector< std::vector< std::pair< double, '
+        'std::pair< int, std::list< std::set< bool > > > > > > > mymap_in;\n'
         '    for (i = 0; i < n; ++i) {\n'
-        '    std::string key;{        std::string key_in = cyclus::Query<std::string>(sub, "name", i);\n'
-        'key = key_in;}    std::vector< std::vector< std::pair< double, std::pair< int, std::list< std::set< bool > > > > > > val;{cyclus::InfileTree* bub = sub->SubTree("efficiencies");\n'
-        'cyclus::InfileTree* sub = bub;\n'
-        'int n = sub->NMatches("val");\n'
-        '        std::vector< std::vector< std::pair< double, std::pair< int, std::list< std::set< bool > > > > > > val_in;\n'
+        '      std::string key;\n'
+        '      {\n'
+        '        std::string key_in = cyclus::Query<std::string>(sub, "name", i);\n'
+        '        key = key_in;\n'
+        '      }\n'
+        '      std::vector< std::vector< std::pair< double, std::pair< int, '
+        'std::list< std::set< bool > > > > > > val;\n'
+        '      {\n'
+        '        cyclus::InfileTree* bub = sub->SubTree("efficiencies");\n'
+        '        cyclus::InfileTree* sub = bub;\n'
+        '        int n = sub->NMatches("val");\n'
+        '        std::vector< std::vector< std::pair< double, std::pair< int, '
+        'std::list< std::set< bool > > > > > > val_in;\n'
         '        val_in.resize(n);\n'
         '        for (i = 0; i < n; ++i) {\n'
-        '        std::vector< std::pair< double, std::pair< int, std::list< std::set< bool > > > > > elem;{cyclus::InfileTree* bub = sub->SubTree("val");\n'
-        'cyclus::InfileTree* sub = bub;\n'
-        'int n = sub->NMatches("val");\n'
-        '            std::vector< std::pair< double, std::pair< int, std::list< std::set< bool > > > > > elem_in;\n'
+        '          std::vector< std::pair< double, std::pair< int, std::list< '
+        'std::set< bool > > > > > elem;\n'
+        '          {\n'
+        '            cyclus::InfileTree* bub = sub->SubTree("val");\n'
+        '            cyclus::InfileTree* sub = bub;\n'
+        '            int n = sub->NMatches("val");\n'
+        '            std::vector< std::pair< double, std::pair< int, std::list< '
+        'std::set< bool > > > > > elem_in;\n'
         '            elem_in.resize(n);\n'
         '            for (i = 0; i < n; ++i) {\n'
-        '            std::pair< double, std::pair< int, std::list< std::set< bool > > > > elem;{cyclus::InfileTree* bub = sub->SubTree("val");\n'
-        'cyclus::InfileTree* sub = bub;\n'
-        '                double first;{                    double first_in = cyclus::Query<double>(sub, "first");\n'
-        'first = first_in;}                std::pair< int, std::list< std::set< bool > > > second;{cyclus::InfileTree* bub = sub->SubTree("second");\n'
-        'cyclus::InfileTree* sub = bub;\n'
-        '                    int first;{                        int first_in = cyclus::Query<int>(sub, "first");\n'
-        'first = first_in;}                    std::list< std::set< bool > > second;{cyclus::InfileTree* bub = sub->SubTree("second");\n'
-        'cyclus::InfileTree* sub = bub;\n'
-        'int n = sub->NMatches("val");\n'
+        '              std::pair< double, std::pair< int, std::list< std::set< bool '
+        '> > > > elem;\n'
+        '              {\n'
+        '                cyclus::InfileTree* bub = sub->SubTree("val");\n'
+        '                cyclus::InfileTree* sub = bub;\n'
+        '                  double first;\n'
+        '                  {\n'
+        '                    double first_in = cyclus::Query<double>(sub, '
+        '"first");\n'
+        '                    first = first_in;\n'
+        '                  }\n'
+        '                  std::pair< int, std::list< std::set< bool > > > second;\n'
+        '                  {\n'
+        '                    cyclus::InfileTree* bub = sub->SubTree("second");\n'
+        '                    cyclus::InfileTree* sub = bub;\n'
+        '                      int first;\n'
+        '                      {\n'
+        '                        int first_in = cyclus::Query<int>(sub, "first");\n'
+        '                        first = first_in;\n'
+        '                      }\n'
+        '                      std::list< std::set< bool > > second;\n'
+        '                      {\n'
+        '                        cyclus::InfileTree* bub = sub->SubTree("second");\n'
+        '                        cyclus::InfileTree* sub = bub;\n'
+        '                        int n = sub->NMatches("val");\n'
         '                        std::list< std::set< bool > > second_in;\n'
         '                        for (i = 0; i < n; ++i) {\n'
-        '                        std::set< bool > elem;{cyclus::InfileTree* bub = sub->SubTree("val");\n'
-        'cyclus::InfileTree* sub = bub;\n'
-        'int n = sub->NMatches("val");\n'
+        '                          std::set< bool > elem;\n'
+        '                          {\n'
+        '                            cyclus::InfileTree* bub = '
+        'sub->SubTree("val");\n'
+        '                            cyclus::InfileTree* sub = bub;\n'
+        '                            int n = sub->NMatches("val");\n'
         '                            std::set< bool > elem_in;\n'
         '                            for (i = 0; i < n; ++i) {\n'
-        '                            bool elem;{                                bool elem_in = cyclus::Query<bool>(sub, "val", i);\n'
-        'elem = elem_in;}                              elem_in.insert(elem);\n'
+        '                              bool elem;\n'
+        '                              {\n'
+        '                                bool elem_in = cyclus::Query<bool>(sub, '
+        '"val", i);\n'
+        '                                elem = elem_in;\n'
+        '                              }\n'
+        '                              elem_in.insert(elem);\n'
         '                            }\n'
-        'elem = elem_in;}                          second_in.push_back(elem);\n'
+        '                            elem = elem_in;\n'
+        '                          }\n'
+        '                          second_in.push_back(elem);\n'
         '                        }\n'
-        'second = second_in;}                    std::pair< int, std::list< std::set< bool > > > second_in(first, second);\n'
-        'second = second_in;}                std::pair< double, std::pair< int, std::list< std::set< bool > > > > elem_in(first, second);\n'
-        'elem = elem_in;}              elem_in[i] = elem;\n'
+        '                        second = second_in;\n'
+        '                      }\n'
+        '                    std::pair< int, std::list< std::set< bool > > > '
+        'second_in(first, second);\n'
+        '                    second = second_in;\n'
+        '                  }\n'
+        '                std::pair< double, std::pair< int, std::list< std::set< '
+        'bool > > > > elem_in(first, second);\n'
+        '                elem = elem_in;\n'
+        '              }\n'
+        '              elem_in[i] = elem;\n'
         '            }\n'
-        'elem = elem_in;}          val_in[i] = elem;\n'
+        '            elem = elem_in;\n'
+        '          }\n'
+        '          val_in[i] = elem;\n'
         '        }\n'
-        'val = val_in;}      mymap_in[key] = val;\n'
+        '        val = val_in;\n'
+        '      }\n'
+        '      mymap_in[key] = val;\n'
         '    }\n'
-        'mymap = mymap_in;}'
-        )
+        '    mymap = mymap_in;\n'
+        '  }\n')
 
-    print('gotted:')
-    pprint.pprint(gen)
-    print('')
+    print(gen)
     yield assert_equal, exp_gen, gen
 
 def test_nuclide_uitype():

--- a/tests/cycpp_tests.py
+++ b/tests/cycpp_tests.py
@@ -393,17 +393,10 @@ def test_itdbfilter():
     yield assert_equal, exp_args, args
 
     impl = f.impl()
-    exp_impl = ('  int rawcycpp_shape_y[1] = {42};\n'
-                '  cycpp_shape_y = std::vector<int>(rawcycpp_shape_y, rawcycpp_shape_y + 1);\n'
-                '  cyclus::InfileTree* sub = tree->SubTree("config/*");\n'
-                '  int i;\n'
-                '  int n;\n'
-                '{  int x_val = cyclus::Query<int>(sub, "x");\n'
-                'x = x_val;}THINGFISH\n'
-                '  di.NewDatum("Info")\n'
-                '  ->AddVal("x", x)\n'
-                'ABSOLUTELY FREE\n'
-                '  ->Record();\n')
+    exp_impl = (
+        '  int rawcycpp_shape_y[1] = {42};\n  cycpp_shape_y = std::vector<int>(rawcycpp_shape_y, rawcycpp_shape_y + 1);\n  cyclus::InfileTree* sub = tree->SubTree("config/*");\n  int i;\n  int n;\n  {\n    int x_val = cyclus::Query<int>(sub, "x");\n    x = x_val;\n  }\nTHINGFISH\n  di.NewDatum("Info")\n  ->AddVal("x", x)\nABSOLUTELY FREE\n  ->Record();\n'
+        )
+
     yield assert_equal, exp_impl, impl
 
 def test_itdbfilter_val():
@@ -827,7 +820,6 @@ def test_infiletodb_read_member():
         '    mymap = mymap_in;\n'
         '  }\n')
 
-    print(gen)
     yield assert_equal, exp_gen, gen
 
 def test_nuclide_uitype():
@@ -853,14 +845,7 @@ def test_nuclide_uitype():
     f = InfileToDbFilter(m)
     f.given_classname = 'MyFactory'
     impl = f.impl()
-    exp_impl = (
-        '  cyclus::InfileTree* sub = tree->SubTree("config/*");\n'
-        '  int i;\n'
-        '  int n;\n'
-        '{  int x_val = pyne::nucname::id(cyclus::Query<std::string>(sub, "x"));\n'
-        'x = x_val;}  di.NewDatum("Info")\n'
-        '  ->AddVal("x", x)\n'
-        '  ->Record();\n')
+    exp_impl = '  cyclus::InfileTree* sub = tree->SubTree("config/*");\n  int i;\n  int n;\n  {\n    int x_val = pyne::nucname::id(cyclus::Query<std::string>(sub, "x"));\n    x = x_val;\n  }\n  di.NewDatum("Info")\n  ->AddVal("x", x)\n  ->Record();\n'
 
     yield assert_equal, exp_impl, impl
 


### PR DESCRIPTION
Also cleaned up xml schema generation.  Now it uses xml.dom.minidom to prettify and auto-escapes quotes and backslashes (e.g. for newlines).  This results in custom-schema snippets being much easier for archetype devs to write (and also makes the cyclus.github.com docs about them un-incorrect).

Full disclosure - there are some lines much longer than 80 chars - most/all of these are in the tests and are long because they are 'generated' snippets from the filters used as hybrid regression/unit tests (the unit test factor comes from the fact that I carefully verified the generated snippets to be correct).  In case we ever tweak the filters in the future, we can easily regenerate the changed "regression" snippets and verify correctness.  This is why I don't think it prudent to make them shorter.