### PR TITLE
LTEQ Demand Constraint

### DIFF
--- a/src/bid_portfolio.h
+++ b/src/bid_portfolio.h
@@ -58,7 +58,10 @@ class BidPortfolio : public boost::enable_shared_from_this< BidPortfolio<T> > {
 
   /// @brief add a capacity constraint associated with the portfolio
   /// @param c the constraint to add
+  /// @throws ValueError if a GTEQ constraint is added
   inline void AddConstraint(const CapacityConstraint<T>& c) {
+    if (c.cap_type() == GTEQ)
+      throw ValueError("Bids can not have a GTEQ constraint.");
     constraints_.insert(c);
   }
 

--- a/src/capacity_constraint.h
+++ b/src/capacity_constraint.h
@@ -68,6 +68,7 @@ class CapacityConstraint {
   CapacityConstraint(double capacity, typename Converter<T>::Ptr converter)
       : capacity_(capacity),
         converter_(converter),
+        cap_type_(NONE),
         id_(next_id_++) {
     if (capacity_ <= 0)
       throw ValueError("Capacity is not positive, no trades will be executed");
@@ -77,6 +78,7 @@ class CapacityConstraint {
   /// that simply returns 1)
   explicit CapacityConstraint(double capacity)
       : capacity_(capacity),
+        cap_type_(NONE),
         id_(next_id_++) {
     if (capacity_ <= 0)
       throw ValueError("Capacity is not positive, no trades will be executed");
@@ -87,13 +89,23 @@ class CapacityConstraint {
   CapacityConstraint(const CapacityConstraint& other)
       : capacity_(other.capacity_),
         converter_(other.converter_),
-        id_(next_id_++) {}
-
-  /// @return the constraints capacity
-  inline double capacity() const {
-    return capacity_;
+        cap_type_(other.cap_type_),
+        id_(next_id_++) {
+    assert(capacity_ > 0);
   }
 
+  /// capacity getters/setters
+  // @{
+  inline double capacity() const { return capacity_; }
+  inline void capacity(double c) { capacity_ = c; }
+  // @}
+  
+  /// type getters/setters
+  // @{
+  inline cap_t cap_type() const { return cap_type_; }
+  inline void cap_type(cap_t t) const { cap_type_ = t; }
+  // @}
+  
   /// @return the converter
   inline typename Converter<T>::Ptr converter() const {
     return converter_;
@@ -113,6 +125,7 @@ class CapacityConstraint {
 
  private:
   double capacity_;
+  cap_t cap_type_;
   typename Converter<T>::Ptr converter_;
   int id_;
   static int next_id_;
@@ -125,7 +138,8 @@ template<class T>
 inline bool operator==(const CapacityConstraint<T>& lhs,
                        const CapacityConstraint<T>& rhs) {
   return  ((lhs.capacity() == rhs.capacity()) &&
-           (*lhs.converter() == *rhs.converter()));
+           (*lhs.converter() == *rhs.converter()) &&
+           (lhs.cap_type() == rhs.cap_type()));
 }
 
 /// @brief CapacityConstraint-CapacityConstraint comparison operator, allows

--- a/src/capacity_constraint.h
+++ b/src/capacity_constraint.h
@@ -6,6 +6,7 @@
 #include "error.h"
 #include "exchange_graph.h"
 #include "exchange_translation_context.h"
+#include "capacity_types.h"
 
 namespace cyclus {
 

--- a/src/capacity_types.h
+++ b/src/capacity_types.h
@@ -1,0 +1,15 @@
+#ifndef CYCLUS_SRC_CAPACITY_TYPES_H_
+#define CYCLUS_SRC_CAPACITY_TYPES_H_
+
+namespace cyclus {
+
+/// the type of capacity, currently less-than-or-equal-to (LTEQ) and
+/// greater-than-or-equal-to (GTEQ) are supported
+enum CapType {
+  LTEQ = 0,
+  GTEQ,
+} typedef cap_t;
+
+}  // namespace cyclus
+
+#endif  // CYCLUS_SRC_CAPACITY_TYPES_H_

--- a/src/capacity_types.h
+++ b/src/capacity_types.h
@@ -8,6 +8,7 @@ namespace cyclus {
 enum CapType {
   LTEQ = 0,
   GTEQ,
+  NONE, // default
 } typedef cap_t;
 
 }  // namespace cyclus

--- a/src/exchange_graph.h
+++ b/src/exchange_graph.h
@@ -10,6 +10,8 @@
 #include <boost/shared_ptr.hpp>
 #include <boost/weak_ptr.hpp>
 
+#include "capacity_types.h"
+
 namespace cyclus {
 
 class ExchangeNodeGroup;
@@ -135,6 +137,10 @@ class ExchangeNodeGroup {
   const std::vector<double>& capacities() const { return capacities_; }
   std::vector<double>& capacities() { return capacities_; }
 
+  /// @brief the kind of capacities (i.e., LTEQ, GTEQ, EQ) 
+  const std::vector<cap_t>& cap_types() const { return cap_types_; }
+  std::vector<cap_t>& cap_types() { return cap_types_; }
+
   /// @brief Add the node to the ExchangeNodeGroup and informs the node it is a
   /// member of this ExchangeNodeGroup
   virtual void AddExchangeNode(ExchangeNode::Ptr node);
@@ -153,12 +159,26 @@ class ExchangeNodeGroup {
   void AddExclNode(ExchangeNode::Ptr n);
 
   /// @brief Add a flow capacity to the group
-  inline void AddCapacity(double c) { capacities_.push_back(c); }
+  /// @param c the rhs for the capacity
+  /// @param t the capacity type, the default for exchange groups is LTEQ
+  // @{
+  inline virtual void AddCapacity(double c) {
+    capacities_.push_back(c);
+    cap_types_.push_back(LTEQ);
+  }
+  inline void AddCapacity(double c, cap_t t) {
+    capacities_.push_back(c);
+    cap_types_.push_back(t);
+  }
+  // @}
 
+ protected:
+  std::vector<double> capacities_;
+  std::vector<cap_t> cap_types_;
+  
  private:
   std::vector<ExchangeNode::Ptr> nodes_;
   std::vector< std::vector<ExchangeNode::Ptr> > excl_node_groups_;
-  std::vector<double> capacities_;
 };
 
 /// @class RequestGroup
@@ -178,6 +198,16 @@ class RequestGroup : public ExchangeNodeGroup {
   /// the group of exclusive nodes
   virtual void AddExchangeNode(ExchangeNode::Ptr node);
 
+  /// @brief Add a flow capacity to the group
+  /// @param c the rhs for the capacity
+  /// @param t the capacity type, the default for request groups is GTEQ
+  // @{
+  inline virtual void AddCapacity(double c) {
+    capacities_.push_back(c);
+    cap_types_.push_back(GTEQ);
+  }
+  // @}
+  
  private:
   double qty_;
 };

--- a/src/exchange_graph.h
+++ b/src/exchange_graph.h
@@ -206,6 +206,10 @@ class RequestGroup : public ExchangeNodeGroup {
     capacities_.push_back(c);
     cap_types_.push_back(GTEQ);
   }
+  inline void AddCapacity(double c, cap_t t) {
+    capacities_.push_back(c);
+    cap_types_.push_back(t);
+  }
   // @}
   
  private:

--- a/src/exchange_graph.h
+++ b/src/exchange_graph.h
@@ -187,6 +187,7 @@ class ExchangeNodeGroup {
 /// requested quantity.
 class RequestGroup : public ExchangeNodeGroup {
  public:
+  using ExchangeNodeGroup::AddCapacity;
   typedef boost::shared_ptr<RequestGroup> Ptr;
 
   explicit RequestGroup(double qty = 0.0);
@@ -205,10 +206,6 @@ class RequestGroup : public ExchangeNodeGroup {
   inline virtual void AddCapacity(double c) {
     capacities_.push_back(c);
     cap_types_.push_back(GTEQ);
-  }
-  inline void AddCapacity(double c, cap_t t) {
-    capacities_.push_back(c);
-    cap_types_.push_back(t);
   }
   // @}
   

--- a/src/exchange_translator.h
+++ b/src/exchange_translator.h
@@ -165,7 +165,17 @@ RequestGroup::Ptr TranslateRequestPortfolio(
   for (c_it = rp->constraints().begin();
        c_it != rp->constraints().end();
        ++c_it) {
-    rs->AddCapacity(c_it->capacity());
+    switch(c_it->cap_type()) {
+      case GTEQ:
+        rs->ExchangeNodeGroup::AddCapacity(c_it->capacity(), GTEQ);
+        break;
+      case LTEQ:
+        rs->ExchangeNodeGroup::AddCapacity(c_it->capacity(), GTEQ);
+        break;
+      case NONE:
+        rs->AddCapacity(c_it->capacity());
+        break;
+    }
   }
 
   return rs;
@@ -213,7 +223,17 @@ ExchangeNodeGroup::Ptr TranslateBidPortfolio(
   for (c_it = bp->constraints().begin();
        c_it != bp->constraints().end();
        ++c_it) {
-    bs->AddCapacity(c_it->capacity());
+    switch(c_it->cap_type()) {
+      case GTEQ:
+        bs->AddCapacity(c_it->capacity(), GTEQ);
+        break;
+      case LTEQ:
+        bs->AddCapacity(c_it->capacity(), GTEQ);
+        break;
+      case NONE:
+        bs->AddCapacity(c_it->capacity());
+        break;
+    }
   }
 
   return bs;

--- a/src/exchange_translator.h
+++ b/src/exchange_translator.h
@@ -140,12 +140,14 @@ void TranslateConstraints(ExchangeNodeGroup::Ptr g,
                           const std::set< CapacityConstraint<T> >& s) {
   typename std::set< CapacityConstraint<T> >::const_iterator c_it;
   for (c_it = s.begin(); c_it != s.end(); ++c_it) {
-    switch(c_it->cap_type()) {
+    cap_t type = c_it->cap_type(); 
+    switch(type) {
       case NONE:
-        g->AddCapacity(c_it->capacity());
+        // use default value for backwards compatability
+        g->AddCapacity(c_it->capacity()); 
         break;
       default:
-        g->AddCapacity(c_it->capacity(), c_it->cap_type());
+        g->AddCapacity(c_it->capacity(), type);
         break;
     }
   }

--- a/src/exchange_translator.h
+++ b/src/exchange_translator.h
@@ -134,6 +134,23 @@ inline void AddBid(ExchangeTranslationContext<T>& translation_ctx,
   translation_ctx.node_to_bid[n] = b;
 }
 
+/// @brief translate a set of constraints to an exchange node group
+template <class T>
+void TranslateConstraints(ExchangeNodeGroup::Ptr g,
+                          const std::set< CapacityConstraint<T> >& s) {
+  typename std::set< CapacityConstraint<T> >::const_iterator c_it;
+  for (c_it = s.begin(); c_it != s.end(); ++c_it) {
+    switch(c_it->cap_type()) {
+      case NONE:
+        g->AddCapacity(c_it->capacity());
+        break;
+      default:
+        g->AddCapacity(c_it->capacity(), c_it->cap_type());
+        break;
+    }
+  }
+}
+
 /// @brief translates a request portfolio by adding request nodes and
 /// accounting for capacities. Request unit capcities must be added when arcs
 /// are known
@@ -206,22 +223,6 @@ ExchangeNodeGroup::Ptr TranslateBidPortfolio(
   TranslateConstraints(bs, bp->constraints());
   
   return bs;
-}
-
-template <class T>
-void TranslateConstraints(ExchangeNodeGroup::Ptr g,
-                          const std::set< CapacityConstraint<T> >& s) {
-  typename std::set< CapacityConstraint<T> >::const_iterator c_it;
-  for (c_it = s.begin(); c_it != s.end(); ++c_it) {
-    switch(c_it->cap_type()) {
-      case NONE:
-        g->AddCapacity(c_it->capacity());
-        break;
-      default:
-        g->AddCapacity(c_it->capacity(), c_it->cap_type());
-        break;
-    }
-  }
 }
 
 /// @brief translates an arc given a bid and subsequent data, and also

--- a/src/exchange_translator.h
+++ b/src/exchange_translator.h
@@ -161,23 +161,8 @@ RequestGroup::Ptr TranslateRequestPortfolio(
 
   CLOG(LEV_DEBUG4) << "adding " << rp->constraints().size()
                    << " request capacities";
-  typename std::set< CapacityConstraint<T> >::const_iterator c_it;
-  for (c_it = rp->constraints().begin();
-       c_it != rp->constraints().end();
-       ++c_it) {
-    switch(c_it->cap_type()) {
-      case GTEQ:
-        rs->ExchangeNodeGroup::AddCapacity(c_it->capacity(), GTEQ);
-        break;
-      case LTEQ:
-        rs->ExchangeNodeGroup::AddCapacity(c_it->capacity(), GTEQ);
-        break;
-      case NONE:
-        rs->AddCapacity(c_it->capacity());
-        break;
-    }
-  }
-
+  TranslateConstraints(rs, rp->constraints());
+  
   return rs;
 }
 
@@ -218,25 +203,25 @@ ExchangeNodeGroup::Ptr TranslateBidPortfolio(
 
   CLOG(LEV_DEBUG4) << "adding " << bp->constraints().size()
                    << " bid capacities";
+  TranslateConstraints(bs, bp->constraints());
+  
+  return bs;
+}
 
+template <class T>
+void TranslateConstraints(ExchangeNodeGroup::Ptr g,
+                          const std::set< CapacityConstraint<T> >& s) {
   typename std::set< CapacityConstraint<T> >::const_iterator c_it;
-  for (c_it = bp->constraints().begin();
-       c_it != bp->constraints().end();
-       ++c_it) {
+  for (c_it = s.begin(); c_it != s.end(); ++c_it) {
     switch(c_it->cap_type()) {
-      case GTEQ:
-        bs->AddCapacity(c_it->capacity(), GTEQ);
-        break;
-      case LTEQ:
-        bs->AddCapacity(c_it->capacity(), GTEQ);
-        break;
       case NONE:
-        bs->AddCapacity(c_it->capacity());
+        g->AddCapacity(c_it->capacity());
+        break;
+      default:
+        g->AddCapacity(c_it->capacity(), c_it->cap_type());
         break;
     }
   }
-
-  return bs;
 }
 
 /// @brief translates an arc given a bid and subsequent data, and also

--- a/src/greedy_solver.cc
+++ b/src/greedy_solver.cc
@@ -109,7 +109,7 @@ double GreedySolver::Capacity(ExchangeNode::Ptr n, const Arc& a,
 
   double stdmax = std::numeric_limits<double>::max();
   double gtcap = stdmax;
-  double ltcap = -stdmax;
+  double ltcap = stdmax;
   for (int i = 0; i < unit_caps.size(); i++) {
     grp_cap = group_caps[i];
     u_cap = unit_caps[i];
@@ -125,7 +125,7 @@ double GreedySolver::Capacity(ExchangeNode::Ptr n, const Arc& a,
         gtcap = std::min(gtcap, cap);
         break;
       case LTEQ:
-        ltcap = std::max(ltcap, cap);
+        ltcap = std::min(ltcap, cap);
         break;
       default:
           std::stringstream ss;
@@ -134,7 +134,7 @@ double GreedySolver::Capacity(ExchangeNode::Ptr n, const Arc& a,
     }
   }
 
-  if (ltcap == -stdmax) {
+  if (ltcap == stdmax) {
     cap = gtcap; // never saw a LTEQ
   } else if (gtcap == stdmax) {
     cap = ltcap; // never saw a GTEQ

--- a/src/greedy_solver.cc
+++ b/src/greedy_solver.cc
@@ -187,7 +187,7 @@ void GreedySolver::GreedilySatisfySet(RequestGroup::Ptr prs) {
         tomatch = std::min(remain, Capacity(a, n_qty_[u], n_qty_[v]));
 
         // exclusivity adjustment
-        if (arc_it->exclusive()) {
+        if (exclusive_orders_ && arc_it->exclusive()) {
           excl_val = a.excl_val();
           tomatch = (tomatch < excl_val) ? 0 : excl_val;
         }

--- a/src/greedy_solver.h
+++ b/src/greedy_solver.h
@@ -105,27 +105,25 @@ class GreedySolver: public ExchangeSolver {
   ///
   /// @throws StateError if ExchangeNode does not have a ExchangeNodeGroup
   /// @param n the node
-  /// @param min_cap whether to use the minimum or maximum capacity value. In general,
-  /// nodes that represent bids use the minimum (i.e., the capacities represents a
-  /// less-than constraint) and nodes that represent requests use the maximum
-  /// value (i.e., the capacities represents a greater-than constraint).
   /// @param curr_qty the currently allocated node quantity (if solving piecemeal)
   /// @return The minimum of the node's nodegroup capacities / the node's unit
   /// capacities, or the ExchangeNode's remaining qty -- whichever is smaller.
+  /// @{
+  double Capacity(ExchangeNode::Ptr n, const Arc& a, double curr_qty);
+  inline double Capacity(ExchangeNode::Ptr n, const Arc& a) {
+    return Capacity(n, a, 0.0);
+  }
+  /// @}
+
+  /// @warning deprecated!
   /// @{
   double Capacity(ExchangeNode::Ptr n, const Arc& a, bool min_cap,
                   double curr_qty);
   inline double Capacity(ExchangeNode::Ptr n, const Arc& a, bool min_cap) {
     return Capacity(n, a, min_cap, 0.0);
   }
-  inline double Capacity(ExchangeNode::Ptr n, const Arc& a, double curr_qty) {
-    return Capacity(n, a, true, curr_qty);
-  }
-  inline double Capacity(ExchangeNode::Ptr n, const Arc& a) {
-    return Capacity(n, a, true, 0.0);
-  }
-  /// @}
-
+  /// }@
+  
  protected:
   /// @brief the GreedySolver solves an ExchangeGraph by iterating over each
   /// RequestGroup and matching requests with the minimum bids possible, starting

--- a/src/greedy_solver.h
+++ b/src/greedy_solver.h
@@ -149,6 +149,7 @@ class GreedySolver: public ExchangeSolver {
   GreedyPreconditioner* conditioner_;
   std::map<ExchangeNode::Ptr, double> n_qty_;
   std::map<ExchangeNodeGroup*, std::vector<double> > grp_caps_;
+  std::map<ExchangeNodeGroup*, std::vector<cap_t> > cap_types_;
   double obj_;
   double unmatched_;
 };

--- a/src/prog_solver.cc
+++ b/src/prog_solver.cc
@@ -46,10 +46,9 @@ double ProgSolver::SolveGraph() {
       std::cout << "Solving problem, message handler has log level of "
                 << iface->messageHandler()->logLevel() << "\n";
     }
-    bool verbose = false; // turn this off, solveprog prints a lot
 
     // solve and back translate
-    SolveProg(iface, greedy_obj, verbose);
+    SolveProg(iface, greedy_obj, verbose_);
     xlator.FromProg();
   } catch(...) {
     delete iface;

--- a/src/prog_translator.cc
+++ b/src/prog_translator.cc
@@ -117,11 +117,12 @@ void ProgTranslator::XlateCaps(ExchangeNodeGroup* grp,
   int i;
 
   for (i = 0; i != cap_rows.size(); i++) {
-    if (request) {
+    gteq = cap_types[i] == GTEQ;
+
+    if (request && gteq) {
       cap_rows[i].insert(faux_id, 1.0);  // faux arc
     }
 
-    gteq = cap_types[i] == GTEQ;
     ctx.row_lbs.push_back(gteq ? caps[i] : 0);
     ctx.row_ubs.push_back(gteq ? ctx.inf : caps[i]);
     ctx.m.appendRow(cap_rows[i]);

--- a/src/prog_translator.h
+++ b/src/prog_translator.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "CoinPackedMatrix.hpp"
+#include "CoinPackedVector.hpp"
 
 class OsiSolverInterface;
 
@@ -33,8 +34,22 @@ class ProgTranslator {
     std::vector<double> col_ubs;
     std::vector<double> col_lbs;
     CoinPackedMatrix m;
+    double inf;
   };
 
+  /// a helper function to translate capacities
+  ///
+  /// @param grp the exchange group
+  /// @param request whether this is a request or not
+  /// @param faux_id a false arc id for surplus supply
+  /// @param cap_rows the capacity rows which will be appended to
+  /// @param ctx the translation context
+  static void XlateCaps(ExchangeNodeGroup* grp,
+                        bool request,
+                        int faux_id,
+                        std::vector<CoinPackedVector>& cap_rows,
+                        ProgTranslator::Context& ctx);
+  
   /// constructor
   ///
   /// @param g the exchange graph

--- a/tests/bid_portfolio_tests.cc
+++ b/tests/bid_portfolio_tests.cc
@@ -13,26 +13,15 @@
 #include "test_context.h"
 #include "test_agents/test_facility.h"
 
-using cyclus::Bid;
-using cyclus::BidPortfolio;
-using cyclus::CapacityConstraint;
-using cyclus::Converter;
-using cyclus::KeyError;
-using cyclus::Request;
-using cyclus::Material;
-using cyclus::TestContext;
-using std::string;
-using test_helpers::get_mat;
-using test_helpers::TestConverter;
+namespace cyclus {
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 class BidPortfolioTests: public ::testing::Test {
  protected:
   TestContext tc;
   TestFacility* fac1;
   TestFacility* fac2;
-  string commod1;
-  string commod2;
+  std::string commod1;
+  std::string commod2;
 
   Request<Material>* req1;
   Request<Material>* req2;
@@ -52,26 +41,24 @@ class BidPortfolioTests: public ::testing::Test {
   }
 };
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(BidPortfolioTests, RespAdd) {
   BidPortfolio<Material>::Ptr rp(new BidPortfolio<Material>());
   EXPECT_EQ(rp->bids().size(), 0);
-  Bid<Material>* r1 = rp->AddBid(req1, get_mat(), fac1);
+  Bid<Material>* r1 = rp->AddBid(req1, test_helpers::get_mat(), fac1);
   EXPECT_EQ(rp->bidder(), fac1);
   EXPECT_EQ(rp->bids().size(), 1);
   EXPECT_EQ(*rp->bids().begin(), r1);
 
-  EXPECT_THROW(rp->AddBid(req2, get_mat(), fac2), KeyError);
+  EXPECT_THROW(rp->AddBid(req2, test_helpers::get_mat(), fac2), KeyError);
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(BidPortfolioTests, Sets) {
   BidPortfolio<Material>::Ptr rp1(new BidPortfolio<Material>());
   BidPortfolio<Material>::Ptr rp2(new BidPortfolio<Material>());
   BidPortfolio<Material>::Ptr rp3(new BidPortfolio<Material>());
 
-  rp3->AddBid(req1, get_mat(), fac1);
-  rp3->AddBid(req1, get_mat(), fac1);
+  rp3->AddBid(req1, test_helpers::get_mat(), fac1);
+  rp3->AddBid(req1, test_helpers::get_mat(), fac1);
 
   std::set< BidPortfolio<Material>::Ptr > bids;
   EXPECT_EQ(bids.size(), 0);
@@ -98,12 +85,16 @@ TEST_F(BidPortfolioTests, Sets) {
   EXPECT_EQ(bids.count(rp3), 1);
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(BidPortfolioTests, CapAdd) {
-  Converter<Material>::Ptr test_converter(new TestConverter());
+  Converter<Material>::Ptr test_converter(new test_helpers::TestConverter());
   CapacityConstraint<Material> c(5, test_converter);
 
   BidPortfolio<Material>::Ptr rp(new BidPortfolio<Material>());
   EXPECT_NO_THROW(rp->AddConstraint(c));
   EXPECT_EQ(*rp->constraints().begin(), c);
+
+  CapacityConstraint<Material> bad(5, GTEQ, test_converter);
+  EXPECT_THROW(rp->AddConstraint(bad), ValueError);
+}
+
 }

--- a/tests/capacity_constraint_tests.cc
+++ b/tests/capacity_constraint_tests.cc
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include "capacity_constraint.h"
+#include "capacity_types.h"
 #include "composition.h"
 #include "cyc_limits.h"
 #include "material.h"
@@ -94,9 +95,11 @@ TEST(CapacityConstraintTests, Trivial) {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST(CapacityConstraintTests, Equality) {
-  CapacityConstraint<Resource> cc1(val);
-  CapacityConstraint<Resource> cc2(val);
+  CapacityConstraint<Resource> cc1(val, cyclus::GTEQ);
+  CapacityConstraint<Resource> cc2(val, cyclus::GTEQ);
   EXPECT_EQ(cc1, cc2);
+  CapacityConstraint<Resource> cc3(val, cyclus::LTEQ);
+  EXPECT_NE(cc1, cc3);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/tests/exchange_solver_tests.cc
+++ b/tests/exchange_solver_tests.cc
@@ -25,6 +25,13 @@ TEST(ExSolverTests, Interface) {
   EXPECT_EQ(2, s.i);
 }
 
+// Generates a very simple graph to test less-than constraints for requesters
+//
+// The graph is comprised of a single request node and a single bid node. The
+// request is made for 1 unit of resource.
+//
+// Based on consumer_lteq, a constraint is added either by the consumer or the
+// supplier. The same flow is expected in both cases.
 ExchangeGraph* gen(bool consumer_lteq) {
   ExchangeNode::Ptr u(new ExchangeNode());
   ExchangeNode::Ptr v(new ExchangeNode());
@@ -106,6 +113,18 @@ TEST(ExSolverTests, CustomConstraintsProg) {
   delete h;  
 }
 
+// This generates a slightly more complicated graph comprised of a single
+// requester with two bidders.
+//
+// Solvers can turn on and off exclusive trades; both cases are tested.
+//
+// There is a preference differential, with p1 >> p2. Without any LTEQ
+// constraints, the first arc is expected to be satisfied in all cases.
+//
+// A LTEQ is optionally added, where the first arc is constrained, i.e., a_1 >
+// a_2. In the non-exclusive case, the first arc is still met to its maximum
+// value. However, in the exclusive case, the first arc can not meet the total
+// demand, therefore the second arc is engaged.
 ExchangeGraph* gen2(bool consumer_lteq) {
   bool excl = true;
   ExchangeNode::Ptr u(new ExchangeNode(1, excl));
@@ -117,17 +136,13 @@ ExchangeGraph* gen2(bool consumer_lteq) {
   Arc a2(u2, w);
 
   u->unit_capacities[a].push_back(1);
-  u->prefs[a] = 1;
+  u->prefs[a] = 5;
   u2->unit_capacities[a2].push_back(1);
   u2->prefs[a2] = 0.5;
 
   RequestGroup::Ptr gu(new RequestGroup(1));
   gu->AddExchangeNode(u);
   gu->AddExchangeNode(u2);
-  // std::vector<ExchangeNode::Ptr> excl_grp;
-  // excl_grp.push_back(u);
-  // excl_grp.push_back(u2);
-  // gu->AddExclGroup(excl_grp);
   gu->AddCapacity(1);
 
   if (consumer_lteq) {
@@ -138,12 +153,8 @@ ExchangeGraph* gen2(bool consumer_lteq) {
 
   ExchangeNodeGroup::Ptr gv(new ExchangeNodeGroup());
   gv->AddExchangeNode(v);
-  // v->unit_capacities[a].push_back(1);
-  // gv->AddCapacity(1.0);
   ExchangeNodeGroup::Ptr gw(new ExchangeNodeGroup());
   gw->AddExchangeNode(w);
-  // w->unit_capacities[a2].push_back(1);
-  // gw->AddCapacity(1.0);
   
   ExchangeGraph* g = new ExchangeGraph();
   g->AddRequestGroup(gu);
@@ -156,9 +167,10 @@ ExchangeGraph* gen2(bool consumer_lteq) {
 
 
 TEST(ExSolverTests, CustomConstraintsGreedy2) {
-  bool consumer_lteq;
+  // test exclusive trades and non-exclusive trades
   GreedySolver greedy_nex(false);
   GreedySolver greedy_ex(true);
+  bool consumer_lteq;
   
   // test supplier and consumer constraints
   consumer_lteq = false;
@@ -194,29 +206,41 @@ TEST(ExSolverTests, CustomConstraintsGreedy2) {
 }
 
 TEST(ExSolverTests, CustomConstraintsProg2) {
+  // test exclusive trades and non-exclusive trades
   ProgSolver cbc_nex("cbc");
+  ProgSolver cbc_ex("cbc", true);
   bool consumer_lteq;
   
   // test supplier and consumer constraints
   consumer_lteq = false;
   ExchangeGraph* g = gen2(consumer_lteq);
-  Match exp_g = Match(g->arcs().at(0), 1.0);
+  Match exp_gnex = Match(g->arcs().at(0), 1.0);
   cbc_nex.graph(g);
   cbc_nex.Solve();
   ASSERT_EQ(g->matches().size(), 1);
-  EXPECT_EQ(exp_g, g->matches().at(0));
+  EXPECT_EQ(exp_gnex, g->matches().at(0));
   g->ClearMatches();
+  Match exp_gex = Match(g->arcs().at(0), 1.);
+  cbc_ex.graph(g);
+  cbc_ex.Solve();
+  ASSERT_EQ(g->matches().size(), 1);
+  EXPECT_EQ(exp_gex, g->matches().at(0));
   delete g;
 
   // test consumer with LTEQ constraints
   consumer_lteq = true;
   ExchangeGraph* h = gen2(consumer_lteq);
-  Match exp_h = Match(h->arcs().at(0), 0.5);
+  Match exp_hnex = Match(h->arcs().at(0), 0.5);
   cbc_nex.graph(h);
   cbc_nex.Solve();
   ASSERT_EQ(h->matches().size(), 1);
-  EXPECT_EQ(exp_h, h->matches().at(0));
+  EXPECT_EQ(exp_hnex, h->matches().at(0));
   h->ClearMatches();
+  Match exp_hex = Match(h->arcs().at(1), 1.);
+  cbc_ex.graph(h);
+  cbc_ex.Solve();
+  ASSERT_EQ(h->matches().size(), 1);
+  EXPECT_EQ(exp_hex, h->matches().at(0));
   delete h;  
 }
 

--- a/tests/exchange_solver_tests.cc
+++ b/tests/exchange_solver_tests.cc
@@ -106,4 +106,118 @@ TEST(ExSolverTests, CustomConstraintsProg) {
   delete h;  
 }
 
+ExchangeGraph* gen2(bool consumer_lteq) {
+  bool excl = true;
+  ExchangeNode::Ptr u(new ExchangeNode(1, excl));
+  ExchangeNode::Ptr v(new ExchangeNode());
+  Arc a(u, v);
+
+  ExchangeNode::Ptr u2(new ExchangeNode(1, excl));
+  ExchangeNode::Ptr w(new ExchangeNode());
+  Arc a2(u2, w);
+
+  u->unit_capacities[a].push_back(1);
+  u->prefs[a] = 1;
+  u2->unit_capacities[a2].push_back(1);
+  u2->prefs[a2] = 0.5;
+
+  RequestGroup::Ptr gu(new RequestGroup(1));
+  gu->AddExchangeNode(u);
+  gu->AddExchangeNode(u2);
+  // std::vector<ExchangeNode::Ptr> excl_grp;
+  // excl_grp.push_back(u);
+  // excl_grp.push_back(u2);
+  // gu->AddExclGroup(excl_grp);
+  gu->AddCapacity(1);
+
+  if (consumer_lteq) {
+    u->unit_capacities[a].push_back(2);
+    u2->unit_capacities[a2].push_back(1);
+    gu->AddCapacity(1.0, LTEQ);
+  }  
+
+  ExchangeNodeGroup::Ptr gv(new ExchangeNodeGroup());
+  gv->AddExchangeNode(v);
+  // v->unit_capacities[a].push_back(1);
+  // gv->AddCapacity(1.0);
+  ExchangeNodeGroup::Ptr gw(new ExchangeNodeGroup());
+  gw->AddExchangeNode(w);
+  // w->unit_capacities[a2].push_back(1);
+  // gw->AddCapacity(1.0);
+  
+  ExchangeGraph* g = new ExchangeGraph();
+  g->AddRequestGroup(gu);
+  g->AddSupplyGroup(gv);
+  g->AddSupplyGroup(gw);
+  g->AddArc(a);
+  g->AddArc(a2);
+  return g;
+}
+
+
+TEST(ExSolverTests, CustomConstraintsGreedy2) {
+  bool consumer_lteq;
+  GreedySolver greedy_nex(false);
+  GreedySolver greedy_ex(true);
+  
+  // test supplier and consumer constraints
+  consumer_lteq = false;
+  ExchangeGraph* g = gen2(consumer_lteq);
+  Match exp_gnex = Match(g->arcs().at(0), 1.);
+  greedy_nex.graph(g);
+  greedy_nex.Solve();
+  ASSERT_EQ(g->matches().size(), 1);
+  EXPECT_EQ(exp_gnex, g->matches().at(0));
+  g->ClearMatches();
+  Match exp_gex = Match(g->arcs().at(0), 1.);
+  greedy_ex.graph(g);
+  greedy_ex.Solve();
+  ASSERT_EQ(g->matches().size(), 1);
+  EXPECT_EQ(exp_gex, g->matches().at(0));
+  delete g;
+
+  // test consumer with LTEQ constraints
+  consumer_lteq = true;
+  ExchangeGraph* h = gen2(consumer_lteq);
+  Match exp_hnex = Match(h->arcs().at(0), 0.5);
+  greedy_nex.graph(h);
+  greedy_nex.Solve();
+  ASSERT_EQ(h->matches().size(), 1);
+  EXPECT_EQ(exp_hnex, h->matches().at(0));
+  h->ClearMatches();
+  Match exp_hex = Match(h->arcs().at(1), 1.);
+  greedy_ex.graph(h);
+  greedy_ex.Solve();
+  ASSERT_EQ(h->matches().size(), 1);
+  EXPECT_EQ(exp_hex, h->matches().at(0));
+  delete h;
+}
+
+TEST(ExSolverTests, CustomConstraintsProg2) {
+  ProgSolver cbc_nex("cbc");
+  bool consumer_lteq;
+  
+  // test supplier and consumer constraints
+  consumer_lteq = false;
+  ExchangeGraph* g = gen2(consumer_lteq);
+  Match exp_g = Match(g->arcs().at(0), 1.0);
+  cbc_nex.graph(g);
+  cbc_nex.Solve();
+  ASSERT_EQ(g->matches().size(), 1);
+  EXPECT_EQ(exp_g, g->matches().at(0));
+  g->ClearMatches();
+  delete g;
+
+  // test consumer with LTEQ constraints
+  consumer_lteq = true;
+  ExchangeGraph* h = gen2(consumer_lteq);
+  Match exp_h = Match(h->arcs().at(0), 0.5);
+  cbc_nex.graph(h);
+  cbc_nex.Solve();
+  ASSERT_EQ(h->matches().size(), 1);
+  EXPECT_EQ(exp_h, h->matches().at(0));
+  h->ClearMatches();
+  delete h;  
+}
+
 }

--- a/tests/exchange_solver_tests.cc
+++ b/tests/exchange_solver_tests.cc
@@ -1,8 +1,11 @@
 #include <gtest/gtest.h>
 
 #include "exchange_solver.h"
+#include "exchange_graph.h"
+#include "greedy_solver.h"
+#include "prog_solver.h"
 
-using cyclus::ExchangeSolver;
+namespace cyclus {
 
 class MockSolver: public ExchangeSolver {
  public:
@@ -22,3 +25,54 @@ TEST(ExSolverTests, Interface) {
   EXPECT_EQ(2, s.i);
 }
 
+ExchangeGraph* gen() {
+  ExchangeNode::Ptr u(new ExchangeNode());
+  ExchangeNode::Ptr v(new ExchangeNode());
+  Arc a(u, v);
+
+  u->unit_capacities[a].push_back(1);
+  u->unit_capacities[a].push_back(1);
+  v->unit_capacities[a].push_back(1);
+  u->prefs[a] = 1;
+
+  RequestGroup::Ptr gu(new RequestGroup(1));
+  gu->AddExchangeNode(u);
+  gu->AddCapacity(1);
+  gu->AddCapacity(1, LTEQ);
+  ExchangeNodeGroup::Ptr gv(new ExchangeNodeGroup());
+  gv->AddExchangeNode(v);
+  gv->AddCapacity(2); // 2 > 1
+
+  ExchangeGraph* g = new ExchangeGraph();
+  g->AddRequestGroup(gu);
+  g->AddSupplyGroup(gv);
+  g->AddArc(a);
+  return g;
+}
+
+TEST(ExSolverTests, Constraints) {
+  ExchangeGraph* g = gen();
+  ProgSolver s("clp");
+  // GreedySolver s(false);
+
+  // test unit flow to consumer
+  s.graph(g);
+  s.Solve();
+  Match exp = Match(g->arcs().at(0), 1);
+  ASSERT_TRUE(g->matches().size() > 0);
+  EXPECT_EQ(exp, g->matches().at(0));
+  g->ClearMatches();
+
+  // test less-than unit flow to consumer
+  RequestGroup::Ptr rg = g->request_groups()[0];
+  rg->capacities()[1] = 0.5;
+  EXPECT_EQ(0.5, g->request_groups().at(0)->capacities.at(1));
+  s.Solve();
+  Match exp2 = Match(g->arcs().at(0), 0.5);
+  ASSERT_TRUE(g->matches().size() > 0);
+  EXPECT_EQ(exp2, g->matches().at(0));
+  
+  delete g;
+}
+
+}

--- a/tests/exchange_solver_tests.cc
+++ b/tests/exchange_solver_tests.cc
@@ -4,7 +4,6 @@
 
 using cyclus::ExchangeSolver;
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 class MockSolver: public ExchangeSolver {
  public:
   explicit MockSolver() : i(0) {}
@@ -14,7 +13,6 @@ class MockSolver: public ExchangeSolver {
   int i;
 };
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST(ExSolverTests, Interface) {
   MockSolver s;
   EXPECT_EQ(0, s.i);
@@ -23,3 +21,4 @@ TEST(ExSolverTests, Interface) {
   s.Solve();
   EXPECT_EQ(2, s.i);
 }
+

--- a/tests/exchange_solver_tests.cc
+++ b/tests/exchange_solver_tests.cc
@@ -54,8 +54,7 @@ ExchangeGraph* gen(bool consumer_lteq) {
   return g;
 }
 
-TEST(ExSolverTests, CustomConstraints) {
-  ProgSolver clp("clp");
+TEST(ExSolverTests, CustomConstraintsGreedy) {
   GreedySolver greedy(false);
   bool consumer_lteq;
   
@@ -67,12 +66,6 @@ TEST(ExSolverTests, CustomConstraints) {
   greedy.Solve();
   ASSERT_TRUE(g->matches().size() > 0);
   EXPECT_EQ(exp_g, g->matches().at(0));
-  g->ClearMatches();
-  clp.graph(g);
-  clp.Solve();
-  ASSERT_TRUE(g->matches().size() > 0);
-  EXPECT_EQ(exp_g, g->matches().at(0));
-  g->ClearMatches();
   delete g;
 
   // test consumer with LTEQ constraints
@@ -83,9 +76,30 @@ TEST(ExSolverTests, CustomConstraints) {
   greedy.Solve();
   ASSERT_TRUE(h->matches().size() > 0);
   EXPECT_EQ(exp_h, h->matches().at(0));
-  h->ClearMatches();
-  clp.graph(h);
-  clp.Solve();
+  delete h;  
+}
+
+TEST(ExSolverTests, CustomConstraintsProg) {
+  ProgSolver cbc("cbc");
+  bool consumer_lteq;
+  
+  // test supplier and consumer constraints
+  consumer_lteq = false;
+  ExchangeGraph* g = gen(consumer_lteq);
+  Match exp_g = Match(g->arcs().at(0), 0.5);
+  cbc.graph(g);
+  cbc.Solve();
+  ASSERT_TRUE(g->matches().size() > 0);
+  EXPECT_EQ(exp_g, g->matches().at(0));
+  g->ClearMatches();
+  delete g;
+
+  // test consumer with LTEQ constraints
+  consumer_lteq = true;
+  ExchangeGraph* h = gen(consumer_lteq);
+  Match exp_h = Match(h->arcs().at(0), 0.5);
+  cbc.graph(h);
+  cbc.Solve();
   ASSERT_TRUE(h->matches().size() > 0);
   EXPECT_EQ(exp_h, h->matches().at(0));
   h->ClearMatches();

--- a/tests/prog_translator_tests.cc
+++ b/tests/prog_translator_tests.cc
@@ -16,7 +16,25 @@
 
 namespace cyclus {
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+TEST(ProgTranslatorTests, xlatecaps) {
+  int ncaps = 2;
+  std::vector<CoinPackedVector> cap_rows;
+  cap_rows.resize(2);
+  
+  ProgTranslator::Context ctx;
+  int faux_id = 0;
+  bool request = false;
+  ExchangeNodeGroup::Ptr grp(new ExchangeNodeGroup());
+  grp->AddCapacity(5, LTEQ);
+  grp->AddCapacity(6, GTEQ);
+
+  ProgTranslator::XlateCaps(grp.get(), request, faux_id, cap_rows, ctx);
+  EXPECT_EQ(ctx.row_lbs[0], 0);
+  EXPECT_EQ(ctx.row_ubs[0], 5);
+  EXPECT_EQ(ctx.row_lbs[1], 6);
+  EXPECT_EQ(ctx.row_ubs[1], ctx.inf);
+}
+
 TEST(ProgTranslatorTests, translation) {
   // Logger::ReportLevel() = Logger::ToLogLevel("LEV_DEBUG2");
   SolverFactory sf("cbc");


### PR DESCRIPTION
Hi folks,

This PR adds the ability for consumers to supply a LTEQ constraint. For example, a reactor can now make a demand for fuel with total fission products less than a threshold. Support has been added for both the Greedy and mathematical programming solvers.  

I added basic unit tests, a "trivial" integration test (integrating exchange layer to formulation layer and back), and a less trivial integration test.