### PR TITLE
be careful with exclusivity float comparisons in DRE

### DIFF
--- a/src/cyc_limits.h
+++ b/src/cyc_limits.h
@@ -25,6 +25,10 @@ inline bool AlmostEq(double d1, double d2) {
   return std::fabs(d1 - d2) < eps();
 }
 
+/// distance in ULP within which floating point numbers should be considered
+/// equal.
+static const double float_ulp_eq = 2;
+
 /// maximum value for a function modifier (i.e., a_i for variable x_i)
 static const double kModifierLimit = pow(10, 10);
 

--- a/src/greedy_solver.cc
+++ b/src/greedy_solver.cc
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <functional>
 #include <vector>
+#include <boost/math/special_functions/next.hpp>
 
 #include "cyc_limits.h"
 #include "error.h"
@@ -173,7 +174,15 @@ void GreedySolver::GreedilySatisfySet(RequestGroup::Ptr prs) {
         // exclusivity adjustment
         if (arc_it->exclusive()) {
           excl_val = a.excl_val();
-          tomatch = (tomatch < excl_val) ? 0 : excl_val;
+
+          // this careful float comparison is vital for preventing false positive
+          // constraint violations w.r.t. exclusivity-related capacity.
+          double dist = boost::math::float_distance(tomatch, excl_val);
+          if (dist >= float_ulp_eq ) {
+            tomatch = 0;
+          } else {
+            tomatch = excl_val;
+          }
         }
 
         if (tomatch > eps()) {


### PR DESCRIPTION
Previously, some exclusivity arcs were being terminated (set to zero) because
floating point comparisons failed that should have succeeded such as:

    29565 <= 29564.999999999994

This uses ULP comparisons to determine closeness of floats more robustly
handling cases of numbers that should be treated as ~identical.

This resolves some issues Baptiste has been having in his FCO work.