### PR TITLE
expand on Set API in material buy policy with defaults

### DIFF
--- a/src/toolkit/matl_buy_policy.cc
+++ b/src/toolkit/matl_buy_policy.cc
@@ -94,6 +94,15 @@ MatlBuyPolicy& MatlBuyPolicy::Init(Agent* manager, ResourceBuff* buf,
   return *this;
 }
 
+MatlBuyPolicy& MatlBuyPolicy::Set(std::string commod) {
+  Composition::Ptr c;
+  return Set(commod, c, 1.0);
+}
+
+MatlBuyPolicy& MatlBuyPolicy::Set(std::string commod, Composition::Ptr c) {
+  return Set(commod, c, 1.0);
+}
+
 MatlBuyPolicy& MatlBuyPolicy::Set(std::string commod, Composition::Ptr c,
                                   double pref) {
   CommodDetail d;

--- a/src/toolkit/matl_buy_policy.h
+++ b/src/toolkit/matl_buy_policy.h
@@ -98,7 +98,11 @@ class MatlBuyPolicy : public Trader {
   /// @param commod the commodity name
   /// @param c the composition to request for the given commodity
   /// @param pref the preference value for the commodity
-  MatlBuyPolicy& Set(std::string commod, Composition::Ptr c, double pref=1.0);
+  /// @{
+  MatlBuyPolicy& Set(std::string commod);
+  MatlBuyPolicy& Set(std::string commod, Composition::Ptr c);
+  MatlBuyPolicy& Set(std::string commod, Composition::Ptr c, double pref);
+  /// @}
 
   /// Registers this policy as a trader in the current simulation.  This
   /// function must be called for the policy to begin participating in resource


### PR DESCRIPTION
this will be helpful in the developer tutorial so devs don't have to explicitly make an empty composition