### PR TITLE
protected access is not enough - need a setter for Agent::lifetime

### DIFF
--- a/src/agent.cc
+++ b/src/agent.cc
@@ -105,6 +105,13 @@ std::string Agent::str() {
   return ss.str();
 }
 
+void Agent::lifetime(int n_timesteps) {
+  if (enter_time_ != -1) {
+    throw ValueError("cannot set the lifetime of an already-built facility");
+  }
+  lifetime_ = n_timesteps;
+}
+
 bool Agent::AncestorOf(Agent* other) {
   other = other->parent();
   while (other != NULL) {

--- a/src/agent.h
+++ b/src/agent.h
@@ -375,6 +375,12 @@ class Agent : public StateWrangler, virtual public Ider {
   /// the agent has never been built).
   inline const int enter_time() const { return enter_time_; }
 
+  /// Sets the number of time steps this agent operates between building and
+  /// decommissioning (-1 if the agent has an infinite lifetime).  This should
+  /// generally only be called BEFORE an agent is added to a context as a
+  /// prototype.  Throws ValueError if the agent has already been deployed.
+  void lifetime(int n_timesteps);
+
   /// Returns the number of time steps this agent operates between building and
   /// decommissioning (-1 if the agent has an infinite lifetime).
   inline const int lifetime() const { return lifetime_; }
@@ -431,10 +437,10 @@ class Agent : public StateWrangler, virtual public Ider {
   /// subclasses must set this variable in their constructor(s).
   std::string kind_;
 
+ private:
   /// length of time this agent is intended to operate
   int lifetime_;
 
- private:
   /// Prevents creation/use of copy constructors (including in subclasses).
   /// Cloning and InitFrom should be used instead.
   Agent(const Agent& m) {}

--- a/tests/agent_class_tests.cc
+++ b/tests/agent_class_tests.cc
@@ -7,6 +7,18 @@
 
 namespace cyclus {
 
+TEST(AgentClassTests, lifetime) {
+  TestContext tc;
+  Agent* a = new TestAgent(tc.get());
+
+  EXPECT_EQ(-1, a->lifetime());
+  EXPECT_NO_THROW(a->lifetime(42));
+  EXPECT_EQ(42, a->lifetime());
+  a->Build(NULL);
+  EXPECT_THROW(a->lifetime(13), ValueError);
+  EXPECT_EQ(42, a->lifetime());
+}
+
 TEST(AgentClassTests, FamilyTree) {
   TestContext tc;
 


### PR DESCRIPTION
 to enable other agents to manually specify lifetimes.