### PR TITLE
mocksim can now take custom lifetimes for tested agents.

### DIFF
--- a/src/mock_sim.cc
+++ b/src/mock_sim.cc
@@ -131,6 +131,28 @@ MockSim::MockSim(AgentSpec spec, std::string config, int duration)
   agent = ctx_.CreateAgent<Agent>(a->prototype());
 }
 
+MockSim::MockSim(AgentSpec spec, std::string config, int duration, int lifetime)
+    : ctx_(&ti_, &rec_), back_(NULL), agent(NULL) {
+  Env::SetNucDataPath();
+  warn_limit = 0;
+  back_ = new SqliteBack(":memory:");
+  rec_.RegisterBackend(back_);
+  ti_.Initialize(&ctx_, SimInfo(duration));
+
+  Agent* a = DynamicModule::Make(&ctx_, spec);
+
+  std::stringstream xml;
+  xml << "<facility>"
+      << "<lifetime>" << lifetime << "</lifetime>"
+      << "<name>agent_being_tested</name>"
+      << "<config><foo>" << config << "</foo></config>"
+      << "</facility>";
+  InitAgent(a, xml, &rec_, back_);
+
+  ctx_.AddPrototype(a->prototype(), a);
+  agent = ctx_.CreateAgent<Agent>(a->prototype());
+}
+
 void MockSim::DummyProto(std::string name) {
   Agent* a = DynamicModule::Make(&ctx_, AgentSpec(":agents:Source"));
 

--- a/src/mock_sim.cc
+++ b/src/mock_sim.cc
@@ -191,9 +191,10 @@ void MockSim::AddRecipe(std::string name, Composition::Ptr c) {
 
 int MockSim::Run() {
   agent->Build(NULL);
+  int id = agent->id();
   ti_.RunSim();
   rec_.Flush();
-  return agent->id();
+  return id;
 }
 
 Material::Ptr MockSim::GetMaterial(int resid) {

--- a/src/mock_sim.h
+++ b/src/mock_sim.h
@@ -139,6 +139,13 @@ class MockSim {
   /// steps.
   MockSim(AgentSpec spec, std::string config, int duration);
 
+  /// Creates and initializes a new mock simulation environment to test the
+  /// archetype identified by spec.  config should contain the
+  /// archetype-specific xml snippet excluding the wrapping "<config>" and
+  /// "<[AgentName]>" tags.  duration is the length of the simulation in time
+  /// steps.  'lifetime' is the lifetime of the agent being tested.
+  MockSim(AgentSpec spec, std::string config, int duration, int lifetime);
+
   ~MockSim();
 
   /// AddSource adds a source facility that can offer/provide material to the


### PR DESCRIPTION
allows testing of end-of-life behavior of agents.