### PR TITLE
Implement CEP23 - custom time step duration

### DIFF
--- a/share/CMakeLists.txt
+++ b/share/CMakeLists.txt
@@ -35,3 +35,4 @@ INSTALL(FILES
     DESTINATION share/cyclus
     COMPONENT core
     )
+

--- a/share/cyclus-flat.rng.in
+++ b/share/cyclus-flat.rng.in
@@ -18,6 +18,9 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
       <optional> 
         <element name="decay"><text/></element> 
       </optional>
+      <optional> 
+        <element name="dt"><data type="nonNegativeInteger"/></element> 
+      </optional>
       <optional>
         <element name="solver"> 
           <interleave>

--- a/share/cyclus.rng.in
+++ b/share/cyclus.rng.in
@@ -19,6 +19,9 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
       <optional>
         <element name="decay"> <text/> </element>
       </optional>
+      <optional> 
+        <element name="dt"><data type="nonNegativeInteger"/></element> 
+      </optional>
       <optional>
         <element name="solver"> 
           <interleave>

--- a/src/composition.cc
+++ b/src/composition.cc
@@ -61,7 +61,7 @@ const CompMap& Composition::mass() {
   return mass_;
 }
 
-Composition::Ptr Composition::Decay(int delta) {
+Composition::Ptr Composition::Decay(int delta, uint64_t secs_per_timestep) {
   int tot_decay = prev_decay_ + delta;
   if (decay_line_->count(tot_decay) == 1) {
     // decay_line_ has cached, pre-computed result of this decay
@@ -72,9 +72,13 @@ Composition::Ptr Composition::Decay(int delta) {
   // It will automagically appear in the decay chain for all other compositions
   // that are a part of this decay chain because decay_line_ is a pointer that
   // all compositions in the chain share.
-  Composition::Ptr decayed = NewDecay(delta);
+  Composition::Ptr decayed = NewDecay(delta, secs_per_timestep);
   (*decay_line_)[tot_decay] = decayed;
   return decayed;
+}
+
+Composition::Ptr Composition::Decay(int delta) {
+  return Decay(delta, kDefaultTimeStepDur);
 }
 
 void Composition::Record(Context* ctx) {
@@ -109,7 +113,7 @@ Composition::Composition(int prev_decay, ChainPtr decay_line)
   next_id_++;
 }
 
-Composition::Ptr Composition::NewDecay(int delta) {
+Composition::Ptr Composition::NewDecay(int delta, uint64_t secs_per_timestep) {
   int tot_decay = prev_decay_ + delta;
   atom();  // force evaluation of atom-composition if not calculated already
 
@@ -121,7 +125,7 @@ Composition::Ptr Composition::NewDecay(int delta) {
   if (atom_.size() == 0)
     return decayed;
 
-  decayed->atom_ = pyne::decayers::decay(atom_, 2419200.0 * delta);
+  decayed->atom_ = pyne::decayers::decay(atom_, static_cast<double>(secs_per_timestep) * delta);
   return decayed;
 }
 

--- a/src/composition.h
+++ b/src/composition.h
@@ -63,9 +63,14 @@ class Composition {
   /// Returns the unnormalized mass composition.
   const CompMap& mass();
 
-  /// Returns a decayed version of this composition (decayed
-  /// delta timesteps). This composition remains unchanged.
+  /// Returns a decayed version of this composition (decayed delta timesteps)
+  /// assuming a time step is 1/12 of one year in duration. This composition
+  /// remains unchanged.
   Ptr Decay(int delta);
+
+  /// Returns a decayed version of this composition (decayed
+  /// delta timesteps) using the seconds to timestep conversion specified.
+  Ptr Decay(int delta, uint64_t secs_per_timestep);
 
   /// Records the composition in output database Compositions table (if
   /// not done previously).
@@ -89,7 +94,7 @@ class Composition {
   Composition(int prev_decay, ChainPtr decay_line);
 
   /// Performs a decay calculation and creates a new decayed composition.
-  Ptr NewDecay(int delta);
+  Ptr NewDecay(int delta, uint64_t secs_per_timestep);
 
   static int next_id_;
   int id_;

--- a/src/composition.h
+++ b/src/composition.h
@@ -2,6 +2,7 @@
 #define CYCLUS_SRC_COMPOSITION_H_
 
 #include <map>
+#include <stdint.h>
 #include <boost/shared_ptr.hpp>
 
 class SimInitTest;

--- a/src/context.cc
+++ b/src/context.cc
@@ -16,6 +16,7 @@ SimInfo::SimInfo()
     : duration(0),
       y0(0),
       m0(0),
+      dt(kDefaultTimeStepDur),
       decay("manual"),
       branch_time(-1),
       parent_sim(boost::uuids::nil_uuid()),
@@ -25,6 +26,7 @@ SimInfo::SimInfo(int dur, int y0, int m0, std::string handle)
     : duration(dur),
       y0(y0),
       m0(m0),
+      dt(kDefaultTimeStepDur),
       decay("manual"),
       branch_time(-1),
       handle(handle),
@@ -35,6 +37,7 @@ SimInfo::SimInfo(int dur, int y0, int m0, std::string handle, std::string d)
     : duration(dur),
       y0(y0),
       m0(m0),
+      dt(kDefaultTimeStepDur),
       decay(d),
       branch_time(-1),
       handle(handle),
@@ -47,6 +50,7 @@ SimInfo::SimInfo(int dur, boost::uuids::uuid parent_sim,
     : duration(dur),
       y0(-1),
       m0(-1),
+      dt(kDefaultTimeStepDur),
       decay("manual"),
       parent_sim(parent_sim),
       parent_type(parent_type),
@@ -181,6 +185,10 @@ void Context::InitSim(SimInfo si) {
 
   NewDatum("DecayMode")
       ->AddVal("Decay", si.decay)
+      ->Record();
+
+  NewDatum("TimeStepDur")
+      ->AddVal("DurationSecs", static_cast<int>(si.dt))
       ->Record();
 
   NewDatum("XMLPPInfo")

--- a/src/context.cc
+++ b/src/context.cc
@@ -187,6 +187,8 @@ void Context::InitSim(SimInfo si) {
       ->AddVal("Decay", si.decay)
       ->Record();
 
+  // TODO: when the backends get uint64_t support, the static_cast here should
+  // be removed.
   NewDatum("TimeStepDur")
       ->AddVal("DurationSecs", static_cast<int>(si.dt))
       ->Record();

--- a/src/context.h
+++ b/src/context.h
@@ -17,6 +17,8 @@
 #include "greedy_solver.h"
 #include "recorder.h"
 
+const uint64_t kDefaultTimeStepDur = 2629846;
+
 class SimInitTest;
 
 namespace cyclus {
@@ -91,6 +93,9 @@ class SimInfo {
 
   /// timestep at which simulation branching occurs if any
   int branch_time;
+
+  /// Duration in seconds of a single time step in the simulation.
+  uint64_t dt;
 };
 
 /// A simulation context provides access to necessary simulation-global

--- a/src/context.h
+++ b/src/context.h
@@ -4,6 +4,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <stdint.h>
 
 #ifndef CYCPP
 // The cyclus preprocessor cannot handle this file since there are two

--- a/src/context.h
+++ b/src/context.h
@@ -215,6 +215,9 @@ class Context {
   /// Returns the current simulation timestep.
   virtual int time();
 
+  /// Returns the duration of a single time step in seconds.
+  inline uint64_t dt() {return si_.dt;};
+
   /// Return static simulation info.
   inline SimInfo sim_info() const {
     return si_;

--- a/src/sim_init.cc
+++ b/src/sim_init.cc
@@ -152,6 +152,8 @@ void SimInit::LoadInfo() {
   std::string d = dq.GetVal<std::string>("Decay");
 
   dq = b_->Query("TimeStepDur", NULL);
+  // TODO: when the backends support uint64_t, the int template here
+  // should be updated to uint64_t.
   uint64_t ts = dq.GetVal<int>("DurationSecs");
 
   si_ = SimInfo(dur, y0, m0, h, d);

--- a/src/sim_init.cc
+++ b/src/sim_init.cc
@@ -150,6 +150,10 @@ void SimInit::LoadInfo() {
 
   QueryResult dq = b_->Query("DecayMode", NULL);
   std::string d = dq.GetVal<std::string>("Decay");
+
+  dq = b_->Query("TimeStepDur", NULL);
+  uint64_t ts = dq.GetVal<int>("DurationSecs");
+
   si_ = SimInfo(dur, y0, m0, h, d);
   si_.parent_sim = qr.GetVal<boost::uuids::uuid>("ParentSimId");
   ctx_->InitSim(si_);

--- a/src/xml_file_loader.cc
+++ b/src/xml_file_loader.cc
@@ -383,7 +383,12 @@ void XMLFileLoader::LoadControlParams() {
   // get decay mode
   std::string d = OptionalQuery<std::string>(qe, "decay", "manual");
 
-  ctx_->InitSim(SimInfo(dur, y0, m0, handle, d));
+  SimInfo si(dur, y0, m0, handle, d);
+
+  // get time step duration
+  si.dt = OptionalQuery<int>(qe, "dt", kDefaultTimeStepDur);
+
+  ctx_->InitSim(si);
 }
 
 }  // namespace cyclus

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -71,6 +71,7 @@ INSTALL(FILES ${header_files}
     COMPONENT testing
     )
 
+ADD_SUBDIRECTORY(input)
 ADD_SUBDIRECTORY(toolkit)
 ADD_SUBDIRECTORY(agent_tests)
 SET(

--- a/tests/composition_tests.cc
+++ b/tests/composition_tests.cc
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 
+#include "context.h"
 #include "composition.h"
 #include "comp_math.h"
 #include "env.h"
@@ -80,7 +81,7 @@ TEST(CompositionTests, decay) {
   cyclus::compmath::Normalize(&v);
   Composition::Ptr c = Composition::CreateFromAtom(v);
 
-  double secs_per_timestep = 2419200.0;
+  double secs_per_timestep = kDefaultTimeStepDur;
   Composition::Ptr newc = c->Decay(int(pyne::half_life("Cs137") / secs_per_timestep));
 
   CompMap newv = newc->atom();

--- a/tests/input/CMakeLists.txt
+++ b/tests/input/CMakeLists.txt
@@ -1,0 +1,8 @@
+
+FILE(GLOB cyclus_infiles "${CMAKE_CURRENT_SOURCE_DIR}/*.xml")
+
+INSTALL(FILES
+    ${cyclus_infiles}
+    DESTINATION share/cyclus/input
+    COMPONENT testing
+    )

--- a/tests/input/custom_dt.xml
+++ b/tests/input/custom_dt.xml
@@ -1,0 +1,57 @@
+<simulation>
+  <control>
+    <duration>1</duration>
+    <startmonth>1</startmonth>
+    <startyear>2000</startyear>
+    <dt>86400</dt>
+  </control>
+
+  <archetypes>
+    <spec><lib>agents</lib><name>Source</name></spec>
+    <spec><lib>agents</lib><name>Sink</name></spec>
+    <spec><lib>agents</lib><name>NullRegion</name></spec>
+    <spec><lib>agents</lib><name>NullInst</name></spec>
+  </archetypes>
+
+  <facility>
+    <name>src</name>
+    <lifetime>1</lifetime>
+    <config>
+      <Source>
+        <commod>commod</commod>
+        <capacity>1</capacity>
+      </Source>
+    </config>
+  </facility>
+
+  <facility>
+    <name>snk</name>
+    <config>
+      <Sink>
+        <in_commods><val>commod</val></in_commods>
+        <recipe_name>commod_recipe</recipe_name>
+        <capacity>1</capacity>
+      </Sink>
+    </config>
+  </facility>
+
+  <region>
+    <name>SingleRegion</name>
+    <config> <NullRegion/> </config>
+    <institution>
+      <name>SingleInstitution</name>
+      <initialfacilitylist>
+        <entry> <prototype>src</prototype> <number>1</number> </entry>
+        <entry> <prototype>snk</prototype> <number>1</number> </entry>
+      </initialfacilitylist>
+      <config> <NullInst/> </config>
+    </institution>
+  </region>
+
+  <recipe>
+    <name>commod_recipe</name>
+    <basis>mass</basis>
+    <nuclide> <id>cs137</id> <comp>1</comp> </nuclide>
+  </recipe>
+
+</simulation>

--- a/tests/input/custom_dt_flat.xml
+++ b/tests/input/custom_dt_flat.xml
@@ -1,0 +1,46 @@
+<simulation>
+  <schematype>flat</schematype>
+  <control>
+    <duration>1</duration>
+    <startmonth>1</startmonth>
+    <startyear>2000</startyear>
+    <dt>86400</dt>
+  </control>
+
+  <archetypes>
+    <spec><lib>agents</lib><name>Source</name></spec>
+    <spec><lib>agents</lib><name>Sink</name></spec>
+  </archetypes>
+
+  <prototype>
+    <name>src</name>
+    <lifetime>1</lifetime>
+    <config>
+      <Source>
+        <commod>commod</commod>
+        <capacity>1</capacity>
+      </Source>
+    </config>
+  </prototype>
+
+  <prototype>
+    <name>snk</name>
+    <config>
+      <Sink>
+        <in_commods><val>commod</val></in_commods>
+        <recipe_name>commod_recipe</recipe_name>
+        <capacity>1</capacity>
+      </Sink>
+    </config>
+  </prototype>
+
+  <agent><name>src1</name><prototype>src</prototype></agent>
+  <agent><name>snk1</name><prototype>snk</prototype></agent>
+
+  <recipe>
+    <name>commod_recipe</name>
+    <basis>mass</basis>
+    <nuclide> <id>cs137</id> <comp>1</comp> </nuclide>
+  </recipe>
+
+</simulation>

--- a/tests/integ_tests.cc
+++ b/tests/integ_tests.cc
@@ -67,7 +67,6 @@ TEST(IntegTests, RunAllInfiles) {
   infiles.push_back("predator.xml");
   infiles.push_back("prey.xml");
   infiles.push_back("source_to_sink.xml");
-  infiles.push_back("stub_example.xml");
   infiles.push_back("trivial_cycle.xml");
 
   for (int i = 0; i < infiles.size(); i++) {

--- a/tests/integ_tests.cc
+++ b/tests/integ_tests.cc
@@ -1,0 +1,97 @@
+#include <cmath>
+
+#include <gtest/gtest.h>
+
+#include "cyclus.h"
+#include "xml_file_loader.h"
+#include "xml_flat_loader.h"
+#include "sim_init.h"
+
+using pyne::nucname::id;
+namespace fs = boost::filesystem;
+
+namespace cyclus {
+
+bool IsFlatSchema(std::string infile) {
+  std::stringstream input;
+  LoadStringstreamFromFile(input, infile);
+  boost::shared_ptr<XMLParser> parser =
+      boost::shared_ptr<XMLParser>(new XMLParser());
+  parser->Init(input);
+  InfileTree tree(*parser);
+  return OptionalQuery<std::string>(&tree, "/simulation/schematype", "") == "flat";
+}
+
+std::string FullPath(std::string infile) {
+  std::string p = Env::GetInstallPath() + "/share/cyclus/input/" + infile;
+  if (fs::exists(p)) {
+    return p;
+  }
+
+  p = Env::GetBuildPath() + "/share/cyclus/input/" + infile;
+  if (fs::exists(p)) {
+    return p;
+  }
+
+  throw IOError(infile + " not found in "
+                + Env::GetInstallPath() + "/share/cyclus/input/ or "
+                + Env::GetBuildPath() + "/share/cyclus/input/");
+}
+
+// RunSim runs the cyclus input file at path infile
+// storing the results in back.
+void RunSim(std::string infile, SqliteBack* back) {
+  Recorder r;
+  r.RegisterBackend(back);
+
+  infile = FullPath(infile);
+  SimInit si;
+  if (IsFlatSchema(infile)) {
+    XMLFlatLoader l(&r, back, Env::rng_schema(true), infile);
+    l.LoadSim();
+  } else {
+    XMLFileLoader l(&r, back, Env::rng_schema(false), infile);
+    l.LoadSim();
+  }
+  si.Init(&r, back);
+  si.timer()->RunSim();
+  r.Flush();
+}
+
+TEST(IntegTests, RunAllInfiles) {
+  std::vector<std::string> infiles;
+  infiles.push_back("custom_dt.xml");
+  infiles.push_back("lotka_volterra_determ.xml");
+  infiles.push_back("minimal_cycle.xml");
+  infiles.push_back("null_sink.xml");
+  infiles.push_back("predator.xml");
+  infiles.push_back("prey.xml");
+  infiles.push_back("source_to_sink.xml");
+  infiles.push_back("stub_example.xml");
+  infiles.push_back("trivial_cycle.xml");
+
+  for (int i = 0; i < infiles.size(); i++) {
+    {
+      SqliteBack back(":memory:");
+      RunSim(infiles[i], &back);
+    }
+  }
+}
+
+TEST(IntegTests, CustomTimestepDur) {
+  {
+    SqliteBack back(":memory:");
+    RunSim("custom_dt.xml", &back);
+    QueryResult qr = back.Query("TimeStepDur", NULL);
+    EXPECT_EQ(86400, qr.GetVal<int>("DurationSecs"));
+  }
+
+  {
+    SqliteBack back(":memory:");
+    RunSim("custom_dt_flat.xml", &back);
+    QueryResult qr = back.Query("TimeStepDur", NULL);
+    EXPECT_EQ(86400, qr.GetVal<int>("DurationSecs"));
+  }
+}
+
+}  // namespace cyclus


### PR DESCRIPTION
Note that there are a couple of TODOs I added to the code to help remind us to update/remove the int casting when backends get uint64_t support.