### PR TITLE
Fix trade record

### DIFF
--- a/release/smbchk.py
+++ b/release/smbchk.py
@@ -38,6 +38,8 @@ api_blacklist = {
     'cyclus::SimInit::LoadMaterial',
     'cyclus::SimInit::LoadProduct',
     'cyclus::SimInit::LoadComposition',
+    'cyclus::TradeExecutor<cyclus::Material>::ExecuteTrades',
+    'cyclus::TradeExecutor<cyclus::Product>::ExecuteTrades',
 }
 
 def load(ns):

--- a/src/exchange_manager.h
+++ b/src/exchange_manager.h
@@ -62,8 +62,7 @@ class ExchangeManager {
 
     // execute trades!
     TradeExecutor<T> exec(trades);
-    exec.ExecuteTrades();
-    exec.RecordTrades(ctx_);
+    exec.ExecuteTrades(ctx_);
   }
 
  private:

--- a/src/trade_executor.h
+++ b/src/trade_executor.h
@@ -51,12 +51,12 @@ class TradeExecutor {
 
   /// @brief execute all trades, collecting responders from bidders and sending
   /// responses to requesters
-  /// @deprecated Use ExecuteTrades(Context*) instead.
+  ///
+  /// @deprecated Use ExecuteTrades(Context*) instead.  This function just
+  /// calls ExecuteTrades(NULL).
   void ExecuteTrades() {
     Warn<IO_WARNING>("this function does not record trades to the database");
-    GroupTradesBySupplier(trade_ctx_, trades_);
-    GetTradeResponses(trade_ctx_);
-    SendTradeResources(trade_ctx_);
+    ExecuteTrades(NULL);
   }
 
   /// @brief execute all trades, collecting responders from bidders and sending

--- a/src/trade_executor.h
+++ b/src/trade_executor.h
@@ -51,9 +51,22 @@ class TradeExecutor {
 
   /// @brief execute all trades, collecting responders from bidders and sending
   /// responses to requesters
+  /// @deprecated Use ExecuteTrades(Context*) instead.
   void ExecuteTrades() {
+    Warn<IO_WARNING>("this function does not record trades to the database");
     GroupTradesBySupplier(trade_ctx_, trades_);
     GetTradeResponses(trade_ctx_);
+    SendTradeResources(trade_ctx_);
+  }
+
+  /// @brief execute all trades, collecting responders from bidders and sending
+  /// responses to requesters
+  void ExecuteTrades(Context* ctx) {
+    GroupTradesBySupplier(trade_ctx_, trades_);
+    GetTradeResponses(trade_ctx_);
+    if (ctx != NULL) {
+      RecordTrades(ctx);
+    }
     SendTradeResources(trade_ctx_);
   }
 


### PR DESCRIPTION
Previously, if a facility modified a received resource in its Accept[Matl/Prod]Trades function, DRE wouldn't record the traded resource until after AcceptTrades returned - resulting in the incorrect resource id and state being recorded as what was transacted.  This tweaks DRE to record the trades and resource info after trades are completely resolved but before the materials are sent to the requesters.  Very tricky bug to find!