### PR TITLE
remove xmlpp header leakage

### DIFF
--- a/src/infile_tree.cc
+++ b/src/infile_tree.cc
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <sstream>
 
+#include <libxml++/libxml++.h>
 #include <boost/lexical_cast.hpp>
 
 #include "error.h"

--- a/src/infile_tree.h
+++ b/src/infile_tree.h
@@ -5,11 +5,14 @@
 #include <vector>
 #include <set>
 
-#include <libxml++/libxml++.h>
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 
 #include "xml_parser.h"
+
+namespace xmlpp {
+  class Node;
+}
 
 namespace cyclus {
 

--- a/src/toolkit/infile_converters.cc
+++ b/src/toolkit/infile_converters.cc
@@ -1,6 +1,7 @@
 #include <sstream>
 
 #include <boost/shared_ptr.hpp>
+#include <libxml++/libxml++.h>
 
 #include "error.h"
 #include "infile_converters.h"

--- a/src/xml_parser.cc
+++ b/src/xml_parser.cc
@@ -2,6 +2,7 @@
 
 #include <stdlib.h>
 #include <string>
+#include <libxml++/libxml++.h>
 
 #include "error.h"
 #include "logger.h"
@@ -10,16 +11,21 @@
 namespace cyclus {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-XMLParser::XMLParser() {}
+XMLParser::XMLParser() : parser_(NULL) {
+  parser_ = new xmlpp::DomParser();
+}
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 XMLParser::~XMLParser() {
-  parser_.reset();
+  delete parser_;
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void XMLParser::Init(const std::stringstream& xml_input_snippet) {
-  parser_ = boost::shared_ptr<xmlpp::DomParser>(new xmlpp::DomParser());
+  if (parser_ != NULL) {
+    delete parser_;
+  }
+  parser_ = new xmlpp::DomParser();
   try {
     CLOG(LEV_DEBUG5) << "Parsing the snippet: " << xml_input_snippet.str();
 

--- a/src/xml_parser.h
+++ b/src/xml_parser.h
@@ -2,8 +2,12 @@
 #define CYCLUS_SRC_XML_PARSER_H_
 
 #include <sstream>
-#include <libxml++/libxml++.h>
 #include <boost/shared_ptr.hpp>
+
+namespace xmlpp {
+  class DomParser;
+  class Document;
+}
 
 namespace cyclus {
 
@@ -15,7 +19,7 @@ class XMLParser {
   XMLParser();
 
   /// destructor
-  ~XMLParser();
+  virtual ~XMLParser();
 
   /// initializes a parser with an xml snippet
   /// @param input an xml snippet to be used as input
@@ -30,7 +34,7 @@ class XMLParser {
 
  private:
   /// file parser
-  boost::shared_ptr<xmlpp::DomParser> parser_;
+  xmlpp::DomParser* parser_;
 };
 
 }  // namespace cyclus

--- a/tests/xml_parser_tests.cc
+++ b/tests/xml_parser_tests.cc
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <fstream>
 #include <gtest/gtest.h>
+#include <libxml++/libxml++.h>
 
 #include "error.h"
 


### PR DESCRIPTION
This buys us some time to decide how we want to deal with c++11 support for stubs, cycamore, etc. by not leaking the c++11 requiring headers.  And it makes compiling archetypes simpler anyway. Addresses a small part of #1199.