### PR TITLE
Fix for hdf5_back_gen.py compatibility issues.

### DIFF
--- a/src/hdf5_back_gen.py
+++ b/src/hdf5_back_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python3
 """This module generates HDF5 backend code found in src/hdf5_back.cc"""
 import os
 import json

--- a/src/hdf5_back_gen.py
+++ b/src/hdf5_back_gen.py
@@ -4,19 +4,20 @@ import os
 import json
 from ast import literal_eval
 
-def resolve_unicode(item):
+def resolve_unicode(item):	   
+    #Python3, if we can handle it, don't bother.    
     if isinstance(item, str):
-        return item.encode('utf-8')	
+        return item        
+    #We must check every element in tuples and lists.    
     elif isinstance(item, tuple):
         return tuple([resolve_unicode(i) for i in item])
     elif isinstance(item, list):
         return [resolve_unicode(i) for i in item]
+    #Not a string, either unicode (Python2.7) or an int.    
     else: 
-        #print("Reading in ", type(item))
         try:
             return item.encode('utf-8')
         except Exception:
-            #print('could not encode ',type(item))
             pass
         return item
 
@@ -31,11 +32,6 @@ for row in range(0, len(RAW_TABLE)):
         break
 
 V3_TABLE = list(tuple(row) for row in RAW_TABLE[TABLE_START:])
-#for row in range(0, len(V3_TABLE)):
-#    row_as_list = list(V3_TABLE[row])    
-#    for col in range(0, len(row_as_list)):     
-#        row_as_list[col] = resolve_unicode(row_as_list[col])
-#    V3_TABLE[row] = tuple(row_as_list)
 
 CANON_SET = set()
 DB_TO_CPP = {}
@@ -48,8 +44,7 @@ def convert_canonical(raw_list):
     return tuple(convert_canonical(x) for x in raw_list)
 
 for row in V3_TABLE:
-    if row[6] == 1 and row[4] == "HDF5":
-        print(row)        
+    if row[6] == 1 and row[4] == "HDF5":        
         CANON_SET.add(convert_canonical(row[7]))
         DB_TO_CPP[row[1]] = row[2]
         CANON_TO_DB[convert_canonical(row[7])] = row[1]
@@ -506,8 +501,6 @@ READERS = {'INT': REINTERPRET_CAST_READER,
            'MAP_PAIR_INT_VL_STRING_DOUBLE': MAP_PAIR_INT_VL_STRING_DOUBLE_READER,
            'VL_MAP_PAIR_INT_VL_STRING_DOUBLE': VL_READER}
 
-QUERY_CASES = ''
-
 def indent(text, prefix, predicate=None):
     """Adds 'prefix' to the beginning of selected lines in 'text'.
     If 'predicate' is provided, 'prefix' will only be added to the lines
@@ -523,6 +516,8 @@ def indent(text, prefix, predicate=None):
         for line in text.splitlines(True):
             yield (prefix + line if predicate(line) else line)
     return ''.join(prefixed_lines())
+
+QUERY_CASES = ''
 
 def main():
     global QUERY_CASES

--- a/src/hdf5_back_gen.py
+++ b/src/hdf5_back_gen.py
@@ -39,7 +39,7 @@ CANON_TO_DB = {}
 INDENT = '    '
 
 def convert_canonical(raw_list):
-    if type(raw_list) is str:
+    if isinstance(raw_list, str):
         return raw_list
     return tuple(convert_canonical(x) for x in raw_list)
 
@@ -502,7 +502,9 @@ READERS = {'INT': REINTERPRET_CAST_READER,
            'VL_MAP_PAIR_INT_VL_STRING_DOUBLE': VL_READER}
 
 def indent(text, prefix, predicate=None):
-    """Adds 'prefix' to the beginning of selected lines in 'text'.
+    """This function copied from textwrap library version 3.3.
+
+    Adds 'prefix' to the beginning of selected lines in 'text'.
     If 'predicate' is provided, 'prefix' will only be added to the lines
     where 'predicate(line)' is True. If 'predicate' is not provided,
     it will default to adding 'prefix' to all non-empty lines that do not


### PR DESCRIPTION
This is in reference to #1236.

On my clean install of 14.04, this fix allows to cyclus to install successfully with no hdf5_back recursion errors. I sorted out unicode characters at the point when we pull in data from dbtypes.json. 

Additionally, this allows almost all unit tests to pass, except the following 3: 

```[----------] Global test environment tear-down
[==========] 553 tests from 109 test cases ran. (30570 ms total)
[  PASSED  ] 550 tests.```
```[  FAILED  ] 3 tests, listed below:```
```[  FAILED  ] ProgTranslatorTests.translation```
```[  FAILED  ] Hdf5BackTests.ReadWriteDouble```
```[  FAILED  ] Hdf5BackTest.ReadWriteAll```

In terms of the ReadWriteDouble, the generated double code looks to be correct.
```
case DOUBLE: {
        double x = *reinterpret_cast<double*>(buf + offset);
        is_row_selected = CmpConds<double>(&x, &(field_conds[qr.fields[j]]));
        if (is_row_selected)
            row[j] = x;
        break;
}
```

So I'm not sure what's going on there.