### PR TITLE
buy policy throughput

### DIFF
--- a/src/toolkit/matl_buy_policy.cc
+++ b/src/toolkit/matl_buy_policy.cc
@@ -61,11 +61,11 @@ MatlBuyPolicy& MatlBuyPolicy::Init(Agent* manager, ResourceBuff* buf,
 }
 
 MatlBuyPolicy& MatlBuyPolicy::Init(Agent* manager, ResourceBuff* buf,
-                                   std::string name, double quantize) {
+                                   std::string name, double throughput) {
   Trader::manager_ = manager;
   buf_ = buf;
   name_ = name;
-  set_quantize(quantize);
+  set_throughput(throughput);
   return *this;
 }
 
@@ -81,21 +81,9 @@ MatlBuyPolicy& MatlBuyPolicy::Init(Agent* manager, ResourceBuff* buf,
 }
 
 MatlBuyPolicy& MatlBuyPolicy::Init(Agent* manager, ResourceBuff* buf,
-                                   std::string name, double quantize,
-                                   double fill_to, double req_when_under) {
-  Trader::manager_ = manager;
-  buf_ = buf;
-  name_ = name;
-  set_fill_to(fill_to);
-  set_req_when_under(req_when_under);
-  set_quantize(quantize);
-  return *this;
-}
-
-MatlBuyPolicy& MatlBuyPolicy::Init(Agent* manager, ResourceBuff* buf,
-                                   std::string name, double quantize,
+                                   std::string name, double throughput,
                                    double fill_to, double req_when_under,
-                                   double throughput) {
+                                   double quantize) {
   Trader::manager_ = manager;
   buf_ = buf;
   name_ = name;

--- a/src/toolkit/matl_buy_policy.cc
+++ b/src/toolkit/matl_buy_policy.cc
@@ -15,6 +15,7 @@ namespace toolkit {
 MatlBuyPolicy::MatlBuyPolicy() :
     Trader(NULL),
     name_(""),
+    throughput_(std::numeric_limits<double>::max()),
     quantize_(-1),
     fill_to_(1),
     req_when_under_(1) {
@@ -44,6 +45,11 @@ void MatlBuyPolicy::set_req_when_under(double x) {
 void MatlBuyPolicy::set_quantize(double x) {
   assert(x != 0);
   quantize_ = x;
+}
+
+void MatlBuyPolicy::set_throughput(double x) {
+  assert(x > 0);
+  throughput_ = x;
 }
 
 MatlBuyPolicy& MatlBuyPolicy::Init(Agent* manager, ResourceBuff* buf,
@@ -83,6 +89,20 @@ MatlBuyPolicy& MatlBuyPolicy::Init(Agent* manager, ResourceBuff* buf,
   set_fill_to(fill_to);
   set_req_when_under(req_when_under);
   set_quantize(quantize);
+  return *this;
+}
+
+MatlBuyPolicy& MatlBuyPolicy::Init(Agent* manager, ResourceBuff* buf,
+                                   std::string name, double quantize,
+                                   double fill_to, double req_when_under,
+                                   double throughput) {
+  Trader::manager_ = manager;
+  buf_ = buf;
+  name_ = name;
+  set_fill_to(fill_to);
+  set_req_when_under(req_when_under);
+  set_quantize(quantize);
+  set_throughput(throughput);
   return *this;
 }
 

--- a/src/toolkit/matl_buy_policy.h
+++ b/src/toolkit/matl_buy_policy.h
@@ -66,15 +66,16 @@ class MatlBuyPolicy : public Trader {
   /// @param manager the agent
   /// @param buf the resource buffer
   /// @param name a unique name identifying this policy
-  /// @param throughput a maximum on total transaction quantities
-  /// @param quantize If quantize is greater than zero, the policy will make
-  /// exclusive, integral quantize kg requests.  Otherwise, single requests will
-  /// be sent to fill the buffer's empty space.
+  /// @param throughput a constraining value for total transaction quantities in
+  /// a single time step
   /// @param fill_to the amount or fraction of inventory to order when placing
   /// an order. This is equivalent to the S in an (s, S) inventory policy.
   /// @param req_when_under place an request when the buf's quantity is less
   /// than its capacity * fill_to (as a fraction). This is equivalent to the s
   /// in an (s, S) inventory policy.
+  /// @param quantize If quantize is greater than zero, the policy will make
+  /// exclusive, integral quantize kg requests.  Otherwise, single requests will
+  /// be sent to fill the buffer's empty space.
   /// @warning, (s, S) policy values are ambiguous for buffers with a capacity
   /// in (0, 1]. However that is a rare case.
   /// @{

--- a/src/toolkit/matl_buy_policy.h
+++ b/src/toolkit/matl_buy_policy.h
@@ -80,15 +80,12 @@ class MatlBuyPolicy : public Trader {
   /// @{
   MatlBuyPolicy& Init(Agent* manager, ResourceBuff* buf, std::string name);
   MatlBuyPolicy& Init(Agent* manager, ResourceBuff* buf, std::string name,
-                      double quantize);
+                      double throughput);
   MatlBuyPolicy& Init(Agent* manager, ResourceBuff* buf, std::string name,
                       double fill_to, double req_when_under);
   MatlBuyPolicy& Init(Agent* manager, ResourceBuff* buf, std::string name,
-                      double quantize,
-                      double fill_to, double req_when_under);
-  MatlBuyPolicy& Init(Agent* manager, ResourceBuff* buf, std::string name,
-                      double quantize, double fill_to,
-                      double req_when_under, double throughput);
+                      double throughput, double fill_to,
+                      double req_when_under, double quantize);
   /// @}
     
   /// Instructs the policy to fill its buffer with requests on the given

--- a/src/toolkit/matl_buy_policy.h
+++ b/src/toolkit/matl_buy_policy.h
@@ -66,6 +66,7 @@ class MatlBuyPolicy : public Trader {
   /// @param manager the agent
   /// @param buf the resource buffer
   /// @param name a unique name identifying this policy
+  /// @param throughput a maximum on total transaction quantities
   /// @param quantize If quantize is greater than zero, the policy will make
   /// exclusive, integral quantize kg requests.  Otherwise, single requests will
   /// be sent to fill the buffer's empty space.
@@ -85,6 +86,9 @@ class MatlBuyPolicy : public Trader {
   MatlBuyPolicy& Init(Agent* manager, ResourceBuff* buf, std::string name,
                       double quantize,
                       double fill_to, double req_when_under);
+  MatlBuyPolicy& Init(Agent* manager, ResourceBuff* buf, std::string name,
+                      double quantize, double fill_to,
+                      double req_when_under, double throughput);
   /// @}
     
   /// Instructs the policy to fill its buffer with requests on the given
@@ -112,7 +116,8 @@ class MatlBuyPolicy : public Trader {
 
   /// the total amount requested
   inline double TotalQty() const {
-    return fill_to_ * buf_->capacity() - buf_->quantity();
+    return std::min(throughput_,
+                    fill_to_ * buf_->capacity() - buf_->quantity());
   }
 
   /// whether trades will be denoted as exclusive or not
@@ -153,10 +158,11 @@ class MatlBuyPolicy : public Trader {
   /// requires buf_ already set
   void set_req_when_under(double x); 
   void set_quantize(double x); 
+  void set_throughput(double x); 
   
   ResourceBuff* buf_;
   std::string name_;
-  double fill_to_, req_when_under_, quantize_;
+  double fill_to_, req_when_under_, quantize_, throughput_;
   std::map<Material::Ptr, std::string> rsrc_commods_;
   std::map<std::string, CommodDetail> commod_details_;
 };

--- a/tests/toolkit/matl_buy_policy_tests.cc
+++ b/tests/toolkit/matl_buy_policy_tests.cc
@@ -46,16 +46,23 @@ TEST_F(MatlBuyPolicyTests, Init) {
   ASSERT_FLOAT_EQ(p.ReqQty(), cap);
   ASSERT_EQ(p.NReq(), 1);
 
+  // throughput
+  double throughput = cap - 1;
+  p.Init(fac1, &buff, "", -1, 1, 1, throughput);
+  ASSERT_FLOAT_EQ(p.TotalQty(), throughput);
+  ASSERT_FLOAT_EQ(p.ReqQty(), throughput);
+  ASSERT_EQ(p.NReq(), 1);
+
   // exclusive orders
   double quantize = 2.5;
-  p.Init(fac1, &buff, "", quantize);
+  p.Init(fac1, &buff, "", quantize, 1, 1, std::numeric_limits<double>::max());
   ASSERT_FLOAT_EQ(p.TotalQty(), cap);
   ASSERT_FLOAT_EQ(p.ReqQty(), quantize);
   ASSERT_EQ(p.NReq(), static_cast<int>(cap / quantize));
 
   // S,s with nothing in buffer 
   double S = 4, s = 2;
-  p.Init(fac1, &buff, "", -1, S, s);
+  p.Init(fac1, &buff, "", -1, S, s, std::numeric_limits<double>::max());
   ASSERT_FLOAT_EQ(p.TotalQty(), S);
   ASSERT_FLOAT_EQ(p.ReqQty(), S);
   ASSERT_EQ(p.NReq(), 1);

--- a/tests/toolkit/matl_buy_policy_tests.cc
+++ b/tests/toolkit/matl_buy_policy_tests.cc
@@ -48,21 +48,24 @@ TEST_F(MatlBuyPolicyTests, Init) {
 
   // throughput
   double throughput = cap - 1;
-  p.Init(fac1, &buff, "", -1, 1, 1, throughput);
+  p.Init(fac1, &buff, "", throughput, 1, 1, -1);
   ASSERT_FLOAT_EQ(p.TotalQty(), throughput);
   ASSERT_FLOAT_EQ(p.ReqQty(), throughput);
   ASSERT_EQ(p.NReq(), 1);
 
   // exclusive orders
   double quantize = 2.5;
-  p.Init(fac1, &buff, "", quantize, 1, 1, std::numeric_limits<double>::max());
+  p.Init(fac1, &buff, "", std::numeric_limits<double>::max(), 1, 1, quantize);
   ASSERT_FLOAT_EQ(p.TotalQty(), cap);
   ASSERT_FLOAT_EQ(p.ReqQty(), quantize);
   ASSERT_EQ(p.NReq(), static_cast<int>(cap / quantize));
 
   // S,s with nothing in buffer 
   double S = 4, s = 2;
-  p.Init(fac1, &buff, "", -1, S, s, std::numeric_limits<double>::max());
+  // reset
+  p.Init(fac1, &buff, "", std::numeric_limits<double>::max(), 1, 1, -1); 
+  // use Ss constructor
+  p.Init(fac1, &buff, "", S, s);
   ASSERT_FLOAT_EQ(p.TotalQty(), S);
   ASSERT_FLOAT_EQ(p.ReqQty(), S);
   ASSERT_EQ(p.NReq(), 1);
@@ -112,7 +115,7 @@ TEST_F(MatlBuyPolicyTests, Reqs) {
   
   // two portfolios with quantize
   double quantize = 2.5;
-  p.Init(fac1, &buff, "", quantize);
+  p.Init(fac1, &buff, "", std::numeric_limits<double>::max(), 1, 1, quantize);
   obs = p.GetMatlRequests();
   ASSERT_EQ(obs.size(), 2);
   ASSERT_EQ((*obs.begin())->requests().size(), 2);


### PR DESCRIPTION
This adds a throughput member to buy policies and matches its Init method signature with the sell policy. This replaces #1135 and should be in 1.3 because of its use for the developer tutorial.