### PR TITLE
call agents' get[matl/prod][requests/bids] in deterministic order

### DIFF
--- a/src/resource_exchange.h
+++ b/src/resource_exchange.h
@@ -73,7 +73,7 @@ class ResourceExchange {
 
   /// @brief queries traders and collects all requests for bids
   void AddAllRequests() {
-    std::set<Trader*> traders = ctx_->traders();
+    std::set<Trader*, trader_compare> traders = OrderedTraders();
     std::for_each(
         traders.begin(),
         traders.end(),
@@ -83,7 +83,7 @@ class ResourceExchange {
 
   /// @brief queries traders and collects all responses to requests for bids
   void AddAllBids() {
-    std::set<Trader*> traders = ctx_->traders();
+    std::set<Trader*, trader_compare> traders = OrderedTraders();
     std::for_each(
         traders.begin(),
         traders.end(),
@@ -132,6 +132,22 @@ class ResourceExchange {
       AdjustPrefs(m, prefs);
       m = m->parent();
     }
+  }
+
+  struct trader_compare {
+    bool operator()(Trader* lhs, Trader* rhs) const {
+      return lhs->manager()->id() < rhs->manager()->id();
+    }
+  };
+
+  std::set<Trader*, trader_compare> OrderedTraders() {
+    std::set<Trader*> orig = ctx_->traders();
+    std::set<Trader*>::iterator it;
+    std::set<Trader*, trader_compare> ordered;
+    for (it = orig.begin(); it != orig.end(); ++it) {
+      ordered.insert(*it);
+    }
+    return ordered;
   }
 
   Context* ctx_;

--- a/src/resource_exchange.h
+++ b/src/resource_exchange.h
@@ -63,9 +63,7 @@ class ResourceExchange {
   /// @brief default constructor
   ///
   /// @param ctx the simulation context
-  ResourceExchange(Context* ctx) {
-    ctx_ = ctx;
-  }
+  ResourceExchange(Context* ctx) : ctx_(ctx) { }
 
   inline ExchangeContext<T>& ex_ctx() {
     return ex_ctx_;
@@ -73,26 +71,27 @@ class ResourceExchange {
 
   /// @brief queries traders and collects all requests for bids
   void AddAllRequests() {
-    std::set<Trader*, trader_compare> traders = OrderedTraders();
+    InitTraders();
     std::for_each(
-        traders.begin(),
-        traders.end(),
+        traders_.begin(),
+        traders_.end(),
         std::bind1st(std::mem_fun(&cyclus::ResourceExchange<T>::AddRequests_),
                      this));
   }
 
   /// @brief queries traders and collects all responses to requests for bids
   void AddAllBids() {
-    std::set<Trader*, trader_compare> traders = OrderedTraders();
+    InitTraders();
     std::for_each(
-        traders.begin(),
-        traders.end(),
+        traders_.begin(),
+        traders_.end(),
         std::bind1st(std::mem_fun(&cyclus::ResourceExchange<T>::AddBids_),
                      this));
   }
 
   /// @brief adjust preferences for requests given bid responses
   void AdjustAll() {
+    InitTraders();
     std::set<Trader*> traders = ex_ctx_.requesters;
     std::for_each(
         traders.begin(),
@@ -103,6 +102,16 @@ class ResourceExchange {
   }
 
  private:
+  void InitTraders() {
+    if (traders_.size() == 0) {
+      std::set<Trader*> orig = ctx_->traders();
+      std::set<Trader*>::iterator it;
+      for (it = orig.begin(); it != orig.end(); ++it) {
+        traders_.insert(*it);
+      }
+    }
+  }
+
   /// @brief queries a given facility agent for
   void AddRequests_(Trader* t) {
     std::set<typename RequestPortfolio<T>::Ptr> rp = QueryRequests<T>(t);
@@ -140,17 +149,14 @@ class ResourceExchange {
     }
   };
 
-  std::set<Trader*, trader_compare> OrderedTraders() {
-    std::set<Trader*> orig = ctx_->traders();
-    std::set<Trader*>::iterator it;
-    std::set<Trader*, trader_compare> ordered;
-    for (it = orig.begin(); it != orig.end(); ++it) {
-      ordered.insert(*it);
-    }
-    return ordered;
-  }
-
   Context* ctx_;
+
+  // this sorts traders (and results in iteration...) based on traders'
+  // manager id.  Iterating over traders in this order helps increase the
+  // determinism of Cyclus overall.  This allows all traders' resource
+  // exchange functions are called in a much closer to deterministic order.
+  std::set<Trader*, trader_compare> traders_;
+
   ExchangeContext<T> ex_ctx_;
 };
 


### PR DESCRIPTION
This eliminates one of the most significant sources of non-determinism remaining.  In simulations I've run, this is enough to get ~exact reproducability.  There are other things like modifying the ``Arc::operator<`` function that could also increase determinism, and also using the ordered traders set for calling accept/get matl trades functions, but lets only do that as needed as it has a tendency to reduce performance, etc.