### PR TITLE
added Close() to FullBackend

### DIFF
--- a/src/hdf5_back.cc
+++ b/src/hdf5_back.cc
@@ -37,7 +37,11 @@ Hdf5Back::Hdf5Back(std::string path) : path_(path) {
   vldts_[BLOB] = blob_type_;
 }
 
-Hdf5Back::~Hdf5Back() {
+void Hdf5Back::Close() {
+  // make sure we are still open
+  if (closed_)
+    return;
+
   // cleanup HDF5
   Flush();
   H5Fclose(file_);
@@ -60,6 +64,13 @@ Hdf5Back::~Hdf5Back() {
   for (dbtit = schemas_.begin(); dbtit != schemas_.end(); ++dbtit) {
     delete[](dbtit->second);
   }
+
+  closed_ = true;
+}
+
+Hdf5Back::~Hdf5Back() {
+  if (!closed_)
+    Close();
 }
 
 void Hdf5Back::Notify(DatumList data) {

--- a/src/hdf5_back.h
+++ b/src/hdf5_back.h
@@ -81,6 +81,9 @@ class Hdf5Back : public FullBackend {
   /// cleans up resources and closes the file.
   virtual ~Hdf5Back();
 
+  /// Closes and flushes the backend.
+  virtual void Close();
+
   virtual void Notify(DatumList data);
 
   virtual std::string Name();

--- a/src/query_backend.h
+++ b/src/query_backend.h
@@ -377,6 +377,13 @@ class QueryableBackend {
 class FullBackend: public QueryableBackend, public RecBackend {
  public:
   virtual ~FullBackend() {}
+
+  /// Closes the backend, if approriate.
+  virtual void Close() {}
+
+ protected:
+  /// Flag for whether the backend is closed or not.
+  bool closed_ = false;
 };
 
 /// Wrapper class for QueryableBackends that injects a set of Cond's into every


### PR DESCRIPTION
This adds a Close() method to FullBackend to allow it to behave more like a true file object when used from libcyclus.  This was implemented because HDF5 keeps an internal cache of datasets, datatypes, and so on that is not cleared until the HDF5 object is itself closed.  Not clearing this cache was causing problems if you had:

1. run a simulation
2. opened a file with cymetric
3. left the interpreter open (via IPython, xonsh, etc)
4. run a new simulation in another process that used the same database
5. querying the new simulation data via cymetric would have partial, malformed data at best.

This PR allows cymetric to fully close the backend and the open an new handle if needed.

@hodger, can you please review.