### PR TITLE
Python 3 in cyclus-deps instead of python 2

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ dependencies:
 test:
   override:
     - docker run cyclus/cyclus:latest cyclus_unit_tests
-    - docker run cyclus/cyclus:latest nosetests -w /cyclus/tests
+    - docker run cyclus/cyclus:latest nosetests3 -w /cyclus/tests
 
 deployment:
   develop:

--- a/circle.yml
+++ b/circle.yml
@@ -17,3 +17,10 @@ deployment:
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker push cyclus/cyclus:latest
+
+  master:
+    branch: master
+    commands:
+      - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+      - docker tag cyclus/cyclus:latest cyclus/cyclus:stable
+      - docker push cyclus/cyclus:stable

--- a/docker/README.md
+++ b/docker/README.md
@@ -19,3 +19,16 @@ Each subdirectory contains a dockerfile that does something useful:
   the docker container and used for the build.  The dockerfile in the cyclus
   repository root is a symbolic link to this dockerfile.
 
+The script ``dockercyclus.sh`` downloads (if not already downloaded before)
+the cyclus/cycamore docker image and passes all given arguments to an cyclus
+command run inside a docker container.  The current working directory is also
+mounted inside the docker container so files in it (recursively) can be seen
+by cyclus, and all output files end up in the host working directory.  This is
+an example of an alternative distribution mechanism for cyclus.
+
+The ``dockerbuild.sh`` script assumes the current working directory contains
+the cyclus core repository and mounts it inside a docker container and builds
+and installs the cyclus kernel.  The built docker image is saved as
+cyclus/cyclus:local - which can be used to run tests, etc.  This could become
+an easy way to onboard new kernel developers - they no longer have to set up a
+fancy environment - all they have to do is clone cyclus and install docker.

--- a/docker/cyclus-deps/Dockerfile
+++ b/docker/cyclus-deps/Dockerfile
@@ -22,11 +22,11 @@ RUN apt-get install -y --force-yes \
     g++ \
     libgoogle-perftools-dev \
     git \
-    python \
-    python-tables \
-    python-numpy \
-    python-nose
+    python3 \
+    python3-tables \
+    python3-numpy \
+    python3-nose
 
 RUN rm /usr/bin/python
-
 RUN ln -s /usr/bin/python3 /usr/bin/python
+

--- a/docker/cyclus-deps/Dockerfile
+++ b/docker/cyclus-deps/Dockerfile
@@ -27,3 +27,6 @@ RUN apt-get install -y --force-yes \
     python-numpy \
     python-nose
 
+RUN rm /usr/bin/python
+
+RUN ln -s /usr/bin/python3 /usr/bin/python

--- a/docker/dockerbuild.sh
+++ b/docker/dockerbuild.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+docker rm cyclus-local
+docker run -w /cyclus --name cyclus-local -v $PWD:/cyclus cyclus/cyclus-deps bash -c "mkdir -p Debug && cd Debug && cmake .. && make -j2 && make install"
+docker commit cyclus-local cyclus/cyclus:local
+

--- a/docker/dockercyclus.sh
+++ b/docker/dockercyclus.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker run --rm -w /data -v $PWD:/data cyclus/cycamore cyclus $@
+


### PR DESCRIPTION
Built on #1201 - fixes a few other changes required for python3 stuff to work.