### PR TITLE
Coinpref1

### DIFF
--- a/release/smbchk.py
+++ b/release/smbchk.py
@@ -40,6 +40,8 @@ api_blacklist = {
     'cyclus::SimInit::LoadComposition',
     'cyclus::TradeExecutor<cyclus::Material>::ExecuteTrades',
     'cyclus::TradeExecutor<cyclus::Product>::ExecuteTrades',
+    'cyclus::Arc cyclus::TranslateArc<cyclus::Material>',
+    'cyclus::Arc cyclus::TranslateArc<cyclus::Product>',    
 }
 
 def load(ns):

--- a/share/cyclus-flat.rng.in
+++ b/share/cyclus-flat.rng.in
@@ -32,8 +32,8 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
                   </optional>
                 </interleave>
               </element>
-              <element name="optimize">
-                <element name="library"> <text/> </element>
+              <element name="coin-or">
+                <empty/>
               </element>
             </choice>
             <optional>

--- a/share/cyclus-flat.rng.in
+++ b/share/cyclus-flat.rng.in
@@ -24,6 +24,7 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
       <optional>
         <element name="solver"> 
           <interleave>
+            <optional><element name="config">
             <choice>
               <element name="greedy">
                 <interleave>
@@ -40,6 +41,7 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
                 </interleave>
               </element>
             </choice>
+            </element></optional>
             <optional>
               <element name="exclusive_orders_only">
                 <data type="boolean" />

--- a/share/cyclus-flat.rng.in
+++ b/share/cyclus-flat.rng.in
@@ -24,19 +24,18 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
       <optional>
         <element name="solver"> 
           <interleave>
-            <optional>
-              <element name="config">
-                <choice>
-                  <element name="greedy">
-                    <interleave>
-                      <optional>
-                        <element name="preconditioner"> <text/> </element>
-                      </optional>
-                    </interleave>
-                  </element>
-                </choice>
+            <choice>
+              <element name="greedy">
+                <interleave>
+                  <optional>
+                    <element name="preconditioner"> <text/> </element>
+                  </optional>
+                </interleave>
               </element>
-            </optional>
+              <element name="optimize">
+                <element name="library"> <text/> </element>
+              </element>
+            </choice>
             <optional>
               <element name="exclusive_orders_only">
                 <data type="boolean" />
@@ -44,7 +43,7 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
             </optional>
           </interleave>
         </element>
-      </optional> 
+      </optional>
     </interleave>
   </element>
 

--- a/share/cyclus-flat.rng.in
+++ b/share/cyclus-flat.rng.in
@@ -45,6 +45,10 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
             </choice>
             </element></optional>
             <optional>
+              <element name="allow_exclusive_orders">
+                <data type="boolean" />
+              </element>
+            <optional><!--deprecated. @TODO remove in release 1.5 -->
               <element name="exclusive_orders_only">
                 <data type="boolean" />
               </element>

--- a/share/cyclus-flat.rng.in
+++ b/share/cyclus-flat.rng.in
@@ -33,7 +33,11 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
                 </interleave>
               </element>
               <element name="coin-or">
-                <empty/>
+                <interleave>
+                  <optional>
+                    <element name="timeout">  <data type="positiveInteger"/>  </element>
+                  </optional>
+                </interleave>
               </element>
             </choice>
             <optional>

--- a/share/cyclus-flat.rng.in
+++ b/share/cyclus-flat.rng.in
@@ -38,6 +38,8 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
                   <optional>
                     <element name="timeout">  <data type="positiveInteger"/>  </element>
                   </optional>
+                  <optional><element name="verbose"><data type="boolean"/></element></optional>
+                  <optional><element name="mps"><data type="boolean"/></element></optional>
                 </interleave>
               </element>
             </choice>

--- a/share/cyclus-flat.rng.in
+++ b/share/cyclus-flat.rng.in
@@ -48,6 +48,7 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
               <element name="allow_exclusive_orders">
                 <data type="boolean" />
               </element>
+            </optional>
             <optional><!--deprecated. @TODO remove in release 1.5 -->
               <element name="exclusive_orders_only">
                 <data type="boolean" />

--- a/share/cyclus.rng.in
+++ b/share/cyclus.rng.in
@@ -25,20 +25,18 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
       <optional>
         <element name="solver"> 
           <interleave>
-            <optional>
-              <element name="name"> <text/> </element>
-            </optional>
-            <optional>
-              <choice>
-                <element name="greedy">
-                  <interleave>
-                    <optional>
-                      <element name="preconditioner"> <text/> </element>
-                    </optional>
-                  </interleave>
-                </element>
-              </choice>
-            </optional>
+            <choice>
+              <element name="greedy">
+                <interleave>
+                  <optional>
+                    <element name="preconditioner"> <text/> </element>
+                  </optional>
+                </interleave>
+              </element>
+              <element name="optimize">
+                <element name="library"> <text/> </element>
+              </element>
+            </choice>
             <optional>
               <element name="exclusive_orders_only">
                 <data type="boolean" />

--- a/share/cyclus.rng.in
+++ b/share/cyclus.rng.in
@@ -40,6 +40,7 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
                     <element name="timeout">  <data type="positiveInteger"/>  </element>
                   </optional>
                   <optional><element name="verbose"><data type="boolean"/></element></optional>
+                  <optional><element name="mps"><data type="boolean"/></element></optional>
                 </interleave>
               </element>
             </choice>

--- a/share/cyclus.rng.in
+++ b/share/cyclus.rng.in
@@ -39,6 +39,7 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
                   <optional>
                     <element name="timeout">  <data type="positiveInteger"/>  </element>
                   </optional>
+                  <optional><element name="verbose"><data type="boolean"/></element></optional>
                 </interleave>
               </element>
             </choice>

--- a/share/cyclus.rng.in
+++ b/share/cyclus.rng.in
@@ -25,6 +25,7 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
       <optional>
         <element name="solver"> 
           <interleave>
+            <optional><element name="config">
             <choice>
               <element name="greedy">
                 <interleave>
@@ -41,6 +42,7 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
                 </interleave>
               </element>
             </choice>
+            </element></optional>
             <optional>
               <element name="exclusive_orders_only">
                 <data type="boolean" />

--- a/share/cyclus.rng.in
+++ b/share/cyclus.rng.in
@@ -46,6 +46,11 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
             </choice>
             </element></optional>
             <optional>
+              <element name="allow_exclusive_orders">
+                <data type="boolean" />
+              </element>
+            </optional>
+            <optional><!--deprecated. @TODO remove in release 1.5 -->
               <element name="exclusive_orders_only">
                 <data type="boolean" />
               </element>

--- a/share/cyclus.rng.in
+++ b/share/cyclus.rng.in
@@ -34,7 +34,11 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
                 </interleave>
               </element>
               <element name="coin-or">
-                <empty/>
+                <interleave>
+                  <optional>
+                    <element name="timeout">  <data type="positiveInteger"/>  </element>
+                  </optional>
+                </interleave>
               </element>
             </choice>
             <optional>

--- a/share/cyclus.rng.in
+++ b/share/cyclus.rng.in
@@ -33,8 +33,8 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
                   </optional>
                 </interleave>
               </element>
-              <element name="optimize">
-                <element name="library"> <text/> </element>
+              <element name="coin-or">
+                <empty/>
               </element>
             </choice>
             <optional>

--- a/src/context.h
+++ b/src/context.h
@@ -249,6 +249,7 @@ class Context {
   /// sets the solver associated with this context
   void solver(ExchangeSolver* solver) {
     solver_ = solver;
+    solver_->sim_ctx(this);
   }
 
   /// @return the number of agents of a given prototype currently in the

--- a/src/exchange_graph.cc
+++ b/src/exchange_graph.cc
@@ -134,4 +134,8 @@ void ExchangeGraph::AddMatch(const Arc& a, double qty) {
   matches_.push_back(std::make_pair(a, qty));
 }
 
+void ExchangeGraph::ClearMatches() {
+  matches_.clear();
+}
+
 }  // namespace cyclus

--- a/src/exchange_graph.cc
+++ b/src/exchange_graph.cc
@@ -134,8 +134,4 @@ void ExchangeGraph::AddMatch(const Arc& a, double qty) {
   matches_.push_back(std::make_pair(a, qty));
 }
 
-void ExchangeGraph::ClearMatches() {
-  matches_.clear();
-}
-
 }  // namespace cyclus

--- a/src/exchange_graph.cc
+++ b/src/exchange_graph.cc
@@ -78,6 +78,7 @@ Arc::Arc(boost::shared_ptr<ExchangeNode> unode,
 Arc::Arc(const Arc& other)
     : unode_(other.unode()),
       vnode_(other.vnode()),
+      pref_(other.pref()),
       exclusive_(other.exclusive()),
       excl_val_(other.excl_val()) {}
 

--- a/src/exchange_graph.cc
+++ b/src/exchange_graph.cc
@@ -121,7 +121,7 @@ void ExchangeGraph::AddSupplyGroup(ExchangeNodeGroup::Ptr pss) {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void ExchangeGraph::AddArc(const Arc& a) {
-  arcs_.push_back(a);
+  arcs_.push_back(a);    
   int id = next_arc_id_++;
   arc_ids_.insert(std::pair<Arc, int>(a, id));
   arc_by_id_.insert(std::pair<int, Arc>(id, a));

--- a/src/exchange_graph.h
+++ b/src/exchange_graph.h
@@ -97,12 +97,14 @@ class Arc {
   inline boost::shared_ptr<ExchangeNode> vnode() const { return vnode_.lock(); }
   inline bool exclusive() const { return exclusive_; }
   inline double excl_val() const { return excl_val_; }
-
+  inline double pref() const { return pref_; }
+  inline void pref(double pref) { pref_ = pref; }
+  
  private:
   boost::weak_ptr<ExchangeNode> unode_;
   boost::weak_ptr<ExchangeNode> vnode_;
   bool exclusive_;
-  double excl_val_;
+  double excl_val_, pref_;
 };
 
 /// @brief ExchangeNode-ExchangeNode equality operator

--- a/src/exchange_graph.h
+++ b/src/exchange_graph.h
@@ -227,8 +227,8 @@ class ExchangeGraph {
   void AddMatch(const Arc& a, double qty);
 
   /// clears all matches
-  inline void ClearMatches() { matches_.clear(); }
-
+  void ClearMatches();
+  
   inline const std::vector<RequestGroup::Ptr>& request_groups() const {
     return request_groups_;
   }

--- a/src/exchange_graph.h
+++ b/src/exchange_graph.h
@@ -73,7 +73,6 @@ class Arc {
 
   Arc(boost::shared_ptr<ExchangeNode> unode,
       boost::shared_ptr<ExchangeNode> vnode);
-
   Arc(const Arc& other);
 
   inline Arc& operator=(const Arc& other) {

--- a/src/exchange_graph.h
+++ b/src/exchange_graph.h
@@ -227,7 +227,7 @@ class ExchangeGraph {
   void AddMatch(const Arc& a, double qty);
 
   /// clears all matches
-  void ClearMatches();
+  inline void ClearMatches() { matches_.clear(); }
   
   inline const std::vector<RequestGroup::Ptr>& request_groups() const {
     return request_groups_;

--- a/src/exchange_graph.h
+++ b/src/exchange_graph.h
@@ -148,6 +148,17 @@ class ExchangeNodeGroup {
     excl_node_groups_.push_back(nodes);
   }
 
+  /// @return true of any nodes have arcs associated with them
+  bool HasArcs() {
+    for (std::vector<ExchangeNode::Ptr>::iterator it = nodes_.begin();
+         it != nodes_.end();
+         ++it) {
+      if (it->get()->prefs.size() > 0)
+        return true;
+    }
+    return false;
+  }
+  
   /// @brief adds a single node to the set of exclusive node groupings, in
   /// general this function is used for demand exclusivity
   void AddExclNode(ExchangeNode::Ptr n);

--- a/src/exchange_manager.h
+++ b/src/exchange_manager.h
@@ -39,10 +39,12 @@ class ExchangeManager {
     exchng.AddAllBids();
     exchng.AdjustAll();
     CLOG(LEV_DEBUG1) << "done with info gathering";
-
-    if (debug_) {
+    
+    if (debug_)
       RecordDebugInfo(exchng.ex_ctx());
-    }
+
+    if (exchng.Empty())
+      return; // empty exchange, move on
 
     // translate graph
     ExchangeTranslator<T> xlator(&exchng.ex_ctx());

--- a/src/exchange_solver.cc
+++ b/src/exchange_solver.cc
@@ -69,5 +69,5 @@ double ExchangeSolver::PseudoCost(double cost_add) {
 
   return max_coeff / min_unit_cap + cost_add;
 }
-
+  
 } // namespace cyclus

--- a/src/exchange_solver.cc
+++ b/src/exchange_solver.cc
@@ -96,7 +96,6 @@ double ExchangeSolver::PseudoCostByPref(double cost_add) {
         cost_add = std::max(cost_add, 1.05 * (1 - a.unode()->qty) / a.pref());
     }
     max_cost = std::max(max_cost, cost);
-    std::cout << "bar: " << max_cost << "\n";
   }
   return max_cost + cost_add;
 }

--- a/src/exchange_solver.cc
+++ b/src/exchange_solver.cc
@@ -7,7 +7,7 @@
 
 namespace cyclus {
 
-double ExchangeSolver::PseudoCost(double cost_add) {
+double ExchangeSolver::PseudoCostByCap(double cost_add) {
   std::vector<ExchangeNode::Ptr>::iterator n_it;
   std::map<Arc, std::vector<double> >::iterator c_it;
   std::map<Arc, double>::iterator p_it;
@@ -69,5 +69,28 @@ double ExchangeSolver::PseudoCost(double cost_add) {
 
   return max_coeff / min_unit_cap + cost_add;
 }
-  
+
+double ExchangeSolver::PseudoCostByPref(double cost_add) {
+  double cost;
+  double max_cost = 0;
+  std::vector<Arc>& arcs = graph_->arcs();
+  for (int i = 0; i != arcs.size(); i++) {
+    Arc& a = arcs[i];
+    if (!a.exclusive()) {
+      cost = 1 / a.pref();
+    } else {
+      cost = a.unode()->qty / a.pref();
+      // special case for small exclusive quantities
+      // cost add must satisfy x > 1/ p * (1 - q)
+      // guarantee strict greater than by multiply by an increase factor
+      // (e.g., 5% -> multiply by 1.05)
+      if (a.unode()->qty < 1) 
+        cost_add = std::max(cost_add, 1.05 * (1 - a.unode()->qty) / a.pref());
+    }
+    max_cost = std::max(max_cost, cost);
+    std::cout << "bar: " << max_cost << "\n";
+  }
+  return max_cost + cost_add;
+}
+
 } // namespace cyclus

--- a/src/exchange_solver.cc
+++ b/src/exchange_solver.cc
@@ -7,6 +7,14 @@
 
 namespace cyclus {
 
+double ExchangeSolver::PseudoCost() {
+  return PseudoCost(1);
+}
+
+double ExchangeSolver::PseudoCost(double cost_add) {
+  return PseudoCostByPref(cost_add);
+}
+
 double ExchangeSolver::PseudoCostByCap(double cost_add) {
   std::vector<ExchangeNode::Ptr>::iterator n_it;
   std::map<Arc, std::vector<double> >::iterator c_it;

--- a/src/exchange_solver.h
+++ b/src/exchange_solver.h
@@ -14,7 +14,13 @@ class Arc;
 /// @brief a very simple interface for solving translated resource exchanges
 class ExchangeSolver {
  public:
-  explicit ExchangeSolver(bool exclusive_orders = false)
+  /// default value to allow exclusive orders or not
+  static const bool kDefaultExclusive = true;
+  
+  /// return the cost of an arc
+  static double Cost(const Arc& a, bool exclusive_orders = kDefaultExclusive);
+
+  explicit ExchangeSolver(bool exclusive_orders = kDefaultExclusive)
     : exclusive_orders_(exclusive_orders),
       sim_ctx_(NULL),
       verbose_(false) {}
@@ -51,9 +57,9 @@ class ExchangeSolver {
   double PseudoCostByCap(double cost_factor);
   double PseudoCostByPref(double cost_factor);
   /// @}
-
+  
   /// return the cost of an arc
-  double Cost(const Arc& a);
+  inline double ArcCost(const Arc& a) { return Cost(a, exclusive_orders_); }
   
  protected:
   /// @brief Worker function for solving a graph. This must be implemented by

--- a/src/exchange_solver.h
+++ b/src/exchange_solver.h
@@ -45,7 +45,9 @@ class ExchangeSolver {
   /// @param cost_add the amount to add to the calculated ratio
   /// @{
   double PseudoCost() { return PseudoCost(1); }
-  double PseudoCost(double cost_add);
+  double PseudoCost(double cost_add) { return PseudoCostByPref(cost_add); }
+  double PseudoCostByCap(double cost_add);
+  double PseudoCostByPref(double cost_add);
   /// @}
 
  protected:

--- a/src/exchange_solver.h
+++ b/src/exchange_solver.h
@@ -7,6 +7,7 @@ namespace cyclus {
 
 class Context;
 class ExchangeGraph;
+class Arc;
 
 /// @class ExchangeSolver
 ///
@@ -42,14 +43,18 @@ class ExchangeSolver {
   /// minimum unit capacity plus an added cost. This is guaranteed to be larger
   /// than any other arc cost measure and can be used as a cost for unmet
   /// demand.
-  /// @param cost_add the amount to add to the calculated ratio
+  /// @param cost_factor the additional cost for false arc costs, i.e., max_cost
+  /// * (1 + cost_factor)
   /// @{
   double PseudoCost();
-  double PseudoCost(double cost_add);
-  double PseudoCostByCap(double cost_add);
-  double PseudoCostByPref(double cost_add);
+  double PseudoCost(double cost_factor);
+  double PseudoCostByCap(double cost_factor);
+  double PseudoCostByPref(double cost_factor);
   /// @}
 
+  /// return the cost of an arc
+  double Cost(const Arc& a);
+  
  protected:
   /// @brief Worker function for solving a graph. This must be implemented by
   /// any solver.

--- a/src/exchange_solver.h
+++ b/src/exchange_solver.h
@@ -5,6 +5,7 @@
 
 namespace cyclus {
 
+class Context;
 class ExchangeGraph;
 
 /// @class ExchangeSolver
@@ -14,9 +15,16 @@ class ExchangeSolver {
  public:
   explicit ExchangeSolver(bool exclusive_orders = false)
     : exclusive_orders_(exclusive_orders),
+      sim_ctx_(NULL),
       verbose_(false) {}
   virtual ~ExchangeSolver() {}
 
+  /// simulation context get/set
+  /// @{
+  inline void sim_ctx(Context* c) { sim_ctx_ = c; }
+  inline Context* sim_ctx() { return sim_ctx_; } 
+  /// @}
+  
   /// tell the solver to be verbose
   inline void verbose() { verbose_ = true; }
   inline void graph(ExchangeGraph* graph) { graph_ = graph; }
@@ -47,6 +55,7 @@ class ExchangeSolver {
   ExchangeGraph* graph_;
   bool exclusive_orders_;
   bool verbose_;
+  Context* sim_ctx_;
 };
 
 }  // namespace cyclus

--- a/src/exchange_solver.h
+++ b/src/exchange_solver.h
@@ -44,8 +44,8 @@ class ExchangeSolver {
   /// demand.
   /// @param cost_add the amount to add to the calculated ratio
   /// @{
-  double PseudoCost() { return PseudoCost(1); }
-  double PseudoCost(double cost_add) { return PseudoCostByPref(cost_add); }
+  double PseudoCost();
+  double PseudoCost(double cost_add);
   double PseudoCostByCap(double cost_add);
   double PseudoCostByPref(double cost_add);
   /// @}

--- a/src/exchange_translator.h
+++ b/src/exchange_translator.h
@@ -94,8 +94,7 @@ class ExchangeTranslator {
       throw ValueError(ss.str());
     }
     // get translated arc
-    Arc a = TranslateArc(xlation_ctx_, bid);
-    a.pref(pref);
+    Arc a = TranslateArc(xlation_ctx_, bid, pref);
     a.unode()->prefs[a] = pref;  // request node is a.unode()
     int n_prefs = a.unode()->prefs.size();
     
@@ -235,12 +234,18 @@ ExchangeNodeGroup::Ptr TranslateBidPortfolio(
 template <class T>
 Arc TranslateArc(const ExchangeTranslationContext<T>& translation_ctx,
                  Bid<T>* bid) {
-  Request<T>* req = bid->request();
+  return TranslateArc<T>(translation_ctx, bid, 1);
+}
 
+template <class T>
+Arc TranslateArc(const ExchangeTranslationContext<T>& translation_ctx,
+                 Bid<T>* bid, double pref) {
+  Request<T>* req = bid->request();
   ExchangeNode::Ptr unode = translation_ctx.request_to_node.at(req);
   ExchangeNode::Ptr vnode = translation_ctx.bid_to_node.at(bid);
   Arc arc(unode, vnode);
-
+  arc.pref(pref); 
+  
   typename T::Ptr offer = bid->offer();
   typename BidPortfolio<T>::Ptr bp = bid->portfolio();
   typename RequestPortfolio<T>::Ptr rp = req->portfolio();

--- a/src/exchange_translator.h
+++ b/src/exchange_translator.h
@@ -95,7 +95,7 @@ class ExchangeTranslator {
     }
     // get translated arc
     Arc a = TranslateArc(xlation_ctx_, bid);
-    
+    a.pref(pref);
     a.unode()->prefs[a] = pref;  // request node is a.unode()
     int n_prefs = a.unode()->prefs.size();
     

--- a/src/prog_solver.cc
+++ b/src/prog_solver.cc
@@ -53,6 +53,7 @@ double ProgSolver::SolveGraph() {
     // set noise level
     CoinMessageHandler h;
     h.setLogLevel(0);
+    verbose_ = true;
     if (verbose_) {
       Report(iface);
       h.setLogLevel(4);
@@ -62,7 +63,8 @@ double ProgSolver::SolveGraph() {
       std::cout << "Solving problem, message handler has log level of "
                 << iface->messageHandler()->logLevel() << "\n";
     }
-    bool verbose = false; // turn this off, solveprog prints a lot
+    //bool verbose = false; // turn this off, solveprog prints a lot
+    bool verbose = true; // turn this on for logging
 
     // solve and back translate
     SolveProg(iface, greedy_obj, verbose);

--- a/src/prog_solver.cc
+++ b/src/prog_solver.cc
@@ -14,8 +14,24 @@ void Report(OsiSolverInterface* iface) {
   std::cout << iface->getNumRows() << " constraints\n";
 }
 
+ProgSolver::ProgSolver(std::string solver_t)
+    : solver_t_(solver_t),
+      tmax_(ProgSolver::KOptimizeDefaultTimeout),
+      ExchangeSolver(false) {}
+
 ProgSolver::ProgSolver(std::string solver_t, bool exclusive_orders)
     : solver_t_(solver_t),
+      tmax_(ProgSolver::KOptimizeDefaultTimeout),
+      ExchangeSolver(exclusive_orders) {}
+
+ProgSolver::ProgSolver(std::string solver_t, double tmax)
+    : solver_t_(solver_t),
+      tmax_(tmax),
+      ExchangeSolver(false) {}
+
+ProgSolver::ProgSolver(std::string solver_t, double tmax, bool exclusive_orders)
+    : solver_t_(solver_t),
+      tmax_(tmax),
       ExchangeSolver(exclusive_orders) {}
 
 ProgSolver::~ProgSolver() {}

--- a/src/prog_solver.cc
+++ b/src/prog_solver.cc
@@ -37,7 +37,7 @@ ProgSolver::ProgSolver(std::string solver_t, double tmax, bool exclusive_orders)
 ProgSolver::~ProgSolver() {}
 
 double ProgSolver::SolveGraph() {
-  SolverFactory sf(solver_t_);
+  SolverFactory sf(solver_t_, tmax_);
   OsiSolverInterface* iface = sf.get();
   try {
     // get greedy solution

--- a/src/prog_solver.cc
+++ b/src/prog_solver.cc
@@ -17,14 +17,14 @@ void Report(OsiSolverInterface* iface) {
 
 ProgSolver::ProgSolver(std::string solver_t)
     : solver_t_(solver_t),
-      tmax_(ProgSolver::kDefaultTimeoutOptimize),
+      tmax_(ProgSolver::kDefaultTimeout),
       verbose_(false),
       mps_(false),
       ExchangeSolver(false) {}
 
 ProgSolver::ProgSolver(std::string solver_t, bool exclusive_orders)
     : solver_t_(solver_t),
-      tmax_(ProgSolver::kDefaultTimeoutOptimize),
+      tmax_(ProgSolver::kDefaultTimeout),
       verbose_(false),
       mps_(false),
       ExchangeSolver(exclusive_orders) {}

--- a/src/prog_solver.cc
+++ b/src/prog_solver.cc
@@ -17,14 +17,14 @@ void Report(OsiSolverInterface* iface) {
 
 ProgSolver::ProgSolver(std::string solver_t)
     : solver_t_(solver_t),
-      tmax_(ProgSolver::KOptimizeDefaultTimeout),
+      tmax_(ProgSolver::kDefaultTimeoutOptimize),
       verbose_(false),
       mps_(false),
       ExchangeSolver(false) {}
 
 ProgSolver::ProgSolver(std::string solver_t, bool exclusive_orders)
     : solver_t_(solver_t),
-      tmax_(ProgSolver::KOptimizeDefaultTimeout),
+      tmax_(ProgSolver::kDefaultTimeoutOptimize),
       verbose_(false),
       mps_(false),
       ExchangeSolver(exclusive_orders) {}
@@ -56,11 +56,10 @@ double ProgSolver::SolveGraph() {
   SolverFactory sf(solver_t_, tmax_);
   iface_ = sf.get();
   try {
-    // // get greedy solution
-    // GreedySolver greedy(exclusive_orders_);
-    // double greedy_obj = greedy.Solve(graph_);
-    double greedy_obj = 0;
-    // graph_->ClearMatches();
+    // get greedy solution
+    GreedySolver greedy(exclusive_orders_);
+    double greedy_obj = greedy.Solve(graph_);
+    graph_->ClearMatches();
     
     // translate graph to iface_ instance
     double pseudo_cost = PseudoCost(); // from ExchangeSolver API

--- a/src/prog_solver.cc
+++ b/src/prog_solver.cc
@@ -17,21 +17,26 @@ void Report(OsiSolverInterface* iface) {
 ProgSolver::ProgSolver(std::string solver_t)
     : solver_t_(solver_t),
       tmax_(ProgSolver::KOptimizeDefaultTimeout),
+      verbose_(false),
       ExchangeSolver(false) {}
 
 ProgSolver::ProgSolver(std::string solver_t, bool exclusive_orders)
     : solver_t_(solver_t),
       tmax_(ProgSolver::KOptimizeDefaultTimeout),
+      verbose_(false),
       ExchangeSolver(exclusive_orders) {}
 
 ProgSolver::ProgSolver(std::string solver_t, double tmax)
     : solver_t_(solver_t),
       tmax_(tmax),
+      verbose_(false),
       ExchangeSolver(false) {}
 
-ProgSolver::ProgSolver(std::string solver_t, double tmax, bool exclusive_orders)
+ProgSolver::ProgSolver(std::string solver_t, double tmax, bool exclusive_orders,
+                       bool verbose)
     : solver_t_(solver_t),
       tmax_(tmax),
+      verbose_(verbose),
       ExchangeSolver(exclusive_orders) {}
 
 ProgSolver::~ProgSolver() {}
@@ -53,7 +58,6 @@ double ProgSolver::SolveGraph() {
     // set noise level
     CoinMessageHandler h;
     h.setLogLevel(0);
-    verbose_ = true;
     if (verbose_) {
       Report(iface);
       h.setLogLevel(4);
@@ -63,11 +67,9 @@ double ProgSolver::SolveGraph() {
       std::cout << "Solving problem, message handler has log level of "
                 << iface->messageHandler()->logLevel() << "\n";
     }
-    //bool verbose = false; // turn this off, solveprog prints a lot
-    bool verbose = true; // turn this on for logging
 
     // solve and back translate
-    SolveProg(iface, greedy_obj, verbose);
+    SolveProg(iface, greedy_obj, verbose_);
     xlator.FromProg();
   } catch(...) {
     delete iface;

--- a/src/prog_solver.h
+++ b/src/prog_solver.h
@@ -14,7 +14,18 @@ class ExchangeGraph;
 /// programming solution to a resource exchange graph.
 class ProgSolver: public ExchangeSolver {
  public:
-  ProgSolver(std::string solver_t, bool exclusive_orders = false);
+  static const int KOptimizeDefaultTimeout = 5 * 60; // 5 * 60 s/min == 5 minutes
+
+  /// @param solver_t the solver type, either "cbc" or "clp"
+  /// @param tmax the maximum solution time, default kOptimizeDefaultTimeout
+  /// @param exclusive_orders whether all orders must be exclusive or not,
+  /// default false
+  /// @{
+  ProgSolver(std::string solver_t);
+  ProgSolver(std::string solver_t, double tmax);
+  ProgSolver(std::string solver_t, bool exclusive_orders);
+  ProgSolver(std::string solver_t, double tmax, bool exclusive_orders);
+  /// @}
   virtual ~ProgSolver();
 
  protected:
@@ -23,6 +34,7 @@ class ProgSolver: public ExchangeSolver {
   
  private:
   std::string solver_t_;
+  double tmax_;
 };
 
 }  // namespace cyclus

--- a/src/prog_solver.h
+++ b/src/prog_solver.h
@@ -22,12 +22,14 @@ class ProgSolver: public ExchangeSolver {
   /// @param tmax the maximum solution time, default kOptimizeDefaultTimeout
   /// @param exclusive_orders whether all orders must be exclusive or not,
   /// default false
-  /// @param verbose print out a lot to stdout
+  /// @param verbose print out a lot to stdout, default false
+  /// @param mps dump mps files for every solve, default false
   /// @{
   ProgSolver(std::string solver_t);
   ProgSolver(std::string solver_t, double tmax);
   ProgSolver(std::string solver_t, bool exclusive_orders);
-  ProgSolver(std::string solver_t, double tmax, bool exclusive_orders, bool verbose);
+  ProgSolver(std::string solver_t, double tmax, bool exclusive_orders,
+             bool verbose, bool mps);
   /// @}
   virtual ~ProgSolver();
 
@@ -40,7 +42,7 @@ class ProgSolver: public ExchangeSolver {
   
   std::string solver_t_;
   double tmax_;
-  bool verbose_;
+  bool verbose_, mps_;
   OsiSolverInterface* iface_;
 };
 

--- a/src/prog_solver.h
+++ b/src/prog_solver.h
@@ -3,6 +3,8 @@
 
 #include <string>
 
+#include "OsiSolverInterface.hpp"
+
 #include "exchange_graph.h"
 #include "exchange_solver.h"
 
@@ -34,9 +36,12 @@ class ProgSolver: public ExchangeSolver {
   virtual double SolveGraph();
   
  private:
+  void WriteMPS();
+  
   std::string solver_t_;
   double tmax_;
   bool verbose_;
+  OsiSolverInterface* iface_;
 };
 
 }  // namespace cyclus

--- a/src/prog_solver.h
+++ b/src/prog_solver.h
@@ -20,11 +20,12 @@ class ProgSolver: public ExchangeSolver {
   /// @param tmax the maximum solution time, default kOptimizeDefaultTimeout
   /// @param exclusive_orders whether all orders must be exclusive or not,
   /// default false
+  /// @param verbose print out a lot to stdout
   /// @{
   ProgSolver(std::string solver_t);
   ProgSolver(std::string solver_t, double tmax);
   ProgSolver(std::string solver_t, bool exclusive_orders);
-  ProgSolver(std::string solver_t, double tmax, bool exclusive_orders);
+  ProgSolver(std::string solver_t, double tmax, bool exclusive_orders, bool verbose);
   /// @}
   virtual ~ProgSolver();
 
@@ -35,6 +36,7 @@ class ProgSolver: public ExchangeSolver {
  private:
   std::string solver_t_;
   double tmax_;
+  bool verbose_;
 };
 
 }  // namespace cyclus

--- a/src/prog_solver.h
+++ b/src/prog_solver.h
@@ -16,10 +16,10 @@ class ExchangeGraph;
 /// programming solution to a resource exchange graph.
 class ProgSolver: public ExchangeSolver {
  public:
-  static const int kDefaultTimeoutOptimize = 5 * 60; // 5 * 60 s/min == 5 minutes
+  static const int kDefaultTimeout = 5 * 60; // 5 * 60 s/min == 5 minutes
 
   /// @param solver_t the solver type, either "cbc" or "clp"
-  /// @param tmax the maximum solution time, default kDefaultTimeoutOptimize
+  /// @param tmax the maximum solution time, default kDefaultTimeout
   /// @param exclusive_orders whether all orders must be exclusive or not,
   /// default false
   /// @param verbose print out a lot to stdout, default false

--- a/src/prog_solver.h
+++ b/src/prog_solver.h
@@ -16,10 +16,10 @@ class ExchangeGraph;
 /// programming solution to a resource exchange graph.
 class ProgSolver: public ExchangeSolver {
  public:
-  static const int KOptimizeDefaultTimeout = 5 * 60; // 5 * 60 s/min == 5 minutes
+  static const int kDefaultTimeoutOptimize = 5 * 60; // 5 * 60 s/min == 5 minutes
 
   /// @param solver_t the solver type, either "cbc" or "clp"
-  /// @param tmax the maximum solution time, default kOptimizeDefaultTimeout
+  /// @param tmax the maximum solution time, default kDefaultTimeoutOptimize
   /// @param exclusive_orders whether all orders must be exclusive or not,
   /// default false
   /// @param verbose print out a lot to stdout, default false

--- a/src/prog_translator.cc
+++ b/src/prog_translator.cc
@@ -7,6 +7,7 @@
 
 #include "cyc_limits.h"
 #include "exchange_graph.h"
+#include "logger.h"
 
 namespace cyclus {
 
@@ -74,6 +75,8 @@ void ProgTranslator::Translate() {
   }
 
   // add each false arc
+  CLOG(LEV_DEBUG1) << "Adding " << arc_offset_ - g_->arcs().size()
+                   << " false arcs.";
   double inf = iface_->getInfinity();
   for (int i = g_->arcs().size(); i != arc_offset_; i++) {
     ctx_.obj_coeffs[i] = pseudo_cost_;
@@ -160,8 +163,9 @@ void ProgTranslator::XlateGrp_(ExchangeNodeGroup* grp, bool request) {
     if (request) {
       cap_rows[i].insert(faux_id, 1.0);  // faux arc
     }
-    
-    ctx_.row_lbs.push_back(request ? caps[i] : 0);
+
+    double rlb = std::min(caps[i], 1e99); // 1e99 is max value for COIN solvers
+    ctx_.row_lbs.push_back(request ? rlb : 0);
     ctx_.row_ubs.push_back(request ? inf : caps[i]);
     ctx_.m.appendRow(cap_rows[i]);
   }

--- a/src/prog_translator.cc
+++ b/src/prog_translator.cc
@@ -181,7 +181,9 @@ void ProgTranslator::XlateGrp_(ExchangeNodeGroup* grp, bool request) {
       cap_rows[i].insert(faux_id, 1.0);  // faux arc
     }
 
-    double rlb = std::min(caps[i], 1e99); // 1e99 is max value for COIN solvers
+    // 1e15 is the largest value that doesn't make the solver fall over
+    // (by emperical testing)
+    double rlb = std::min(caps[i], 1e15); 
     ctx_.row_lbs.push_back(request ? rlb : 0);
     ctx_.row_ubs.push_back(request ? inf : caps[i]);
     ctx_.m.appendRow(cap_rows[i]);

--- a/src/prog_translator.cc
+++ b/src/prog_translator.cc
@@ -158,13 +158,11 @@ void ProgTranslator::XlateGrp_(ExchangeNodeGroup* grp, bool request) {
       }
 
       if (request) {
-        double pref = a.pref();
-        CheckPref(pref);
-        double col_ub = std::min(nodes[i]->qty, inf);
-        double solver_cost = ExchangeSolver::Cost(a, excl_);
-        ctx_.obj_coeffs[arc_id] = solver_cost;
+        CheckPref(a.pref());
+        ctx_.obj_coeffs[arc_id] = ExchangeSolver::Cost(a, excl_);
         ctx_.col_lbs[arc_id] = 0;
-        ctx_.col_ubs[arc_id] = (excl_ && a.exclusive()) ? 1 : col_ub;
+        ctx_.col_ubs[arc_id] = (excl_ && a.exclusive()) ? 1 :
+                               std::min(nodes[i]->qty, inf);
       }
     }
   }

--- a/src/prog_translator.cc
+++ b/src/prog_translator.cc
@@ -61,7 +61,10 @@ void ProgTranslator::CheckPref(double pref) {
   if (pref <= 0) {
     std::stringstream ss;
     ss << "Preference value found to be nonpositive (" << pref
-       << "). Preferences must be positive when using an optimization solver.";
+       << "). Preferences must be positive when using an optimization solver."
+       << " If using Cyclus in simulation mode (e.g., from the command line),"
+       << " this error is likely a bug in Cyclus. Please report it to the developer's "
+       << "list (https://groups.google.com/forum/#!forum/cyclus-dev).";
     throw ValueError(ss.str());
   }
 }

--- a/src/prog_translator.cc
+++ b/src/prog_translator.cc
@@ -8,6 +8,7 @@
 #include "cyc_limits.h"
 #include "error.h"
 #include "exchange_graph.h"
+#include "exchange_solver.h"
 #include "logger.h"
 
 namespace cyclus {
@@ -46,7 +47,6 @@ ProgTranslator::ProgTranslator(ExchangeGraph* g, OsiSolverInterface* iface,
       pseudo_cost_(pseudo_cost) {
   Init();
 }
-
 
 void ProgTranslator::Init() {
   arc_offset_ = g_->arcs().size();
@@ -162,7 +162,7 @@ void ProgTranslator::XlateGrp_(ExchangeNodeGroup* grp, bool request) {
         double pref = nodes[i]->prefs[a];
         CheckPref(pref);
         double col_ub = std::min(nodes[i]->qty, inf);
-        double obj_coeff = (excl_ && a.exclusive()) ? a.excl_val() / pref : 1.0 / pref;
+        double obj_coeff = ExchangeSolver::Cost(a, excl_);
         ctx_.obj_coeffs[arc_id] = obj_coeff;
         ctx_.col_lbs[arc_id] = 0;
         ctx_.col_ubs[arc_id] = (excl_ && a.exclusive()) ? 1 : col_ub;

--- a/src/prog_translator.cc
+++ b/src/prog_translator.cc
@@ -158,12 +158,11 @@ void ProgTranslator::XlateGrp_(ExchangeNodeGroup* grp, bool request) {
       }
 
       if (request) {
-        // add obj coeff for arc
-        double pref = nodes[i]->prefs[a];
+        double pref = a.pref();
         CheckPref(pref);
         double col_ub = std::min(nodes[i]->qty, inf);
-        double obj_coeff = ExchangeSolver::Cost(a, excl_);
-        ctx_.obj_coeffs[arc_id] = obj_coeff;
+        double solver_cost = ExchangeSolver::Cost(a, excl_);
+        ctx_.obj_coeffs[arc_id] = solver_cost;
         ctx_.col_lbs[arc_id] = 0;
         ctx_.col_ubs[arc_id] = (excl_ && a.exclusive()) ? 1 : col_ub;
       }

--- a/src/prog_translator.h
+++ b/src/prog_translator.h
@@ -66,7 +66,10 @@ class ProgTranslator {
 
  private:
   void Init();
- 
+
+  /// @throws if preference is unsatisfactory (i.e., not greater than 0)
+  void CheckPref(double pref);
+  
   /// perform all translation for a node group
   /// @param grp a pointer to the node group
   /// @param req a boolean flag, true if grp is a request group

--- a/src/resource_exchange.h
+++ b/src/resource_exchange.h
@@ -63,7 +63,9 @@ class ResourceExchange {
   /// @brief default constructor
   ///
   /// @param ctx the simulation context
-  ResourceExchange(Context* ctx) : ctx_(ctx) { }
+  ResourceExchange(Context* ctx) {
+    sim_ctx_ = ctx;
+  }
 
   inline ExchangeContext<T>& ex_ctx() {
     return ex_ctx_;
@@ -101,16 +103,14 @@ class ResourceExchange {
             this));
   }
 
-  /// check if this is an empty exchange (i.e., no requests exist, therefore no
-  /// bids)
-  bool Empty() {
-    return ex_ctx_.bids_by_request.empty();
-  }
+  /// return true if this is an empty exchange (i.e., no requests exist,
+  /// therefore no bids)
+  inline bool Empty() { return ex_ctx_.bids_by_request.empty(); }
 
  private:
   void InitTraders() {
     if (traders_.size() == 0) {
-      std::set<Trader*> orig = ctx_->traders();
+      std::set<Trader*> orig = sim_ctx_->traders();
       std::set<Trader*>::iterator it;
       for (it = orig.begin(); it != orig.end(); ++it) {
         traders_.insert(*it);
@@ -155,14 +155,13 @@ class ResourceExchange {
     }
   };
 
-  Context* ctx_;
-
   // this sorts traders (and results in iteration...) based on traders'
   // manager id.  Iterating over traders in this order helps increase the
   // determinism of Cyclus overall.  This allows all traders' resource
   // exchange functions are called in a much closer to deterministic order.
   std::set<Trader*, trader_compare> traders_;
 
+  Context* sim_ctx_;
   ExchangeContext<T> ex_ctx_;
 };
 

--- a/src/resource_exchange.h
+++ b/src/resource_exchange.h
@@ -101,6 +101,12 @@ class ResourceExchange {
             this));
   }
 
+  /// check if this is an empty exchange (i.e., no requests exist, therefore no
+  /// bids)
+  bool Empty() {
+    return ex_ctx_.bids_by_request.empty();
+  }
+
  private:
   void InitTraders() {
     if (traders_.size() == 0) {

--- a/src/sim_init.cc
+++ b/src/sim_init.cc
@@ -257,8 +257,8 @@ void SimInit::LoadSolverInfo() {
   using std::string;
   // context will delete solver
   ExchangeSolver* solver;
-  string solver_name = string("greedy");
-  bool exclusive_orders = false;
+  string solver_name;
+  bool exclusive_orders; // exclusive orders allowed
 
   // load in possible Solver info, needs to be optional to
   // maintain backwards compatibility, defaults above.

--- a/src/sim_init.cc
+++ b/src/sim_init.cc
@@ -245,7 +245,7 @@ ExchangeSolver* SimInit::LoadCoinSolver(bool exclusive,
     mps = qr.GetVal<bool>("Mps");
   }
 
-  timeout = timeout <= 0 ? ProgSolver::KOptimizeDefaultTimeout : timeout;
+  timeout = timeout <= 0 ? ProgSolver::kDefaultTimeoutOptimize : timeout;
   solver = new ProgSolver("cbc", timeout, exclusive, verbose, mps);
   return solver;
 }

--- a/src/sim_init.cc
+++ b/src/sim_init.cc
@@ -257,7 +257,7 @@ void SimInit::LoadSolverInfo() {
   // context will delete solver
   ExchangeSolver* solver;
   string solver_name;
-  bool exclusive_orders; // exclusive orders allowed
+  bool exclusive_orders;
 
   // load in possible Solver info, needs to be optional to
   // maintain backwards compatibility, defaults above.

--- a/src/sim_init.cc
+++ b/src/sim_init.cc
@@ -245,6 +245,7 @@ ExchangeSolver* SimInit::LoadCoinSolver(bool exclusive,
     mps = qr.GetVal<bool>("Mps");
   }
 
+  // set timeout to default if input value is non-positive
   timeout = timeout <= 0 ? ProgSolver::kDefaultTimeout : timeout;
   solver = new ProgSolver("cbc", timeout, exclusive, verbose, mps);
   return solver;

--- a/src/sim_init.cc
+++ b/src/sim_init.cc
@@ -245,7 +245,7 @@ ExchangeSolver* SimInit::LoadCoinSolver(bool exclusive,
     mps = qr.GetVal<bool>("Mps");
   }
 
-  timeout = timeout <= 0 ? ProgSolver::kDefaultTimeoutOptimize : timeout;
+  timeout = timeout <= 0 ? ProgSolver::kDefaultTimeout : timeout;
   solver = new ProgSolver("cbc", timeout, exclusive, verbose, mps);
   return solver;
 }

--- a/src/sim_init.cc
+++ b/src/sim_init.cc
@@ -245,11 +245,8 @@ ExchangeSolver* SimInit::LoadCoinSolver(bool exclusive,
     mps = qr.GetVal<bool>("Mps");
   }
 
-  if (timeout <= 0) {
-    solver = new ProgSolver("cbc", exclusive);
-  } else {
-    solver = new ProgSolver("cbc", timeout, exclusive, verbose, mps);
-  }
+  timeout = timeout <= 0 ? ProgSolver::KOptimizeDefaultTimeout : timeout;
+  solver = new ProgSolver("cbc", timeout, exclusive, verbose, mps);
   return solver;
 }
 

--- a/src/sim_init.cc
+++ b/src/sim_init.cc
@@ -235,19 +235,20 @@ ExchangeSolver* SimInit::LoadCoinSolver(bool exclusive,
                                         std::set<std::string> tables) {
   ExchangeSolver* solver;
   double timeout;
-  bool verbose;
+  bool verbose, mps;
   
   std::string solver_info = "CoinSolverInfo";
   if (0 < tables.count(solver_info)) {
     QueryResult qr = b_->Query(solver_info, NULL);
     timeout = qr.GetVal<double>("Timeout");
     verbose = qr.GetVal<bool>("Verbose");
+    mps = qr.GetVal<bool>("Mps");
   }
 
   if (timeout <= 0) {
     solver = new ProgSolver("cbc", exclusive);
   } else {
-    solver = new ProgSolver("cbc", timeout, exclusive, verbose);
+    solver = new ProgSolver("cbc", timeout, exclusive, verbose, mps);
   }
   return solver;
 }

--- a/src/sim_init.cc
+++ b/src/sim_init.cc
@@ -234,20 +234,20 @@ ExchangeSolver* SimInit::LoadGreedySolver(bool exclusive,
 ExchangeSolver* SimInit::LoadCoinSolver(bool exclusive, 
                                         std::set<std::string> tables) {
   ExchangeSolver* solver;
-  double timeout = -1;
+  double timeout;
+  bool verbose;
   
   std::string solver_info = "CoinSolverInfo";
   if (0 < tables.count(solver_info)) {
     QueryResult qr = b_->Query(solver_info, NULL);
-    if (qr.rows.size() > 0) {
-      timeout = qr.GetVal<double>("Timeout");
-    }
+    timeout = qr.GetVal<double>("Timeout");
+    verbose = qr.GetVal<bool>("Verbose");
   }
 
   if (timeout <= 0) {
     solver = new ProgSolver("cbc", exclusive);
   } else {
-    solver = new ProgSolver("cbc", timeout, exclusive);
+    solver = new ProgSolver("cbc", timeout, exclusive, verbose);
   }
   return solver;
 }

--- a/src/sim_init.h
+++ b/src/sim_init.h
@@ -90,6 +90,7 @@ class SimInit {
 
   void* LoadPreconditioner(std::string name);
   ExchangeSolver* LoadGreedySolver(bool exclusive, std::set<std::string> tables);
+  ExchangeSolver* LoadOptimizeSolver(bool exclusive, std::set<std::string> tables);
   static Resource::Ptr LoadResource(Context* ctx, QueryableBackend* b, int resid);
   static Material::Ptr LoadMaterial(Context* ctx, QueryableBackend* b, int resid);
   static Product::Ptr LoadProduct(Context* ctx, QueryableBackend* b, int resid);

--- a/src/sim_init.h
+++ b/src/sim_init.h
@@ -90,7 +90,7 @@ class SimInit {
 
   void* LoadPreconditioner(std::string name);
   ExchangeSolver* LoadGreedySolver(bool exclusive, std::set<std::string> tables);
-  ExchangeSolver* LoadOptimizeSolver(bool exclusive, std::set<std::string> tables);
+  ExchangeSolver* LoadCoinSolver(bool exclusive, std::set<std::string> tables);
   static Resource::Ptr LoadResource(Context* ctx, QueryableBackend* b, int resid);
   static Material::Ptr LoadMaterial(Context* ctx, QueryableBackend* b, int resid);
   static Product::Ptr LoadProduct(Context* ctx, QueryableBackend* b, int resid);

--- a/src/solver_factory.cc
+++ b/src/solver_factory.cc
@@ -127,16 +127,16 @@ void SolveProg(OsiSolverInterface* si, double greedy_obj, bool verbose) {
     const char *argv[] = {"exchng", "-log", "0", "-solve","-quit"};
     int argc = 3;
     CbcModel model(*si);
-    // ObjValueHandler handler(greedy_obj);
+    ObjValueHandler handler(greedy_obj);
     CbcMain0(model);
-    // model.passInEventHandler(&handler);
+    model.passInEventHandler(&handler);
     CbcMain1(argc, argv, model, CbcCallBack);
     si->setColSolution(model.getColSolution());
-    // if (verbose) {
-    //   std::cout << "Greedy equivalent time: " << handler.time()
-    //             << " and obj " << handler.obj()
-    //             << " and found " << std::boolalpha << handler.found() << "\n";
-    // }
+    if (verbose) {
+      std::cout << "Greedy equivalent time: " << handler.time()
+                << " and obj " << handler.obj()
+                << " and found " << std::boolalpha << handler.found() << "\n";
+    }
   } else {
     // no ints, just solve 'initial lp relaxation' 
     si->initialSolve();

--- a/src/solver_factory.cc
+++ b/src/solver_factory.cc
@@ -127,16 +127,16 @@ void SolveProg(OsiSolverInterface* si, double greedy_obj, bool verbose) {
     const char *argv[] = {"exchng", "-log", "0", "-solve","-quit"};
     int argc = 3;
     CbcModel model(*si);
-    ObjValueHandler handler(greedy_obj);
+    // ObjValueHandler handler(greedy_obj);
     CbcMain0(model);
-    model.passInEventHandler(&handler);
+    // model.passInEventHandler(&handler);
     CbcMain1(argc, argv, model, CbcCallBack);
     si->setColSolution(model.getColSolution());
-    if (verbose) {
-      std::cout << "Greedy equivalent time: " << handler.time()
-                << " and obj " << handler.obj()
-                << " and found " << std::boolalpha << handler.found() << "\n";
-    }
+    // if (verbose) {
+    //   std::cout << "Greedy equivalent time: " << handler.time()
+    //             << " and obj " << handler.obj()
+    //             << " and found " << std::boolalpha << handler.found() << "\n";
+    // }
   } else {
     // no ints, just solve 'initial lp relaxation' 
     si->initialSolve();

--- a/src/solver_factory.h
+++ b/src/solver_factory.h
@@ -49,10 +49,10 @@ class SolverFactory {
   inline void solver_t(std::string t) { t_ = t; }
   inline const std::string solver_t() const { return t_; }
   inline std::string solver_t() { return t_; }
-
+  
   /// get the configured solver
   OsiSolverInterface* get();
-
+  
  private:
   std::string t_;
   double tmax_;

--- a/src/xml_file_loader.cc
+++ b/src/xml_file_loader.cc
@@ -212,7 +212,7 @@ void XMLFileLoader::LoadSolver() {
   string greedy = "greedy";
   string coinor = "coin-or";
   string solver_name = greedy;
-  bool exclusive = false;
+  bool exclusive = true;
   if (xqe.NMatches("/*/control/solver") == 1) {
     qe = xqe.SubTree("/*/control/solver");
     if (qe->NMatches(config) == 1) {

--- a/src/xml_file_loader.cc
+++ b/src/xml_file_loader.cc
@@ -210,10 +210,11 @@ void XMLFileLoader::LoadSolver() {
   // now load the solver info
   string config = "config";
   string greedy = "greedy";
+  string coinor = "coin-or";
   string solver_name = greedy;
   bool exclusive = false;
-  if (xqe.NMatches("/control/solver") == 1) {
-    qe = xqe.SubTree("/control/solver");
+  if (xqe.NMatches("/*/control/solver") == 1) {
+    qe = xqe.SubTree("/*/control/solver");
     if (qe->NMatches(config) == 1) {
       solver_name = qe->SubTree(config)->GetElementName(0);
     }
@@ -226,11 +227,17 @@ void XMLFileLoader::LoadSolver() {
       ->Record();
 
   // now load the actual solver
-  if (solver_name == "greedy") {
-    query = string("/control/solver/config/greedy/preconditioner");
+  if (solver_name == greedy) {
+    query = string("/*/control/solver/config/greedy/preconditioner");
     string precon_name = cyclus::OptionalQuery<string>(&xqe, query, greedy);
     ctx_->NewDatum("GreedySolverInfo")
       ->AddVal("Preconditioner", precon_name)
+      ->Record();
+  } else if (solver_name == coinor) {
+    query = string("/*/control/solver/config/coin-or/timeout");
+    double timeout = cyclus::OptionalQuery<double>(&xqe, query, -1);
+    ctx_->NewDatum("CoinSolverInfo")
+      ->AddVal("Timeout", timeout)
       ->Record();
   } else {
     throw ValueError("unknown solver name: " + solver_name);

--- a/src/xml_file_loader.cc
+++ b/src/xml_file_loader.cc
@@ -236,8 +236,11 @@ void XMLFileLoader::LoadSolver() {
   } else if (solver_name == coinor) {
     query = string("/*/control/solver/config/coin-or/timeout");
     double timeout = cyclus::OptionalQuery<double>(&xqe, query, -1);
+    query = string("/*/control/solver/config/coin-or/verbose");
+    bool verbose = cyclus::OptionalQuery<bool>(&xqe, query, false);
     ctx_->NewDatum("CoinSolverInfo")
       ->AddVal("Timeout", timeout)
+      ->AddVal("Verbose", verbose)
       ->Record();
   } else {
     throw ValueError("unknown solver name: " + solver_name);

--- a/src/xml_file_loader.cc
+++ b/src/xml_file_loader.cc
@@ -221,6 +221,15 @@ void XMLFileLoader::LoadSolver() {
     }
     exclusive = cyclus::OptionalQuery<bool>(qe, "allow_exclusive_orders", 
                                             exclusive);
+    
+    // @TODO remove this after release 1.5
+    // check for deprecated input values
+    if (qe->NMatches(std::string("exclusive_orders_only")) != 0) {
+      std::stringstream ss;
+      ss << "Use of 'exclusive_orders_only' is deprecated."
+         << " Please see http://fuelcycle.org/user/input_specs/control.html";
+      Warn<DEPRECATION_WARNING>(ss.str());
+    }
   }
 
   if (!exclusive) {
@@ -234,17 +243,7 @@ void XMLFileLoader::LoadSolver() {
   ctx_->NewDatum("SolverInfo")
       ->AddVal("Solver", solver_name)
       ->AddVal("ExclusiveOrders", exclusive)
-      ->Record();
-
-  // @TODO remove this after release 1.5
-  // check for deprecated input values
-  if (qe->NMatches("exclusive_orders_only") > 0) {
-    std::stringstream ss;
-    ss << "Use of 'exclusive_orders_only' is deprecated."
-       << " Please see http://fuelcycle.org/user/input_specs/control.html";
-    Warn<DEPRECATION_WARNING>(ss.str());
-  }
-  
+      ->Record();  
   
   // now load the actual solver
   if (solver_name == greedy) {

--- a/src/xml_file_loader.cc
+++ b/src/xml_file_loader.cc
@@ -238,7 +238,7 @@ void XMLFileLoader::LoadSolver() {
     double timeout = cyclus::OptionalQuery<double>(&xqe, query, -1);
     query = string("/*/control/solver/config/coin-or/verbose");
     bool verbose = cyclus::OptionalQuery<bool>(&xqe, query, false);
-    query = string("/*/control/solver/config/coin-or/dump");
+    query = string("/*/control/solver/config/coin-or/mps");
     bool mps = cyclus::OptionalQuery<bool>(&xqe, query, false);
     ctx_->NewDatum("CoinSolverInfo")
       ->AddVal("Timeout", timeout)

--- a/src/xml_file_loader.cc
+++ b/src/xml_file_loader.cc
@@ -238,9 +238,12 @@ void XMLFileLoader::LoadSolver() {
     double timeout = cyclus::OptionalQuery<double>(&xqe, query, -1);
     query = string("/*/control/solver/config/coin-or/verbose");
     bool verbose = cyclus::OptionalQuery<bool>(&xqe, query, false);
+    query = string("/*/control/solver/config/coin-or/dump");
+    bool mps = cyclus::OptionalQuery<bool>(&xqe, query, false);
     ctx_->NewDatum("CoinSolverInfo")
       ->AddVal("Timeout", timeout)
       ->AddVal("Verbose", verbose)
+      ->AddVal("Mps", mps)
       ->Record();
   } else {
     throw ValueError("unknown solver name: " + solver_name);

--- a/src/xml_file_loader.cc
+++ b/src/xml_file_loader.cc
@@ -14,6 +14,7 @@
 #include "cyc_std.h"
 #include "env.h"
 #include "error.h"
+#include "exchange_solver.h"
 #include "greedy_preconditioner.h"
 #include "greedy_solver.h"
 #include "infile_tree.h"
@@ -212,7 +213,7 @@ void XMLFileLoader::LoadSolver() {
   string greedy = "greedy";
   string coinor = "coin-or";
   string solver_name = greedy;
-  bool exclusive = true;
+  bool exclusive = ExchangeSolver::kDefaultExclusive;
   if (xqe.NMatches("/*/control/solver") == 1) {
     qe = xqe.SubTree("/*/control/solver");
     if (qe->NMatches(config) == 1) {

--- a/tests/input/minimal_cycle.xml
+++ b/tests/input/minimal_cycle.xml
@@ -2,7 +2,7 @@
 
 <simulation>
   <control>
-    <duration>100</duration>
+    <duration>50</duration>
     <startmonth>1</startmonth>
     <startyear>2000</startyear>
   <solver><config><coin-or><timeout>100</timeout><verbose>1</verbose></coin-or></config></solver></control>

--- a/tests/input/minimal_cycle.xml
+++ b/tests/input/minimal_cycle.xml
@@ -5,7 +5,7 @@
     <duration>100</duration>
     <startmonth>1</startmonth>
     <startyear>2000</startyear>
-  </control>
+  <solver><config><coin-or><timeout>100</timeout><verbose>1</verbose></coin-or></config></solver></control>
 
   <archetypes>
     <spec><lib>agents</lib><name>KFacility</name></spec>

--- a/tests/input/null_sink.xml
+++ b/tests/input/null_sink.xml
@@ -5,7 +5,7 @@
     <duration>100</duration>
     <startmonth>1</startmonth>
     <startyear>2000</startyear>
-  </control>
+  <solver><config><coin-or><timeout>10</timeout></coin-or></config></solver></control>
 
   <archetypes>
     <spec><lib>agents</lib><name>Sink</name></spec>

--- a/tests/input/source_to_sink.xml
+++ b/tests/input/source_to_sink.xml
@@ -5,7 +5,7 @@
     <duration>100</duration>
     <startmonth>1</startmonth>
     <startyear>2000</startyear>
-    <solver><coin-or/></solver>
+    <solver><coin-or><timeout>3600</timeout></coin-or></solver>
   </control>
 
   <archetypes>

--- a/tests/input/source_to_sink.xml
+++ b/tests/input/source_to_sink.xml
@@ -5,7 +5,7 @@
     <duration>100</duration>
     <startmonth>1</startmonth>
     <startyear>2000</startyear>
-    <solver><coin-or><timeout>3600</timeout></coin-or></solver>
+    <solver><config><coin-or><timeout>3599</timeout></coin-or></config></solver>
   </control>
 
   <archetypes>

--- a/tests/input/source_to_sink.xml
+++ b/tests/input/source_to_sink.xml
@@ -5,7 +5,7 @@
     <duration>100</duration>
     <startmonth>1</startmonth>
     <startyear>2000</startyear>
-    <solver><optimize><library>coin</library></optimize></solver>
+    <solver><coin-or/></solver>
   </control>
 
   <archetypes>

--- a/tests/input/source_to_sink.xml
+++ b/tests/input/source_to_sink.xml
@@ -5,6 +5,7 @@
     <duration>100</duration>
     <startmonth>1</startmonth>
     <startyear>2000</startyear>
+    <solver><optimize><library>coin</library></optimize></solver>
   </control>
 
   <archetypes>

--- a/tests/input/trivial_cycle.xml
+++ b/tests/input/trivial_cycle.xml
@@ -2,7 +2,7 @@
 
 <simulation>
   <control>
-    <duration>100</duration>
+    <duration>50</duration>
     <startmonth>1</startmonth>
     <startyear>2000</startyear>
   <solver><config><coin-or><timeout>10</timeout></coin-or></config></solver></control>

--- a/tests/input/trivial_cycle.xml
+++ b/tests/input/trivial_cycle.xml
@@ -5,7 +5,7 @@
     <duration>100</duration>
     <startmonth>1</startmonth>
     <startyear>2000</startyear>
-  </control>
+  <solver><config><coin-or><timeout>10</timeout></coin-or></config></solver></control>
 
   <archetypes>
     <spec><lib>agents</lib><name>KFacility</name></spec>

--- a/tests/integ_tests.cc
+++ b/tests/integ_tests.cc
@@ -84,7 +84,9 @@ TEST(IntegTests, CustomTimestepDur) {
     QueryResult qr = back.Query("TimeStepDur", NULL);
     EXPECT_EQ(86400, qr.GetVal<int>("DurationSecs"));
   }
+}
 
+TEST(IntegTests, CustomTimestepDurFlat) {
   {
     SqliteBack back(":memory:");
     RunSim("custom_dt_flat.xml", &back);

--- a/tests/prog_translator_tests.cc
+++ b/tests/prog_translator_tests.cc
@@ -79,10 +79,15 @@ TEST(ProgTranslatorTests, translation) {
   ExchangeNode::Ptr d1(new ExchangeNode());
 
   Arc x0(a0, c0);
+  x0.pref(prefs[0]);
   Arc x1(b0, c1);
+  x1.pref(prefs[1]);
   Arc x2(b1, c2);
+  x2.pref(prefs[2]);
   Arc x3(a1, d0);
+  x3.pref(prefs[3]);
   Arc x4(b1, d1);
+  x4.pref(prefs[4]);
 
   a0->unit_capacities[x0] = std::vector<double>(
       ucaps_a_0, ucaps_a_0 + sizeof(ucaps_a_0) / sizeof(ucaps_a_0[0]) );

--- a/tests/sim_init_tests.cc
+++ b/tests/sim_init_tests.cc
@@ -97,6 +97,10 @@ class SimInitTest : public ::testing::Test {
     b = new cy::SqliteBack(dbpath);
     rec.RegisterBackend(b);
     ctx = new cy::Context(&ti, &rec);
+    ctx->NewDatum("SolverInfo")
+        ->AddVal("Solver", "greedy")
+        ->AddVal("ExclusiveOrders", true)
+        ->Record();
     ctx->InitSim(cy::SimInfo(5));
 
     cy::CompMap v;

--- a/tests/sim_init_tests.cc
+++ b/tests/sim_init_tests.cc
@@ -98,7 +98,7 @@ class SimInitTest : public ::testing::Test {
     rec.RegisterBackend(b);
     ctx = new cy::Context(&ti, &rec);
     ctx->NewDatum("SolverInfo")
-        ->AddVal("Solver", "greedy")
+        ->AddVal("Solver", std::string("greedy")) // str constructor for macs
         ->AddVal("ExclusiveOrders", true)
         ->Record();
     ctx->InitSim(cy::SimInfo(5));

--- a/tests/test_minimal_cycle.py
+++ b/tests/test_minimal_cycle.py
@@ -181,17 +181,17 @@ def test_minimal_cycle():
 
             yield assert_array_equal, \
                 np.where(sender_ids == facility_a[0])[0], \
-                pattern_a
+                pattern_a, "Fac A Pattern A"
             yield assert_array_equal, \
                 np.where(receiver_ids == facility_a[0])[0], \
-                pattern_b  # reverse pattern when acted as a receiver
+                pattern_b, "Fac A Pattern B"  # reverse pattern when acted as a receiver
 
             yield assert_array_equal, \
                 np.where(sender_ids == facility_b[0])[0], \
-                pattern_b
+                pattern_b, "Fac B Pattern A"
             yield assert_array_equal, \
                 np.where(receiver_ids == facility_b[0])[0], \
-                pattern_a  # reverse pattern when acted as a receiver
+                pattern_a, "Fac B Pattern B"  # reverse pattern when acted as a receiver
 
             # Transaction ids must be equal range from 1 to the number of rows
             expected_trans_ids = np.arange(sender_ids.size)
@@ -204,7 +204,9 @@ def test_minimal_cycle():
             # limit cyclus::eps() for transaction amounts.
             # Expect not to have shortened transactions, so for two facilities,
             # there must be (2 * duration) number of transactions.
-            yield assert_equal, sender_ids.size, 2 * duration
+            exp = 2 * duration
+            obs = sender_ids.size
+            yield assert_equal, exp, obs, "number of transactions, {} != {}".format(exp, obs)
 
             # Track transacted resources
             quantities = to_ary(resources, "Quantity")

--- a/tests/xml_file_loader_tests.cc
+++ b/tests/xml_file_loader_tests.cc
@@ -88,7 +88,7 @@ std::string XMLFileLoaderTests::ControlSequenceWithSolver() {
           "        <preconditioner>greedy</preconditioner>"
           "      </greedy>"
           "    </config>"
-          "    <exclusive_orders_only>true</exclusive_orders_only>"
+          "    <allow_exclusive_orders>true</allow_exclusive_orders>"
           "  </solver>"
           " </control>"
           "</simulation>";


### PR DESCRIPTION
This PR allows the invoking of optimization solvers on instances of the DRE. Currently, only COIN-based solvers are supported.

In reaching this point, a number of bugs were fixed and issues were addressed. The user-input-to-database workflow for solver information was broken and has been fixed. Tests were implicitly relying on a solver table, and it is now being explicitly written. A number of simulation-to-solver quirks were addressed, such as removing requests without any bids, and artificially setting a ceiling on request bounds (see [here](https://github.com/cyclus/cyclus/compare/cyclus:develop...gidden:coinpref1?expand=1#diff-950f694e6835e4b4167d693547288711R183). This type of empirical observation should be documented and likely addressed by a more automated determination of bounds through inspection (a future PR).

An alternative formulation of false arc cost (``PsuedoCost``) is provided. I have left in the previous formulation for further testing and usage as needed. It can likely come out after a sufficient period of time has elapsed.

A number of constants that have been listed independently in source code (such as default preference values) now a ``static const`` declaration in an appropriate location. Invocations have been updated to use those defined variables.

Documentation needs to be updated to include coin solver input docs, etc. That is on my list of things to do in parallel with better DRE docs and the DRE paper. 

Finally, this PR depends on #1121.

 