### PR TITLE
Fix parametrized FacilityTests

### DIFF
--- a/tests/agent_tests/agent_tests.cc
+++ b/tests/agent_tests/agent_tests.cc
@@ -18,13 +18,11 @@ TEST_P(AgentTests, Clone) {
   delete clone;
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_P(AgentTests, Print) {
   std::string s = agent_->str();
   EXPECT_NO_THROW(std::string s = agent_->str());
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_P(AgentTests, Schema) {
   std::stringstream schema;
   schema << ("<element name=\"foo\">\n");
@@ -34,27 +32,26 @@ TEST_P(AgentTests, Schema) {
   EXPECT_NO_THROW(p.Init(schema));
 }
 
+TEST_P(AgentTests, GetAgentType) {
+  EXPECT_NE(std::string("Agent"), agent_->kind());
+}
+
 TEST_P(AgentTests, Annotations) {
   Json::Value anno = agent_->annotations();
   EXPECT_TRUE(anno.isObject());
 }
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_P(AgentTests, GetAgentType) {
-  EXPECT_NE(std::string("Agent"), agent_->kind());
-}
-
-TEST_P(AgentTests, Name) {
+TEST_P(AgentTests, Annotations_Name) {
   Json::Value a = agent_->annotations();
   EXPECT_TRUE(a["name"].isString());
 }
 
-TEST_P(AgentTests, Parents) {
+TEST_P(AgentTests, Annotations_Parents) {
   Json::Value a = agent_->annotations();
   EXPECT_FALSE(a["parents"].empty());
 }
 
-TEST_P(AgentTests, AllParents) {
+TEST_P(AgentTests, Annotations_AllParents) {
   Json::Value all_parents = agent_->annotations()["all_parents"];
   EXPECT_FALSE(all_parents.empty());
 

--- a/tests/agent_tests/agent_tests.h
+++ b/tests/agent_tests/agent_tests.h
@@ -13,7 +13,6 @@ using ::testing::TestWithParam;
 using ::testing::Values;
 
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // Inside the test body, fixture constructor, SetUp(), and TearDown() we
 // can refer to the test parameter by GetParam().  In this case, the test
 // parameter is a pointer to a concrete Agent instance

--- a/tests/agent_tests/facility_tests.cc
+++ b/tests/agent_tests/facility_tests.cc
@@ -2,18 +2,19 @@
 
 #include <gtest/gtest.h>
 
-// extern int ConnectFacTests() {return 0;}
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_P(FacilityTests, Tick) {
-  int time = 1;
-  facility_->Tick();
-}
+// The FacilityTests initialization does not honor the normal initialization
+// guarantees for archetypes.  And so any type of remotely sophisticated
+// configuration validation of archetypes will be triggered to fail if we try
+// to call methods like e.g. Tick, Tock, Build, etc.  We already know the
+// agents satisfy the Agent class interface implicitly by being able to load
+// them and cast/assign them to Agent*/Facility*/etc. without compiler errors.
+// From now on, only call state-reporting functions with no side-effects in
+// these tests.
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_P(FacilityTests, Tock) {
-  int time = 1;
-  EXPECT_NO_THROW(facility_->Tock());
+TEST_P(FacilityTests, Construct) {
+  // make sure setup construction worked successfully
+  ASSERT_NE(facility_, nullptr);
 }
 
 TEST_P(FacilityTests, Entity) {

--- a/tests/agent_tests/facility_tests.h
+++ b/tests/agent_tests/facility_tests.h
@@ -23,15 +23,12 @@ class FacilityTests : public TestWithParam<AgentConstructor*> {
  public:
   virtual void SetUp() {
     facility_ = dynamic_cast<cyclus::Facility*>((*GetParam())(tc_.get()));
-    test_inst_ = new TestInst(tc_.get());
-    facility_->Build(test_inst_);
   }
 
   virtual void TearDown() {}
 
  protected:
   cyclus::Facility* facility_;
-  TestInst* test_inst_;
   cyclus::TestContext tc_;
 };
 


### PR DESCRIPTION
The FacilityTests initialization does not honor the normal initialization
guarantees for archetypes.  And so any type of remotely sophisticated
configuration validation of archetypes will be triggered to fail if we try to
call methods like e.g. Tick, Tock, Build, etc.  Remove these calls.  We
already know the agents satisfy the Agent class interface implicitly by being
able to load them and cast/assign them to Agent*/Facility*/etc.  From now on,
only call state-reporting functions with no side-effects in these tests.