### PR TITLE
adds a private new decay function to composition

### DIFF
--- a/release/smbchk.py
+++ b/release/smbchk.py
@@ -40,6 +40,7 @@ api_blacklist = {
     'cyclus::SimInit::LoadComposition',
     'cyclus::TradeExecutor<cyclus::Material>::ExecuteTrades',
     'cyclus::TradeExecutor<cyclus::Product>::ExecuteTrades',
+    'cyclus::Composition::NewDecay',
 }
 
 def load(ns):


### PR DESCRIPTION
I had a test failure on a fresh Ubuntu install from source complaining about the ABI test.