### PR TITLE
read CYCLUS_NO_EXCEPTION env variable to know if catching exception is require

### DIFF
--- a/cli/cyclus.cc
+++ b/cli/cyclus.cc
@@ -196,17 +196,17 @@ int main(int argc, char* argv[]) {
   }
 
   
-  char* CYCLUS_NO_EXCEPTION = getenv("CYCLUS_NO_EXCEPTION");
-  if( CYCLUS_NO_EXCEPTION !=NULL && CYCLUS_NO_EXCEPTION != "0" ){
+  char* CYCLUS_NO_CATCH = getenv("CYCLUS_NO_CATCH");
+  if( CYCLUS_NO_CATCH !=NULL && CYCLUS_NO_CATCH != "0" ){
     si.timer()->RunSim();
-  }
-  else {
+  }   else {
     try {
       si.timer()->RunSim();
     } catch (cyclus::Error err) {
       std::cerr << err.what() << "\n";
       return 1;
-    }  }
+    }
+  }
   
   rec.Flush();
 

--- a/cli/cyclus.cc
+++ b/cli/cyclus.cc
@@ -195,13 +195,19 @@ int main(int argc, char* argv[]) {
     si.recorder()->RegisterBackend(fback);
   }
 
-  try {
+  
+  char* CYCLUS_NO_EXCEPTION = getenv("CYCLUS_NO_EXCEPTION");
+  if( CYCLUS_NO_EXCEPTION !=NULL && CYCLUS_NO_EXCEPTION != "0" ){
     si.timer()->RunSim();
-  } catch (cyclus::Error err) {
-    std::cerr << err.what() << "\n";
-    return 1;
   }
-
+  else {
+    try {
+      si.timer()->RunSim();
+    } catch (cyclus::Error err) {
+      std::cerr << err.what() << "\n";
+      return 1;
+    }  }
+  
   rec.Flush();
 
   std::cout << std::endl;


### PR DESCRIPTION
As @rwcarlsen asked, with this modification, one can now remove the catch of exception  by setting CYCLUS_NO_EXCEPTION environment variable to anything but 0.

Not sure the choose of the variable name is the best... I let you guys suggest something better