### PR TITLE
Add optional explicit agent inventory tables

### DIFF
--- a/share/cyclus-flat.rng.in
+++ b/share/cyclus-flat.rng.in
@@ -22,6 +22,12 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
         <element name="dt"><data type="nonNegativeInteger"/></element> 
       </optional>
       <optional>
+        <element name="explicit_inventory"> <data type="boolean"/> </element>
+      </optional>
+      <optional>
+        <element name="explicit_inventory_compact"> <data type="boolean"/> </element>
+      </optional>
+      <optional>
         <element name="solver"> 
           <interleave>
             <optional><element name="config">

--- a/share/cyclus.rng.in
+++ b/share/cyclus.rng.in
@@ -23,6 +23,12 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
         <element name="dt"><data type="nonNegativeInteger"/></element> 
       </optional>
       <optional>
+        <element name="explicit_inventory"> <data type="boolean"/> </element>
+      </optional>
+      <optional>
+        <element name="explicit_inventory_compact"> <data type="boolean"/> </element>
+      </optional>
+      <optional>
         <element name="solver"> 
           <interleave>
             <optional><element name="config">

--- a/src/context.cc
+++ b/src/context.cc
@@ -19,6 +19,8 @@ SimInfo::SimInfo()
       dt(kDefaultTimeStepDur),
       decay("manual"),
       branch_time(-1),
+      explicit_inventory(false),
+      explicit_inventory_compact(false),
       parent_sim(boost::uuids::nil_uuid()),
       parent_type("init") {}
 
@@ -30,6 +32,8 @@ SimInfo::SimInfo(int dur, int y0, int m0, std::string handle)
       decay("manual"),
       branch_time(-1),
       handle(handle),
+      explicit_inventory(false),
+      explicit_inventory_compact(false),
       parent_sim(boost::uuids::nil_uuid()),
       parent_type("init") {}
 
@@ -41,6 +45,8 @@ SimInfo::SimInfo(int dur, int y0, int m0, std::string handle, std::string d)
       decay(d),
       branch_time(-1),
       handle(handle),
+      explicit_inventory(false),
+      explicit_inventory_compact(false),
       parent_sim(boost::uuids::nil_uuid()),
       parent_type("init") {}
 
@@ -55,6 +61,8 @@ SimInfo::SimInfo(int dur, boost::uuids::uuid parent_sim,
       parent_sim(parent_sim),
       parent_type(parent_type),
       branch_time(branch_time),
+      explicit_inventory(false),
+      explicit_inventory_compact(false),
       handle(handle) {}
 
 Context::Context(Timer* ti, Recorder* rec)
@@ -185,6 +193,11 @@ void Context::InitSim(SimInfo si) {
 
   NewDatum("DecayMode")
       ->AddVal("Decay", si.decay)
+      ->Record();
+
+  NewDatum("InfoExplicitInv")
+      ->AddVal("RecordInventory", si.explicit_inventory)
+      ->AddVal("RecordInventoryCompact", si.explicit_inventory_compact)
       ->Record();
 
   // TODO: when the backends get uint64_t support, the static_cast here should

--- a/src/context.h
+++ b/src/context.h
@@ -97,6 +97,15 @@ class SimInfo {
 
   /// Duration in seconds of a single time step in the simulation.
   uint64_t dt;
+
+  /// True if per-agent inventories should be explicitly queried/recorded
+  /// every time step in a table (i.e. agent ID, Time, Nuclide, Quantity).
+  bool explicit_inventory;
+
+  /// True if per-agent inventories should be explicitly queried/recorded
+  /// every time step in a table (i.e. agent ID, Time, Quantity,
+  /// Composition-object and/or reference).
+  bool explicit_inventory_compact;
 };
 
 /// A simulation context provides access to necessary simulation-global
@@ -115,6 +124,7 @@ class Context {
   friend class ::SimInitTest;
   friend class SimInit;
   friend class Agent;
+  friend class Timer;
 
   /// Creates a new context working with the specified timer and datum manager.
   /// The timer does not have to be initialized (yet).

--- a/src/infile_tree.h
+++ b/src/infile_tree.h
@@ -139,6 +139,19 @@ inline int OptionalQuery(InfileTree* tree, std::string query,
 }
 
 template <>
+inline bool OptionalQuery(InfileTree* tree, std::string query,
+                         bool default_val) {
+  if (tree->NMatches(query) == 0) {
+    return default_val;
+  }
+
+  std::string s = tree->GetString(query);
+  boost::trim(s);
+  std::transform(s.begin(), s.end(), s.begin(), ::tolower);
+  return s == "true" || s == "t" || s == "1";
+}
+
+template <>
 inline float OptionalQuery(InfileTree* tree, std::string query,
                            float default_val) {
   float val = default_val;

--- a/src/sim_init.cc
+++ b/src/sim_init.cc
@@ -148,17 +148,21 @@ void SimInit::LoadInfo() {
   int y0 = qr.GetVal<int>("InitialYear");
   int m0 = qr.GetVal<int>("InitialMonth");
   std::string h = qr.GetVal<std::string>("Handle");
-
   QueryResult dq = b_->Query("DecayMode", NULL);
   std::string d = dq.GetVal<std::string>("Decay");
+  si_ = SimInfo(dur, y0, m0, h, d);
 
-  dq = b_->Query("TimeStepDur", NULL);
+  si_.parent_sim = qr.GetVal<boost::uuids::uuid>("ParentSimId");
+
+  qr = b_->Query("TimeStepDur", NULL);
   // TODO: when the backends support uint64_t, the int template here
   // should be updated to uint64_t.
-  uint64_t ts = dq.GetVal<int>("DurationSecs");
+  si_.dt = qr.GetVal<int>("DurationSecs");
 
-  si_ = SimInfo(dur, y0, m0, h, d);
-  si_.parent_sim = qr.GetVal<boost::uuids::uuid>("ParentSimId");
+  qr = b_->Query("InfoExplicitInv", NULL);
+  si_.explicit_inventory = qr.GetVal<bool>("RecordInventory");
+  si_.explicit_inventory_compact = qr.GetVal<bool>("RecordInventoryCompact");
+
   ctx_->InitSim(si_);
 }
 

--- a/src/timer.h
+++ b/src/timer.h
@@ -10,6 +10,7 @@
 #include "material.h"
 #include "infile_tree.h"
 #include "time_listener.h"
+#include "comp_math.h"
 
 class SimInitTest;
 
@@ -83,6 +84,9 @@ class Timer {
   /// sends the tock signal to all of the agents receiving time
   /// notifications.
   void DoTock();
+
+  void RecordInventories(Agent* a);
+  void RecordInventory(Agent* a, std::string name, Material::Ptr m);
 
   /// decommissions all agents queued for the current timestep.
   void DoDecom();

--- a/src/xml_file_loader.cc
+++ b/src/xml_file_loader.cc
@@ -417,6 +417,9 @@ void XMLFileLoader::LoadControlParams() {
 
   SimInfo si(dur, y0, m0, handle, d);
 
+  si.explicit_inventory = OptionalQuery<bool>(qe, "explicit_inventory", false);
+  si.explicit_inventory_compact = OptionalQuery<bool>(qe, "explicit_inventory_compact", false);
+
   // get time step duration
   si.dt = OptionalQuery<int>(qe, "dt", kDefaultTimeStepDur);
 

--- a/tests/input/inventory.xml
+++ b/tests/input/inventory.xml
@@ -1,0 +1,58 @@
+<simulation>
+  <control>
+    <duration>10</duration>
+    <startmonth>1</startmonth>
+    <startyear>2000</startyear>
+    <explicit_inventory>true</explicit_inventory>
+  </control>
+
+  <archetypes>
+    <spec><lib>agents</lib><name>KFacility</name></spec>
+    <spec><lib>agents</lib><name>NullRegion</name></spec>
+    <spec><lib>agents</lib><name>NullInst</name></spec>
+  </archetypes>
+
+  <facility>
+    <name>KFacility</name>
+    <config>
+      <KFacility>
+        <in_commod>commodity</in_commod>
+        <in_capacity>1</in_capacity>
+        <k_factor_in>1</k_factor_in>
+        <out_commod>commodity</out_commod>
+        <recipe_name>commod_recipe</recipe_name>
+        <out_capacity>1</out_capacity>
+        <k_factor_out>1</k_factor_out>
+      </KFacility>
+    </config>
+  </facility>
+
+  <region>
+    <name>SingleRegion</name>
+    <config> <NullRegion/> </config>
+    <institution>
+      <name>SingleInstitution</name>
+      <initialfacilitylist>
+        <entry>
+          <prototype>KFacility</prototype>
+          <number>1</number>
+        </entry>
+      </initialfacilitylist>
+      <config> <NullInst/> </config>
+    </institution>
+  </region>
+
+  <recipe>
+    <name>commod_recipe</name>
+    <basis>mass</basis>
+    <nuclide>
+      <id>922350000</id>
+      <comp>0.711</comp>
+    </nuclide>
+    <nuclide>
+      <id>922380000</id>
+      <comp>99.289</comp>
+    </nuclide>
+  </recipe>
+
+</simulation>

--- a/tests/input/inventory_compact.xml
+++ b/tests/input/inventory_compact.xml
@@ -1,0 +1,58 @@
+<simulation>
+  <control>
+    <duration>10</duration>
+    <startmonth>1</startmonth>
+    <startyear>2000</startyear>
+    <explicit_inventory_compact>true</explicit_inventory_compact>
+  </control>
+
+  <archetypes>
+    <spec><lib>agents</lib><name>KFacility</name></spec>
+    <spec><lib>agents</lib><name>NullRegion</name></spec>
+    <spec><lib>agents</lib><name>NullInst</name></spec>
+  </archetypes>
+
+  <facility>
+    <name>KFacility</name>
+    <config>
+      <KFacility>
+        <in_commod>commodity</in_commod>
+        <in_capacity>1</in_capacity>
+        <k_factor_in>1</k_factor_in>
+        <out_commod>commodity</out_commod>
+        <recipe_name>commod_recipe</recipe_name>
+        <out_capacity>1</out_capacity>
+        <k_factor_out>1</k_factor_out>
+      </KFacility>
+    </config>
+  </facility>
+
+  <region>
+    <name>SingleRegion</name>
+    <config> <NullRegion/> </config>
+    <institution>
+      <name>SingleInstitution</name>
+      <initialfacilitylist>
+        <entry>
+          <prototype>KFacility</prototype>
+          <number>1</number>
+        </entry>
+      </initialfacilitylist>
+      <config> <NullInst/> </config>
+    </institution>
+  </region>
+
+  <recipe>
+    <name>commod_recipe</name>
+    <basis>mass</basis>
+    <nuclide>
+      <id>922350000</id>
+      <comp>0.711</comp>
+    </nuclide>
+    <nuclide>
+      <id>922380000</id>
+      <comp>99.289</comp>
+    </nuclide>
+  </recipe>
+
+</simulation>

--- a/tests/input/inventory_compact_false.xml
+++ b/tests/input/inventory_compact_false.xml
@@ -1,0 +1,58 @@
+<simulation>
+  <control>
+    <duration>10</duration>
+    <startmonth>1</startmonth>
+    <startyear>2000</startyear>
+    <explicit_inventory_compact>false</explicit_inventory_compact>
+  </control>
+
+  <archetypes>
+    <spec><lib>agents</lib><name>KFacility</name></spec>
+    <spec><lib>agents</lib><name>NullRegion</name></spec>
+    <spec><lib>agents</lib><name>NullInst</name></spec>
+  </archetypes>
+
+  <facility>
+    <name>KFacility</name>
+    <config>
+      <KFacility>
+        <in_commod>commodity</in_commod>
+        <in_capacity>1</in_capacity>
+        <k_factor_in>1</k_factor_in>
+        <out_commod>commodity</out_commod>
+        <recipe_name>commod_recipe</recipe_name>
+        <out_capacity>1</out_capacity>
+        <k_factor_out>1</k_factor_out>
+      </KFacility>
+    </config>
+  </facility>
+
+  <region>
+    <name>SingleRegion</name>
+    <config> <NullRegion/> </config>
+    <institution>
+      <name>SingleInstitution</name>
+      <initialfacilitylist>
+        <entry>
+          <prototype>KFacility</prototype>
+          <number>1</number>
+        </entry>
+      </initialfacilitylist>
+      <config> <NullInst/> </config>
+    </institution>
+  </region>
+
+  <recipe>
+    <name>commod_recipe</name>
+    <basis>mass</basis>
+    <nuclide>
+      <id>922350000</id>
+      <comp>0.711</comp>
+    </nuclide>
+    <nuclide>
+      <id>922380000</id>
+      <comp>99.289</comp>
+    </nuclide>
+  </recipe>
+
+</simulation>

--- a/tests/input/inventory_false.xml
+++ b/tests/input/inventory_false.xml
@@ -1,0 +1,58 @@
+<simulation>
+  <control>
+    <duration>10</duration>
+    <startmonth>1</startmonth>
+    <startyear>2000</startyear>
+    <explicit_inventory>false</explicit_inventory>
+  </control>
+
+  <archetypes>
+    <spec><lib>agents</lib><name>KFacility</name></spec>
+    <spec><lib>agents</lib><name>NullRegion</name></spec>
+    <spec><lib>agents</lib><name>NullInst</name></spec>
+  </archetypes>
+
+  <facility>
+    <name>KFacility</name>
+    <config>
+      <KFacility>
+        <in_commod>commodity</in_commod>
+        <in_capacity>1</in_capacity>
+        <k_factor_in>1</k_factor_in>
+        <out_commod>commodity</out_commod>
+        <recipe_name>commod_recipe</recipe_name>
+        <out_capacity>1</out_capacity>
+        <k_factor_out>1</k_factor_out>
+      </KFacility>
+    </config>
+  </facility>
+
+  <region>
+    <name>SingleRegion</name>
+    <config> <NullRegion/> </config>
+    <institution>
+      <name>SingleInstitution</name>
+      <initialfacilitylist>
+        <entry>
+          <prototype>KFacility</prototype>
+          <number>1</number>
+        </entry>
+      </initialfacilitylist>
+      <config> <NullInst/> </config>
+    </institution>
+  </region>
+
+  <recipe>
+    <name>commod_recipe</name>
+    <basis>mass</basis>
+    <nuclide>
+      <id>922350000</id>
+      <comp>0.711</comp>
+    </nuclide>
+    <nuclide>
+      <id>922380000</id>
+      <comp>99.289</comp>
+    </nuclide>
+  </recipe>
+
+</simulation>

--- a/tests/integ_tests.cc
+++ b/tests/integ_tests.cc
@@ -61,6 +61,10 @@ void RunSim(std::string infile, SqliteBack* back) {
 TEST(IntegTests, RunAllInfiles) {
   std::vector<std::string> infiles;
   infiles.push_back("custom_dt.xml");
+  infiles.push_back("inventory.xml");
+  infiles.push_back("inventory_compact.xml");
+  infiles.push_back("inventory_compact_false.xml");
+  infiles.push_back("inventory_false.xml");
   infiles.push_back("lotka_volterra_determ.xml");
   infiles.push_back("minimal_cycle.xml");
   infiles.push_back("null_sink.xml");

--- a/tests/test_inventories.py
+++ b/tests/test_inventories.py
@@ -5,6 +5,7 @@ from numpy.testing import assert_array_equal
 import os
 import tables
 import numpy as np
+import sqlite3
 from tools import check_cmd
 from helper import tables_exist, find_ids, exit_times, \
     h5out, sqliteout, clean_outs, to_ary, which_outfile
@@ -19,7 +20,7 @@ def test_inventories_false():
     paths = [["/ExplicitInventory"], ["/ExplicitInventoryCompact"]]
     for sim, path in zip(sim_inputs, paths):
         holdsrtn = [1]  # needed because nose does not send() to test generator
-        outfile = which_outfile()
+        outfile = sqliteout
         cmd = ["cyclus", "-o", outfile, "--input-file", sim]
         yield check_cmd, cmd, '.', holdsrtn
         rtn = holdsrtn[0]
@@ -43,7 +44,7 @@ def test_inventories():
     paths = [["/ExplicitInventory"], ["/ExplicitInventoryCompact"]]
     for sim, path in zip(sim_inputs, paths):
         holdsrtn = [1]  # needed because nose does not send() to test generator
-        outfile = which_outfile()
+        outfile = sqliteout
         cmd = ["cyclus", "-o", outfile, "--input-file", sim]
         yield check_cmd, cmd, '.', holdsrtn
         rtn = holdsrtn[0]

--- a/tests/test_inventories.py
+++ b/tests/test_inventories.py
@@ -29,7 +29,7 @@ def test_inventories_false():
         # Ensure tables do not exist
         assert_false, tables_exist(outfile, path)
         if tables_exist(outfile, path):
-	    print('Inventory table exists despite false entry in control section of input file.')
+            print('Inventory table exists despite false entry in control section of input file.')
             outfile.close()
             clean_outs()
             return  # don't execute further commands
@@ -53,53 +53,53 @@ def test_inventories():
         # Check if inventory tables exist
         assert_true, tables_exist(outfile, path)
         if not tables_exist(outfile, path):
-	    print('Inventory table does not exist despite true entry in control section of input file.')
+            print('Inventory table does not exist despite true entry in control section of input file.')
             outfile.close()
             clean_outs()
             return  # don't execute further commands
             
         # Get specific table
-	table = path[0]
+        table = path[0]
         if outfile == h5out:
             output = tables.open_file(h5out, mode = "r")
-      	    inventory = output.get_node(table)[:]
-      	    compositions = output.get_node("/Compositions")[:]
+            inventory = output.get_node(table)[:]
+            compositions = output.get_node("/Compositions")[:]
             output.close()
         else:
             conn = sqlite3.connect(outfile)
             conn.row_factory = sqlite3.Row
             cur = conn.cursor()
             exc = cur.execute
-	    sqltable = table.replace('/', '')
-	    sql = "SELECT * FROM %s" % sqltable
+            sqltable = table.replace('/', '')
+            sql = "SELECT * FROM %s" % sqltable
             inventory = exc(sql).fetchall()
             compositions = exc('SELECT * FROM Compositions').fetchall()
             conn.close()
         
-	# Test that quantity increases as expected with k=1
-	if "Compact" not in table:
-	    time = to_ary(inventory, "Time")
-	    quantity = to_ary(inventory, "Quantity")
-	    nucid = to_ary(inventory, "NucId")
-	    massfrac = to_ary(compositions, "MassFrac")
-	    nucid_comp = to_ary(compositions, "NucId") 
-	    expected_quantity = []
-	    expected_nucid = []
-	    repeat = 100
-	    for t in time:
-	    	if t != repeat:
-	    	    expected_quantity.append((t+1)*massfrac[1])
-		    expected_nucid.append(nucid_comp[1])
-		else:
-	    	    expected_quantity.append((t+1)*massfrac[0])
-		    expected_nucid.append(nucid_comp[0])
-		t = repeat
-	    assert_array_equal, quantity, expected_quantity
-	    assert_array_equal, nucid, expected_nucid
-            return  # don't execute further commands
-	else:
-	    # composition will be the same in compact inventory
-	    return  # don't execute further commands
+    # Test that quantity increases as expected with k=1
+    if "Compact" not in table:
+        time = to_ary(inventory, "Time")
+        quantity = to_ary(inventory, "Quantity")
+        nucid = to_ary(inventory, "NucId")
+        massfrac = to_ary(compositions, "MassFrac")
+        nucid_comp = to_ary(compositions, "NucId") 
+        expected_quantity = []
+        expected_nucid = []
+        repeat = 100
+        for t in time:
+            if t != repeat:
+                expected_quantity.append((t+1)*massfrac[1])
+                expected_nucid.append(nucid_comp[1])
+            else:
+                expected_quantity.append((t+1)*massfrac[0])
+                expected_nucid.append(nucid_comp[0])
+                t = repeat
+                assert_array_equal, quantity, expected_quantity
+                assert_array_equal, nucid, expected_nucid
+                return  # don't execute further commands
+    else:
+        # composition will be the same in compact inventory
+        return  # don't execute further commands
 
         clean_outs()
 

--- a/tests/test_inventories.py
+++ b/tests/test_inventories.py
@@ -1,0 +1,105 @@
+#! /usr/bin/env python
+
+from nose.tools import assert_false, assert_true, assert_equal
+from numpy.testing import assert_array_equal
+import os
+import tables
+import numpy as np
+from tools import check_cmd
+from helper import tables_exist, find_ids, exit_times, \
+    h5out, sqliteout, clean_outs, to_ary, which_outfile
+
+"""Tests"""
+def test_inventories_false():
+    """Testing for inventory and compact inventory table non-creation.
+    """
+    clean_outs()
+    # Cyclus simulation input with inventory table
+    sim_inputs = ["./input/inventory_false.xml", "./input/inventory_compact_false.xml"]
+    paths = [["/ExplicitInventory"], ["/ExplicitInventoryCompact"]]
+    for sim, path in zip(sim_inputs, paths):
+        holdsrtn = [1]  # needed because nose does not send() to test generator
+        outfile = which_outfile()
+        cmd = ["cyclus", "-o", outfile, "--input-file", sim]
+        yield check_cmd, cmd, '.', holdsrtn
+        rtn = holdsrtn[0]
+        if rtn != 0:
+            return  # don't execute further commands
+
+        # Ensure tables do not exist
+        assert_false, tables_exist(outfile, path)
+        if tables_exist(outfile, path):
+	    print('Inventory table exists despite false entry in control section of input file.')
+            outfile.close()
+            clean_outs()
+            return  # don't execute further commands
+
+def test_inventories():
+    """Testing for inventory and compact inventory table creation.
+    """
+    clean_outs()
+    # Cyclus simulation input with inventory table
+    sim_inputs = ["./input/inventory.xml", "./input/inventory_compact.xml"]
+    paths = [["/ExplicitInventory"], ["/ExplicitInventoryCompact"]]
+    for sim, path in zip(sim_inputs, paths):
+        holdsrtn = [1]  # needed because nose does not send() to test generator
+        outfile = which_outfile()
+        cmd = ["cyclus", "-o", outfile, "--input-file", sim]
+        yield check_cmd, cmd, '.', holdsrtn
+        rtn = holdsrtn[0]
+        if rtn != 0:
+            return  # don't execute further commands
+            
+        # Check if inventory tables exist
+        assert_true, tables_exist(outfile, path)
+        if not tables_exist(outfile, path):
+	    print('Inventory table does not exist despite true entry in control section of input file.')
+            outfile.close()
+            clean_outs()
+            return  # don't execute further commands
+            
+        # Get specific table
+	table = path[0]
+        if outfile == h5out:
+            output = tables.open_file(h5out, mode = "r")
+      	    inventory = output.get_node(table)[:]
+      	    compositions = output.get_node("/Compositions")[:]
+            output.close()
+        else:
+            conn = sqlite3.connect(outfile)
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            exc = cur.execute
+	    sqltable = table.replace('/', '')
+	    sql = "SELECT * FROM %s" % sqltable
+            inventory = exc(sql).fetchall()
+            compositions = exc('SELECT * FROM Compositions').fetchall()
+            conn.close()
+        
+	# Test that quantity increases as expected with k=1
+	if "Compact" not in table:
+	    time = to_ary(inventory, "Time")
+	    quantity = to_ary(inventory, "Quantity")
+	    nucid = to_ary(inventory, "NucId")
+	    massfrac = to_ary(compositions, "MassFrac")
+	    nucid_comp = to_ary(compositions, "NucId") 
+	    expected_quantity = []
+	    expected_nucid = []
+	    repeat = 100
+	    for t in time:
+	    	if t != repeat:
+	    	    expected_quantity.append((t+1)*massfrac[1])
+		    expected_nucid.append(nucid_comp[1])
+		else:
+	    	    expected_quantity.append((t+1)*massfrac[0])
+		    expected_nucid.append(nucid_comp[0])
+		t = repeat
+	    assert_array_equal, quantity, expected_quantity
+	    assert_array_equal, nucid, expected_nucid
+            return  # don't execute further commands
+	else:
+	    # composition will be the same in compact inventory
+	    return  # don't execute further commands
+
+        clean_outs()
+


### PR DESCRIPTION
Built on #1227 - so this will need a rebase after that goes in.  This is still a work in progress and needs tests.  Closes #1223.

Input file now has two new optional config params in control section:

```xml
<explicit_inventory>[bool]</explicit_inventory>
<explicit_inventory_compact>[bool]</explicit_inventory_compact>
```
which each generate new correspondingly named tables in the database.  There is one main design decision we still need to make:

* We have the ability to record inventories separately by buffer name - i.e. facilities with multiple buffers can have their different buffer inventories recorded separately (e.g. fresh_fuel, in_core, spent_fuel).  This is how I've implemented it here.  The alternative is to just squash all different buffers' materials together and record a single composition for the agent for the time step.  What do you all think?

