### PR TITLE
some performance enhancements

### DIFF
--- a/src/comp_math.cc
+++ b/src/comp_math.cc
@@ -12,32 +12,29 @@ namespace compmath {
 
 CompMap Add(const CompMap& v1, const CompMap& v2) {
   CompMap out(v1);
-  CompMap vv2(v2);
   for (CompMap::const_iterator it = v2.begin(); it != v2.end(); ++it) {
     int nuc = it->first;
-    out[nuc] += vv2[nuc];
+    out[nuc] += it->second;
   }
   return out;
 }
 
 CompMap Sub(const CompMap& v1, const CompMap& v2) {
   CompMap out(v1);
-  CompMap vv2(v2);
   for (CompMap::const_iterator it = v2.begin(); it != v2.end(); ++it) {
     int nuc = it->first;
-    out[nuc] -= vv2[nuc];
+    out[nuc] -= it->second;
   }
   return out;
 }
 
 double Sum(const CompMap& v) {
   std::vector<double> vec;
+  vec.reserve(v.size());
   for (CompMap::const_iterator it = v.begin(); it != v.end(); ++it) {
     vec.push_back(it->second);
   }
-
-  double sum = CycArithmetic::KahanSum(vec);
-  return sum;
+  return CycArithmetic::KahanSum(vec);
 }
 
 void ApplyThreshold(CompMap* v, double threshold) {
@@ -61,8 +58,9 @@ void ApplyThreshold(CompMap* v, double threshold) {
 void Normalize(CompMap* v, double val) {
   double sum = Sum(*v);
   if (sum != val && sum != 0) {
+    double mult = val / sum;
     for (CompMap::iterator it = v->begin(); it != v->end(); ++it) {
-      (*v)[it->first] = it->second / sum * val;
+      it->second *= mult;
     }
   }
 }

--- a/src/composition.cc
+++ b/src/composition.cc
@@ -44,7 +44,7 @@ const CompMap& Composition::atom() {
     CompMap::iterator it;
     for (it = mass_.begin(); it != mass_.end(); ++it) {
       Nuc nuc = it->first;
-      atom_[nuc] = mass_[nuc] / pyne::atomic_mass(nuc);
+      atom_[nuc] = it->second / pyne::atomic_mass(nuc);
     }
   }
   return atom_;
@@ -55,7 +55,7 @@ const CompMap& Composition::mass() {
     CompMap::iterator it;
     for (it = atom_.begin(); it != atom_.end(); ++it) {
       Nuc nuc = it->first;
-      mass_[nuc] = atom_[nuc] * pyne::atomic_mass(nuc);
+      mass_[nuc] = it->second * pyne::atomic_mass(nuc);
     }
   }
   return mass_;

--- a/src/cyc_arithmetic.cc
+++ b/src/cyc_arithmetic.cc
@@ -11,15 +11,14 @@ namespace cyclus {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 double CycArithmetic::KahanSum(std::vector<double> input) {
-  std::vector<double> sorted = sort_ascending(input);
+  sort_inplace_ascending(input);
   // http://en.wikipedia.org/wiki/Kahan_summation_algorithm
   double y, t;
   double sum = 0.0;
   // A running compensation for lost low-order bits.
   double c = 0.0;
-  for (std::vector<double>::iterator i = sorted.begin(); i != sorted.end();
-       ++i) {
-    y = *i - c;
+  for (int i = 0; i < input.size(); i++) {
+    y = input[i] - c;
     // So far, so good: c is zero.
     t = sum + y;
     // Alas, sum is big, y small, so low-order digits of y are lost.
@@ -30,6 +29,11 @@ double CycArithmetic::KahanSum(std::vector<double> input) {
     // Next time around, the lost low part will be added to y in a fresh attempt.
   }
   return sum;
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+void CycArithmetic::sort_inplace_ascending(std::vector<double>& to_sort) {
+  sort(to_sort.begin(), to_sort.end());
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/cyc_arithmetic.h
+++ b/src/cyc_arithmetic.h
@@ -26,6 +26,10 @@ class CycArithmetic {
   /// @returns a set sorted from smallest to largest
   static std::vector<double> sort_ascending(std::vector<double> to_sort);
 
+  /// Identical to sort_ascending(std::vector<double>) except it modifies the
+  /// sorts the vector in-place modifying the passed in argument directly.
+  static void sort_inplace_ascending(std::vector<double>& to_sort);
+
   /// orders the values in a map from smallest value to largest value.
   /// This helps for addition algorithms.
   /// @param to_sort is a map of values to sort (according to the value of the double)

--- a/src/sqlite_back.cc
+++ b/src/sqlite_back.cc
@@ -48,6 +48,10 @@ SqliteBack::SqliteBack(std::string path) : db_(path) {
   path_ = path;
   db_.open();
 
+  db_.Execute("PRAGMA synchronous=OFF;");
+  db_.Execute("PRAGMA journal_mode=MEMORY;");
+  db_.Execute("PRAGMA temp_store=MEMORY;");
+
   // cache pre-existing table names
   SqlStatement::Ptr stmt;
   stmt = db_.Prepare("SELECT name FROM sqlite_master WHERE type='table';");

--- a/src/toolkit/res_manip.cc
+++ b/src/toolkit/res_manip.cc
@@ -61,6 +61,10 @@ std::vector<Resource::Ptr> ResCast(std::vector<Product::Ptr> rs) {
   return casted;
 }
 
+std::vector<Resource::Ptr> ResCast(std::vector<Resource::Ptr> rs) {
+  return rs;
+}
+
 }  // namespace toolkit
 }  // namespace cyclus
 

--- a/src/toolkit/res_manip.h
+++ b/src/toolkit/res_manip.h
@@ -26,6 +26,10 @@ std::vector<Resource::Ptr> ResCast(std::vector<Material::Ptr> rs);
 /// Casts a vector of Products into a vector of Resources.
 std::vector<Resource::Ptr> ResCast(std::vector<Product::Ptr> rs);
 
+/// Casts a vector of Resources into a vector of Resources.  This is actually
+/// basically a no-op that enables ResBuf to work for plain Resource types.
+std::vector<Resource::Ptr> ResCast(std::vector<Resource::Ptr> rs);
+
 }  // namespace toolkit
 }  // namespace cyclus
 

--- a/src/version.h
+++ b/src/version.h
@@ -2,7 +2,7 @@
 #define CYCLUS_SRC_VERSION_H_
 
 #define CYCLUS_VERSION_MAJOR 1
-#define CYCLUS_VERSION_MINOR 2
+#define CYCLUS_VERSION_MINOR 3
 #define CYCLUS_VERSION_MICRO 0
 
 namespace cyclus {

--- a/tests/comp_math_tests.cc
+++ b/tests/comp_math_tests.cc
@@ -23,6 +23,21 @@ TEST(CompMathTests, SubSame) {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+TEST(CompMathTests, Normalize) {
+  CompMap v;
+  v[922350000] = .1;
+  v[922380000] = .2;
+
+  CompMap v2(v);
+  cm::Normalize(&v2, 1);
+
+  CompMap::iterator it;
+  for (it = v.begin(); it != v.end(); ++it) {
+    EXPECT_DOUBLE_EQ(it->second/.3, v2[it->first]);
+  }
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST(CompMathTests, SubCloseSize) {
   CompMap v;
   double qty = 0.1;
@@ -36,6 +51,8 @@ TEST(CompMathTests, SubCloseSize) {
   remainder = cm::Sub(v, v2);
   CompMap::iterator it;
   for (it = remainder.begin(); it != remainder.end(); ++it) {
+    std::cout << "v1: " << it->first << "=" << v[it->first] << "\n";
+    std::cout << "v2: " << it->first << "=" << v2[it->first] << "\n";
     double expected = cyclus::eps_rsrc();
     EXPECT_FLOAT_EQ(expected, it->second);
   }

--- a/tests/toolkit/mat_query_tests.cc
+++ b/tests/toolkit/mat_query_tests.cc
@@ -186,7 +186,7 @@ TEST_F(MaterialMatQueryTest, ExtractDiffComp) {
   const double orig_am241 = mq.mass(am241_);
   const double orig_pb208 = mq.mass(pb208_);
 
-  EXPECT_NO_THROW(m1 = diff_mat_->ExtractComp(mq.mass(u235_), test_comp_));
+  ASSERT_NO_THROW(m1 = diff_mat_->ExtractComp(mq.mass(u235_), test_comp_));
   EXPECT_DOUBLE_EQ(orig - m1->quantity(), diff_mat_->quantity());
   EXPECT_EQ(m1->comp(), test_comp_);
   EXPECT_NE(diff_mat_->comp(), test_comp_);


### PR DESCRIPTION
Speed up compmath ops, composition mass/atom funcs, and summing a bit.  This gives ~15% improvement on some FCO-like simulations. This is built on #1137 - so that needs to go in first.