### PR TITLE
Preference adjustment has been updated to include the managers of both

### DIFF
--- a/src/agent.h
+++ b/src/agent.h
@@ -316,12 +316,25 @@ class Agent : public StateWrangler, virtual public Ider {
   /// their Decommission function.
   virtual void Decommission();
 
-  /// default implementation for material preferences.
+  /// @warning Deprecated!
+  /// @{
   virtual void AdjustMatlPrefs(PrefMap<Material>::type& prefs) {}
+  virtual void AdjustProductPrefs(PrefMap<Product>::type& prefs) {}
+  /// @}
+  
 
   /// default implementation for material preferences.
-  virtual void AdjustProductPrefs(PrefMap<Product>::type& prefs) {}
-
+  virtual double AdjustMatlPref(Request<Material>* req, Bid<Material>* bid,
+                                double pref, TradeSense sense) {
+    return pref;
+  }
+  /// default implementation for product preferences.
+  virtual double AdjustProductPref(Request<Product>* req, Bid<Product>* bid,
+                                   double pref, TradeSense sense) {
+    return pref;
+  }
+  
+  
   /// Returns an agent's xml rng schema for initializing from input files. All
   /// concrete agents should override this function. This must validate the same
   /// xml input that the InfileToDb function receives.

--- a/src/exchange_context.h
+++ b/src/exchange_context.h
@@ -14,6 +14,14 @@
 
 namespace cyclus {
 
+/// @brief A notion of the point of view from which an trade-related action is
+/// being requested
+enum TradeSense {
+  REQUEST = 0, ///< The action is from the request-perspective 
+  BID, ///< The action is from the bid-perspective
+  END
+};    
+
 template <class T>
 struct PrefMap {
   typedef std::map<Request<T>*, std::map<Bid<T>*, double> > type;

--- a/src/resource_exchange.h
+++ b/src/resource_exchange.h
@@ -15,16 +15,31 @@
 #include "trader_management.h"
 
 namespace cyclus {
+  
+/// @warning deprecated!
+/// @{
+template<class T>
+inline static void AdjustPrefs(Agent* m, typename PrefMap<T>::type& prefs) {}
+inline static void AdjustPrefs(Agent* m, PrefMap<Material>::type& prefs) {}
+inline static void AdjustPrefs(Agent* m, PrefMap<Product>::type& prefs) {}
+/// @}
+
 
 /// @brief Preference adjustment method helpers to convert from templates to the
 /// Agent inheritance hierarchy
 template<class T>
-inline static void AdjustPrefs(Agent* m, typename PrefMap<T>::type& prefs) {}
-inline static void AdjustPrefs(Agent* m, PrefMap<Material>::type& prefs) {
-  m->AdjustMatlPrefs(prefs);
+inline static double AdjustPref(Agent* m,
+                                Request<T>* req, Bid<T>* bid,
+                                double pref, TradeSense sense) { return pref; }
+inline static double AdjustPref(Agent* m,
+                                Request<Material>* req, Bid<Material>* bid,
+                                double pref, TradeSense sense) {
+  return m->AdjustMatlPref(req, bid, pref, sense);
 }
-inline static void AdjustPrefs(Agent* m, PrefMap<Product>::type& prefs) {
-  m->AdjustProductPrefs(prefs);
+inline static double AdjustPref(Agent* m,
+                                Request<Product>* req, Bid<Product>* bid,
+                                double pref, TradeSense sense) {
+  return m->AdjustProductPref(req, bid, pref, sense);
 }
 inline static void AdjustPrefs(Trader* t, PrefMap<Material>::type& prefs) {
   t->AdjustMatlPrefs(prefs);
@@ -124,16 +139,40 @@ class ResourceExchange {
 
   /// @brief allows a trader and its parents to adjust any preferences in the
   /// system
-  void AdjustPrefs_(Trader* t) {
-    typename PrefMap<T>::type& prefs = ex_ctx_.trader_prefs[t];
-    AdjustPrefs(t, prefs);
-    Agent* m = t->manager()->parent();
-    while (m != NULL) {
-      AdjustPrefs(m, prefs);
-      m = m->parent();
-    }
-  }
+  void AdjustPrefs_(Trader* reqr) {
+    typename PrefMap<T>::type& prefs = ex_ctx_.trader_prefs[reqr];
+    AdjustPrefs(reqr, prefs);
 
+    Agent* a;
+    Request<T>* req;
+    Bid<T>* bid;
+    double pref;
+    typename PrefMap<T>::type::iterator rit = prefs.begin();
+    for (; rit != prefs.end(); ++rit) {
+      req = rit->first;
+      typename std::map<Bid<T>*, double>::iterator bit = rit->second.begin();
+      for (; bit != rit->second.end(); ++bit) {
+        bid = bit->first;
+        pref = bit->second;
+        // requester insts/regions/etc get to update the pref first
+        a = reqr->manager()->parent();
+        while (a != NULL) {
+          pref = AdjustPref(a, req, bid, pref, REQUEST);
+          a = a->parent();
+        }
+        // followed by bidder inst/regions/etc
+        a = bid->bidder()->manager()->parent();
+        while (a != NULL) {
+          pref = AdjustPref(a, req, bid, pref, BID);
+          a = a->parent();
+        }
+        // update the actual preference in the data structure
+        bit->second = pref;
+      }
+    }
+    
+  }
+  
   Context* ctx_;
   ExchangeContext<T> ex_ctx_;
 };


### PR DESCRIPTION
requesters and bidders. This will let institution and region
interactions be based either trader entity. Only bidders now have no
influence on the preference adjustment process, which could be updated
in the future if needed.

There is a notable deprecation of the *Agent* AdjustPrefs API. As was
true previously, only *managers* of trading agents are called through
this API, i.e., institutions and regions in the RIF model. The new
AdjustPref API includes the request, bid, preference, and whether the
agent is a manager of the requester or bidder (called
TradeSense). Each trade has its preference adjusted
individually. Anything more complex will require much more difficult
logic in the DRE *and* in the agent API.

related to https://github.com/cyclus/cyclus.github.com/pull/130 for requester/bidder preference adjustment