### PR TITLE
fix 3rd party dependency header leakage

### DIFF
--- a/src/infile_tree.cc
+++ b/src/infile_tree.cc
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <sstream>
 
+#include <libxml++/libxml++.h>
 #include <boost/lexical_cast.hpp>
 
 #include "error.h"

--- a/src/infile_tree.h
+++ b/src/infile_tree.h
@@ -5,11 +5,14 @@
 #include <vector>
 #include <set>
 
-#include <libxml++/libxml++.h>
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 
 #include "xml_parser.h"
+
+namespace xmlpp {
+  class Node;
+}
 
 namespace cyclus {
 

--- a/src/prog_translator.h
+++ b/src/prog_translator.h
@@ -12,6 +12,16 @@ namespace cyclus {
 class ExchangeGraph;
 class ExchangeNodeGroup;
 
+/// @brief struct to hold all problem instance state
+struct ProgTranslatorContext {
+  std::vector<double> obj_coeffs;
+  std::vector<double> row_ubs;
+  std::vector<double> row_lbs;
+  std::vector<double> col_ubs;
+  std::vector<double> col_lbs;
+  CoinPackedMatrix m;
+};
+
 /// a helper class to translate a product exchange into a mathematical
 /// program.
 ///
@@ -26,14 +36,7 @@ class ExchangeNodeGroup;
 class ProgTranslator {
  public:
   /// @brief struct to hold all problem instance state
-  struct Context {
-    std::vector<double> obj_coeffs;
-    std::vector<double> row_ubs;
-    std::vector<double> row_lbs;
-    std::vector<double> col_ubs;
-    std::vector<double> col_lbs;
-    CoinPackedMatrix m;
-  };
+  typedef ProgTranslatorContext Context;
 
   /// constructor
   ///
@@ -62,7 +65,7 @@ class ProgTranslator {
   /// @brief translates solution from iface back into graph matches
   void FromProg();
 
-  const ProgTranslator::Context& ctx() const { return ctx_; }
+  const Context& ctx() const { return ctx_; }
 
  private:
   void Init();

--- a/src/relax_ng_validator.cc
+++ b/src/relax_ng_validator.cc
@@ -11,6 +11,8 @@
 #include "relax_ng_validator.h"
 
 #include <libxml/xmlerror.h>
+#include <libxml/relaxng.h>
+#include <libxml++/document.h>
 
 #include "error.h"
 

--- a/src/relax_ng_validator.h
+++ b/src/relax_ng_validator.h
@@ -11,9 +11,18 @@
 #ifndef CYCLUS_SRC_RELAX_NG_VALIDATOR_H_
 #define CYCLUS_SRC_RELAX_NG_VALIDATOR_H_
 
-#include <libxml/relaxng.h>
-#include <libxml++/document.h>
 #include <glibmm/ustring.h>
+
+class _xmlRelaxNG;
+class _xmlRelaxNGParserCtxt;
+class _xmlRelaxNGValidCtxt;
+typedef _xmlRelaxNG xmlRelaxNG;
+typedef _xmlRelaxNGParserCtxt xmlRelaxNGParserCtxt;
+typedef _xmlRelaxNGValidCtxt xmlRelaxNGValidCtxt;
+
+namespace xmlpp {
+  class Document;
+}
 
 namespace cyclus {
 
@@ -43,13 +52,13 @@ class RelaxNGValidator {
 
   /// parse a relaxng schema context
   /// @param context the context
-  void parse_context(xmlRelaxNGParserCtxtPtr context);
+  void parse_context(xmlRelaxNGParserCtxt* context);
 
   /// the schema
-  xmlRelaxNGPtr schema_;
+  xmlRelaxNG* schema_;
 
   /// the validated context
-  xmlRelaxNGValidCtxtPtr valid_context_;
+  xmlRelaxNGValidCtxt* valid_context_;
 };
 
 }  // namespace cyclus

--- a/src/toolkit/building_manager.cc
+++ b/src/toolkit/building_manager.cc
@@ -1,6 +1,11 @@
 #include "building_manager.h"
 
+#include "prog_translator.h"
 #include "CoinPackedVector.hpp"
+
+// Headers in this file below this pragma have all warnings shushed.
+#pragma GCC system_header
+#include "OsiCbcSolverInterface.hpp"
 
 namespace cyclus {
 namespace toolkit {

--- a/src/toolkit/building_manager.h
+++ b/src/toolkit/building_manager.h
@@ -7,13 +7,13 @@
 #include "agent_managed.h"
 #include "builder.h"
 #include "commodity_producer.h"
-#include "prog_translator.h"
 
-// Headers in this file below this pragma have all warnings shushed.
-#pragma GCC system_header
-#include "OsiCbcSolverInterface.hpp"
+class OsiCbcSolverInterface;
 
 namespace cyclus {
+
+class ProgTranslatorContext;
+
 namespace toolkit {
 
 /// A struct for a build order: the number of producers to build.
@@ -73,14 +73,14 @@ class BuildingManager : public AgentManaged {
   std::set<Builder*> builders_;
 
   void SetUp_(OsiCbcSolverInterface& iface,
-              ProgTranslator::Context& ctx,
+              ProgTranslatorContext& ctx,
               std::map<CommodityProducer*, Builder*>& p_to_b,
               std::map<int, CommodityProducer*>& idx_to_p,
               Commodity& commodity,
               double demand);
 
   void Solve_(OsiCbcSolverInterface& iface,
-              ProgTranslator::Context& ctx,
+              ProgTranslatorContext& ctx,
               std::map<CommodityProducer*, Builder*>& p_to_b,
               std::map<int, CommodityProducer*>& idx_to_p,
               std::vector<BuildOrder>& orders);

--- a/src/toolkit/infile_converters.cc
+++ b/src/toolkit/infile_converters.cc
@@ -1,6 +1,7 @@
 #include <sstream>
 
 #include <boost/shared_ptr.hpp>
+#include <libxml++/libxml++.h>
 
 #include "error.h"
 #include "infile_converters.h"

--- a/src/xml_parser.cc
+++ b/src/xml_parser.cc
@@ -2,6 +2,7 @@
 
 #include <stdlib.h>
 #include <string>
+#include <libxml++/libxml++.h>
 
 #include "error.h"
 #include "logger.h"
@@ -10,16 +11,21 @@
 namespace cyclus {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-XMLParser::XMLParser() {}
+XMLParser::XMLParser() : parser_(NULL) {
+  parser_ = new xmlpp::DomParser();
+}
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 XMLParser::~XMLParser() {
-  parser_.reset();
+  delete parser_;
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void XMLParser::Init(const std::stringstream& xml_input_snippet) {
-  parser_ = boost::shared_ptr<xmlpp::DomParser>(new xmlpp::DomParser());
+  if (parser_ != NULL) {
+    delete parser_;
+  }
+  parser_ = new xmlpp::DomParser();
   try {
     CLOG(LEV_DEBUG5) << "Parsing the snippet: " << xml_input_snippet.str();
 

--- a/src/xml_parser.h
+++ b/src/xml_parser.h
@@ -2,8 +2,12 @@
 #define CYCLUS_SRC_XML_PARSER_H_
 
 #include <sstream>
-#include <libxml++/libxml++.h>
 #include <boost/shared_ptr.hpp>
+
+namespace xmlpp {
+  class DomParser;
+  class Document;
+}
 
 namespace cyclus {
 
@@ -15,7 +19,7 @@ class XMLParser {
   XMLParser();
 
   /// destructor
-  ~XMLParser();
+  virtual ~XMLParser();
 
   /// initializes a parser with an xml snippet
   /// @param input an xml snippet to be used as input
@@ -30,7 +34,7 @@ class XMLParser {
 
  private:
   /// file parser
-  boost::shared_ptr<xmlpp::DomParser> parser_;
+  xmlpp::DomParser* parser_;
 };
 
 }  // namespace cyclus

--- a/stubs/CMakeLists.txt
+++ b/stubs/CMakeLists.txt
@@ -79,12 +79,6 @@ SET(LIBS ${LIBS} ${CYCLUS_CORE_LIBRARIES})
 # Include macros
 INCLUDE(UseCyclus)
 
-# Find LibXML++ and dependencies
-FIND_PACKAGE(LibXML++ REQUIRED)
-SET(STUB_INCLUDE_DIRS ${STUB_INCLUDE_DIRS} ${LibXML++_INCLUDE_DIR} ${Glibmm_INCLUDE_DIRS} ${LibXML++Config_INCLUDE_DIR})
-SET(LIBS ${LIBS} ${LibXML++_LIBRARIES})
-MESSAGE("--LIBS: ${LIBS}")
-
 MESSAGE("--LD_LIBRARY_PATH: $ENV{LD_LIBRARY_PATH}")
 
 # Include the boost header files, system, and filesystem libraries
@@ -95,13 +89,6 @@ SET(STUB_INCLUDE_DIRS ${STUB_INCLUDE_DIRS} ${Boost_INCLUDE_DIR})
 SET(LIBS ${LIBS} ${Boost_FILESYSTEM_LIBRARY})
 SET(LIBS ${LIBS} ${Boost_SYSTEM_LIBRARY})
 
-# find lapack and link to it
-# note there is no include directory variable:
-# http://www.cmake.org/cmake/help/v3.0/module/FindLAPACK.html
-FIND_PACKAGE(LAPACK REQUIRED)
-set(LIBS ${LIBS} ${LAPACK_LIBRARIES})
-MESSAGE("\tFound LAPACK Libraries: ${LAPACK_LIBRARIES}")
-
 # Find HDF5
 FIND_PACKAGE(HDF5 REQUIRED)
 ADD_DEFINITIONS(${HDF5_DEFINITIONS})
@@ -111,20 +98,6 @@ MESSAGE("--    HDF5 Root: ${HDF5_ROOT}")
 MESSAGE("--    HDF5 Include directory: ${HDF5_INCLUDE_DIR}")
 MESSAGE("--    HDF5 Library directories: ${HDF5_LIBRARY_DIRS}")
 MESSAGE("--    HDF5 Libraries: ${HDF5_LIBRARIES}")
-
-# find coin and link to it
-FIND_PACKAGE(COIN REQUIRED)
-SET(STUB_INCLUDE_DIRS ${STUB_INCLUDE_DIRS} ${COIN_INCLUDE_DIRS})
-set(LIBS ${LIBS} ${COIN_LIBRARIES})
-MESSAGE("--    COIN Root: ${COIN_ROOT}")
-MESSAGE("--    COIN Include directories: ${COIN_INCLUDE_DIRS}")
-MESSAGE("--    COIN Libraries: ${COIN_LIBRARIES}")
-
-FIND_PACKAGE( Sqlite3 REQUIRED )
-SET(STUB_INCLUDE_DIRS ${STUB_INCLUDE_DIRS} ${SQLITE3_INCLUDE_DIR})
-SET(LIBS ${LIBS} ${SQLITE3_LIBRARIES})
-MESSAGE("--    SQLITE3 Include directories: ${SQLITE3_INCLUDE_DIR}")
-MESSAGE("--    SQLITE3 Libraries: ${SQLITE3_LIBRARIES}")
 
 # include all the directories we just found
 INCLUDE_DIRECTORIES(${STUB_INCLUDE_DIRS})

--- a/tests/xml_parser_tests.cc
+++ b/tests/xml_parser_tests.cc
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <fstream>
 #include <gtest/gtest.h>
+#include <libxml++/libxml++.h>
 
 #include "error.h"
 


### PR DESCRIPTION
This buys us some time to decide how we want to deal with c++11 support for stubs, cycamore, etc. by not leaking the c++11 requiring headers (libxml++). And it makes compiling archetypes simpler anyway. Addresses a good chunk of #1199.