### PR TITLE
Trow error when a bid with quantity <=0 is offered

### DIFF
--- a/src/bid_portfolio.cc
+++ b/src/bid_portfolio.cc
@@ -1,0 +1,18 @@
+#include "bid_portfolio.h"
+
+#include "Trader.h"
+
+
+
+namespace cyclus {
+    std::string GetTraderPrototype(Trader* bidder){
+        return bidder->manager()->prototype();
+    }
+
+
+    std::string GetTraderSpec(Trader* bidder){
+        return bidder->manager()->spec();
+    }
+
+
+}

--- a/src/bid_portfolio.cc
+++ b/src/bid_portfolio.cc
@@ -5,14 +5,16 @@
 
 
 namespace cyclus {
-    std::string GetTraderPrototype(Trader* bidder){
-        return bidder->manager()->prototype();
-    }
 
 
-    std::string GetTraderSpec(Trader* bidder){
-        return bidder->manager()->spec();
-    }
+  std::string GetTraderPrototype(Trader* bidder){
+    return bidder->manager()->prototype();
+  }
 
 
-}
+  std::string GetTraderSpec(Trader* bidder){
+    return bidder->manager()->spec();
+  }
+
+
+} // namespace cyclus

--- a/src/bid_portfolio.cc
+++ b/src/bid_portfolio.cc
@@ -1,6 +1,6 @@
 #include "bid_portfolio.h"
 
-#include "Trader.h"
+#include "trader.h"
 
 
 

--- a/src/bid_portfolio.h
+++ b/src/bid_portfolio.h
@@ -58,15 +58,13 @@ class BidPortfolio : public boost::enable_shared_from_this< BidPortfolio<T> > {
         Bid<T>::Create(request, offer, bidder, this->shared_from_this(),
                        exclusive);
     VerifyResponder_(b);
-      if(offer->quantity() > 0 )
-          bids_.insert(b);
-      else{
-
-          std::stringstream ss;
-          ss << GetTraderPrototype(bidder) << " from " << GetTraderSpec(bidder) << " is offering a bid quantity <= 0, Q = " << offer->quantity() ;
-          throw ValueError(ss.str());
-
-      }
+    if(offer->quantity() > 0 )
+      bids_.insert(b);
+    else{
+      std::stringstream ss;
+      ss << GetTraderPrototype(bidder) << " from " << GetTraderSpec(bidder) << " is offering a bid quantity <= 0, Q = " << offer->quantity() ;
+      throw ValueError(ss.str());
+    }
     return b;
   }
 

--- a/src/bid_portfolio.h
+++ b/src/bid_portfolio.h
@@ -3,6 +3,7 @@
 
 #include <set>
 #include <string>
+#include <sstream>
 
 #include <boost/shared_ptr.hpp>
 
@@ -13,6 +14,11 @@
 namespace cyclus {
 
 class Trader;
+
+
+std::string GetTraderPrototype(Trader* bidder);
+std::string GetTraderSpec(Trader* bidder);
+
 
 /// @class BidPortfolio
 ///
@@ -52,7 +58,15 @@ class BidPortfolio : public boost::enable_shared_from_this< BidPortfolio<T> > {
         Bid<T>::Create(request, offer, bidder, this->shared_from_this(),
                        exclusive);
     VerifyResponder_(b);
-    bids_.insert(b);
+      if(offer->quantity() > 0 )
+          bids_.insert(b);
+      else{
+
+          std::stringstream ss;
+          ss << GetTraderPrototype(bidder) << " from " << GetTraderSpec(bidder) << " is offering a bid quantity <= 0, Q = " << offer->quantity() ;
+          throw ValueError(ss.str());
+
+      }
     return b;
   }
 
@@ -122,6 +136,7 @@ class BidPortfolio : public boost::enable_shared_from_this< BidPortfolio<T> > {
 
   Trader* bidder_;
 };
+
 
 }  // namespace cyclus
 

--- a/src/bid_portfolio.h
+++ b/src/bid_portfolio.h
@@ -135,7 +135,6 @@ class BidPortfolio : public boost::enable_shared_from_this< BidPortfolio<T> > {
   Trader* bidder_;
 };
 
-
 }  // namespace cyclus
 
 #endif  // CYCLUS_SRC_BID_PORTFOLIO_H_


### PR DESCRIPTION
Cyclus uses to crash when a bid with a quantity = 0 is offered (creating a *nan* in **exchange_translator.h:** ***void TranslateCapacities( ... )*** method )
 
Now it trows an error.

