### PR TITLE
Add internal tag to cycpp. Modify derived_init tag behavior:

### DIFF
--- a/cli/cycpp.py
+++ b/cli/cycpp.py
@@ -1526,13 +1526,14 @@ class InfileToDbFilter(CodeGeneratorFilter):
                 continue
             d = info['default'] if 'default' in info else None
 
-            if 'internal' in info:
+            if 'internal' in info and info['internal'] == True:
                 # do NOT combine above and below ifs into a single if
                 if d is not None:
                     mname = member + '_tmp'
                     impl += self._val(t, val=d, name=mname, uitype=uitype, ind=ind)
                     impl += ind + '{0} = {1};\n'.format(member, mname)
-                # else: skip else clause below
+                else:
+                    raise RuntimeError('state variables marked as internal must have a default')
             else:
                 labels = info.get('alias', None)
                 if labels is None:

--- a/tests/cycpp_tests.h
+++ b/tests/cycpp_tests.h
@@ -97,6 +97,19 @@ class Villan: public mi6::Spy {
     }
   std::string enemy;
 
+  #pragma cyclus var {"internal": False}
+  int foo1;
+  #pragma cyclus var {"internal": False, "derived_init": "foo3 = std::exp(2);"}
+  int foo3;
+  #pragma cyclus var {"internal": False, "default": 7}
+  int foo5;
+  #pragma cyclus var {"internal": True, "default": 7}
+  int foo6;
+  #pragma cyclus var {"internal": False, "derived_init": "foo3 = std::exp(2);", "default": 7}
+  int foo7;
+  #pragma cyclus var {"internal": True, "derived_init": "foo4 = std::exp(2);", "default": 7}
+  int foo8;
+
   #pragma cyclus var {\
     "default": [1, 2, 5],\
     }


### PR DESCRIPTION
'internal' tag now makes state variables invisible in the xml schema, but
still persisted/loaded normally.  'internal' vars can have default values.
'derived_init' vars now show up in the xml schema as optional and the
derived_init value is overridden if a user specifies the value in the schema.
If a var is both internal and derived_init, then it is not in the schema but
can still have a default value specified.