### PR TITLE
Fix for anonymous namespaces, triggered by boost

### DIFF
--- a/cli/cycpp.py
+++ b/cli/cycpp.py
@@ -111,7 +111,7 @@ WRANGLERS = {
     'mi6::Spy',  # for testing!!
     }
 
-ENTITIES = [('cyclus::Region', 'region'), ('cyclus::Institution', 'institution'), 
+ENTITIES = [('cyclus::Region', 'region'), ('cyclus::Institution', 'institution'),
             ('cyclus::Facility', 'facility'), ('cyclus::Agent', 'archetype')]
 
 def escape_xml(s, ind='    '):
@@ -217,12 +217,12 @@ class Filter(object):
         elif varname is None:
             s = ("The {0!r} class in the {1} machine has the following "
                  "annotations:\n{2}")
-            s = s.format(classname, mc.__class__.__name__, 
+            s = s.format(classname, mc.__class__.__name__,
                          pformat(mc.context[classname]))
         else:
             s = ("The {0!r} state variable on the {1!r} class in the {2} machine "
                  "has the following annotations:\n\n{3}\n")
-            s = s.format(varname, classname, mc.__class__.__name__, 
+            s = s.format(varname, classname, mc.__class__.__name__,
                          pformat(mc.context[classname]['vars'][varname]))
         return s
 
@@ -299,7 +299,7 @@ class NamespaceFilter(Filter):
         state = self.machine
         name = self.match.group(1)
         if name is not None:
-            name = name.strip() or None
+            name = name.strip() or '<anonymous>'
         state.namespaces.append((state.depth, name))
 
     def revert(self, statement, sep):
@@ -489,14 +489,14 @@ class VarDeclarationFilter(Filter):
         vtype, vname = self.match.groups()
         access = state.access[tuple(state.classes)]
         state.ensure_class_context(classname)
-        annotations['type'] = state.canonize_type(vtype, vname, 
+        annotations['type'] = state.canonize_type(vtype, vname,
                                                   statement=statement)
         annotations['index'] = len(state.context[classname]['vars'])
         state.context[classname]['vars'][vname] = annotations
         if 'alias' in annotations:
             alias = annotations['alias']
             while not isinstance(alias, STRING_TYPES):
-                alias = alias[0] 
+                alias = alias[0]
             state.context[classname]['vars'][alias] = vname
         if annotations['type'][0] not in BUFFERS:
             annotations['alias'] = self.canonize_alias(
@@ -536,7 +536,7 @@ class VarDeclarationFilter(Filter):
         given state variable name and defaults for non-nested containers.
         """
         if isinstance(t, STRING_TYPES):
-            return ann or name 
+            return ann or name
         template = defaults[t[0]]
         # expand ann if needed
         if ann is None:
@@ -546,7 +546,7 @@ class VarDeclarationFilter(Filter):
         elif len(ann) < len(t):
             ann = ann + [None]*(len(t) - len(ann))
         # find template name
-        if template[0] is None: 
+        if template[0] is None:
             t0 = ann[0] or name
         else:
             # expand t0 ann if needed
@@ -772,13 +772,13 @@ class StateAccumulator(object):
                     # the alias - which is impossible.
                     continue
                 try:
-                    return self.canonize_type([nsa + scopz + tname] + targs, name, 
+                    return self.canonize_type([nsa + scopz + tname] + targs, name,
                                               statement=statement)
                 except TypeError:
                     pass  # This is the TypeError from below
             else:
                 msg = ("{i}The type of {c}::{n} ({t}) is not a recognized "
-                       "template type: {p}.").format(i=self.includeloc(statement=statement), 
+                       "template type: {p}.").format(i=self.includeloc(statement=statement),
                        t=t, n=name, c=self.classname(),
                        p=", ".join(sorted(self.known_templates)))
                 raise TypeError(msg)
@@ -1150,8 +1150,8 @@ class InfileToDbFilter(CodeGeneratorFilter):
         return '"{0}"' if t == 'std::string' else '{0}'
 
     def _val(self, t, val=None, name=None, uitype=None, ind=''):
-        """Returns a string that represents a Python value (val) of a given 
-        type (t) in C++. For types that do not have an expression 
+        """Returns a string that represents a Python value (val) of a given
+        type (t) in C++. For types that do not have an expression
         representation, the variable (name) may also be used. If a value
         is not provided, the default for the type will be provided.
         """
@@ -1255,7 +1255,7 @@ class InfileToDbFilter(CodeGeneratorFilter):
 
         return v
 
-    def _val_pair(self, t, val=(None, None), name=None, 
+    def _val_pair(self, t, val=(None, None), name=None,
                   uitype=(None, None, None), ind=''):
         ftype, stype = t[1], t[2]
         uitype = prepare_type(t, uitype)
@@ -1298,7 +1298,7 @@ class InfileToDbFilter(CodeGeneratorFilter):
         if tstr.endswith('>'):
             tstr += " "
         # Get keys
-        kw = {'cycns': CYCNS, 'type': tstr, 'alias': alias, 'tree': tree, 
+        kw = {'cycns': CYCNS, 'type': tstr, 'alias': alias, 'tree': tree,
               'path': path}
         kw['index'] = '' if idx is None else ', {0}'.format(idx)
         # get template
@@ -1307,10 +1307,10 @@ class InfileToDbFilter(CodeGeneratorFilter):
                         '"{path}{alias}"{index}))')
         else:
             template = '{cycns}::Query<{type}>({tree}, "{path}{alias}"{index})'
-        # fill in template and return 
+        # fill in template and return
         return template.format(**kw)
 
-    def read_member(self, member, alias, t, uitype=None, ind='  ', idx=None, 
+    def read_member(self, member, alias, t, uitype=None, ind='  ', idx=None,
                     path=''):
         uitype = prepare_type(t, uitype)
         alias = prepare_type(t, alias)
@@ -1361,7 +1361,7 @@ class InfileToDbFilter(CodeGeneratorFilter):
             s += ind + 'for (int i{lev} = 0; i{lev} < n{lev}; ++i{lev})'.format(
                 lev=lev) + ' {\n'
             s += self.read_member(
-                'elem', alias[1], t[1], uitype[1], 
+                'elem', alias[1], t[1], uitype[1],
                 ind+'  ', idx='i{lev}'.format(lev=lev))
             s += ind + '  {0}[{idx}] = elem;\n'.format(
                 member, idx='i{lev}'.format(lev=lev))
@@ -1394,7 +1394,7 @@ class InfileToDbFilter(CodeGeneratorFilter):
             s += ind + 'for (int i{lev} = 0; i{lev} < n{lev}; ++i{lev})'.format(
                 lev=self._idx_lev) + ' {\n'
             s += self.read_member(
-                'elem', alias[1], t[1], uitype[1], 
+                'elem', alias[1], t[1], uitype[1],
                 ind+'  ', idx='i{lev}'.format(lev=self._idx_lev))
             s += ind + '  {0}.insert(elem);\n'.format(member)
             s += ind + '}\n'
@@ -1426,7 +1426,7 @@ class InfileToDbFilter(CodeGeneratorFilter):
             s += ind + 'for (int i{lev} = 0; i{lev} < n{lev}; ++i{lev})'.format(
                 lev=lev) + ' {\n'
             s += self.read_member(
-                'elem', alias[1], t[1], uitype[1], 
+                'elem', alias[1], t[1], uitype[1],
                 ind+'  ', idx='i{lev}'.format(lev=lev))
             s += ind + '  {0}.push_back(elem);\n'.format(member)
             s += ind + '}\n'
@@ -1483,10 +1483,10 @@ class InfileToDbFilter(CodeGeneratorFilter):
             s += ind + '{0} {1};\n'.format(type_to_str(t), member)
             s += ind + 'for (int i{lev} = 0; i{lev} < n{lev}; ++i{lev})'.format(
                 lev=lev) + ' {\n'
-            s += self.read_member('key', alias[1], t[1], uitype[1], 
+            s += self.read_member('key', alias[1], t[1], uitype[1],
                                   ind+'  ', idx='i{lev}'.format(lev=lev),
                                   path=itempath)
-            s += self.read_member('val', alias[2], t[2], uitype[2], 
+            s += self.read_member('val', alias[2], t[2], uitype[2],
                                   ind+'  ', idx='i{lev}'.format(lev=lev),
                                   path=itempath)
             s += ind + '  {0}[key] = val;\n'.format(member)
@@ -1617,13 +1617,13 @@ class SchemaFilter(CodeGeneratorFilter):
         'boost::uuids::uuid': 'token',
         # UI types
         'nuclide': 'string',
-        'commodity': None, 
-        'incommodity': None, 
-        'outcommodity': None, 
-        'range': None, 
-        'combobox': None, 
-        'facility': None, 
-        'prototype': None, 
+        'commodity': None,
+        'incommodity': None,
+        'outcommodity': None,
+        'range': None,
+        'combobox': None,
+        'facility': None,
+        'prototype': None,
         'recipe': None,
         'none': None,
         None: None,
@@ -2165,7 +2165,7 @@ def outter_split(s, open_brace='(', close_brace=')', separator=','):
 def parse_template(s, open_brace='<', close_brace='>', separator=','):
     """Takes a string -- which may represent a template specialization -- and
     returns the corresponding type.
-    
+
     It calls parse_arg to return the type(s) for any template arguments the
     type may have. For example:
 
@@ -2189,7 +2189,7 @@ def parse_template(s, open_brace='<', close_brace='>', separator=','):
 def parse_arg(s, open_brace='<', close_brace='>', separator=','):
     """Takes a string containing one or more c++ template args and returns a
     list of the argument types as strings.
-    
+
     This is called by parse_template to handle the inner portion of the
     template braces.  For example:
 
@@ -2210,7 +2210,7 @@ def parse_arg(s, open_brace='<', close_brace='>', separator=','):
             nest += 1
         elif ch == close_brace:
             nest -= 1
-        
+
         if ch == separator and nest == 0:
             t = parse_template(s[start:i], open_brace, close_brace, separator)
             ts.append(t)

--- a/cmake/UseCyclus.cmake
+++ b/cmake/UseCyclus.cmake
@@ -122,7 +122,11 @@ MACRO(USE_CYCLUS lib_root src_root)
     # not sure if needed..
     IF(NOT EXISTS ${CCOUT})
         MESSAGE(STATUS "Executing ${CYCPP} ${CCIN} ${PREPROCESSOR} ${CCFLAG} ${ORIG} ${INCL_ARGS}")
-        EXECUTE_PROCESS(COMMAND ${CYCPP} ${CCIN} ${PREPROCESSOR} ${CCFLAG} ${ORIG} ${INCL_ARGS})
+        EXECUTE_PROCESS(COMMAND ${CYCPP} ${CCIN} ${PREPROCESSOR} ${CCFLAG}
+                        ${ORIG} ${INCL_ARGS} RESULT_VARIABLE res_var)
+        IF(NOT "${res_var}" STREQUAL "0")
+            message(FATAL_ERROR "cycpp failed with exit code '${res_var}'")
+        ENDIF()
     ENDIF(NOT EXISTS ${CCOUT})
     SET(
         "${lib_root}_CC"

--- a/tests/cycpp_tests.py
+++ b/tests/cycpp_tests.py
@@ -100,7 +100,7 @@ def test_nsfilt():
     yield assert_true, f.isvalid(statement)
     f.transform(statement, sep)
     yield assert_equal, len(m.namespaces), 1
-    yield assert_equal, m.namespaces[0], (0, None)
+    yield assert_equal, m.namespaces[0], (0, '<anonymous>')
     f.revert(statement, sep)
     yield assert_equal, len(m.namespaces), 0
 
@@ -214,19 +214,19 @@ def test_vdeclarfilter_canonize_alias():
         (['x', 'val'], ['std::set', 'float'], 'x', None),
         (['x', 'first', 'second'], ['std::pair', 'int', 'int'], 'x', None),
         ([['x', 'item'], 'key', 'val'], ['std::map', 'int', 'int'], 'x', None),
-        ([['x', 'item'], ['key', 'first', 'second'], ['val', 'val']], 
-            ['std::map', ['std::pair', 'int', 'int'], ['std::set', 'int']], 
+        ([['x', 'item'], ['key', 'first', 'second'], ['val', 'val']],
+            ['std::map', ['std::pair', 'int', 'int'], ['std::set', 'int']],
             'x', None),
         ('y', 'float', 'x', 'y'),
         (['x', 'y'], ['std::set', 'float'], 'x', [None, 'y']),
-        (['y', 'first', 'second'], ['std::pair', 'int', 'int'], 
+        (['y', 'first', 'second'], ['std::pair', 'int', 'int'],
             'x', ['y']),
-        ([['x', 'item'], 'y', 'val'], ['std::map', 'int', 'int'], 'x', 
+        ([['x', 'item'], 'y', 'val'], ['std::map', 'int', 'int'], 'x',
             [None, 'y']),
-        ([['x', 'ytem'], 'y', 'val'], ['std::map', 'int', 'int'], 'x', 
+        ([['x', 'ytem'], 'y', 'val'], ['std::map', 'int', 'int'], 'x',
             [['x', 'ytem'], 'y']),
-        ([['x', 'ytem'], ['key', 'f', 's'], ['data', 'val']], 
-            ['std::map', ['std::pair', 'int', 'int'], ['std::set', 'int']], 
+        ([['x', 'ytem'], ['key', 'f', 's'], ['data', 'val']],
+            ['std::map', ['std::pair', 'int', 'int'], ['std::set', 'int']],
             'x', [[None, 'ytem'], [None, 'f', 's'], 'data']),
         ]
     for exp, t, name, alias in cases:
@@ -241,17 +241,17 @@ def test_vdeclarfilter_canonize_ui():
         ('foo', 'float', 'x', 'foo'),
         (['foo', ''], ['std::set', 'float'], 'x', 'foo'),
         (['foo', 'bar'], ['std::set', 'float'], 'x', ['foo', 'bar']),
-        ([['foo', ''], ['', '', ''], ['', '']], 
-         ['std::map', ['std::pair', 'int', 'int'], ['std::set', 'int']], 
-         'x', 
+        ([['foo', ''], ['', '', ''], ['', '']],
+         ['std::map', ['std::pair', 'int', 'int'], ['std::set', 'int']],
+         'x',
          'foo'),
-        ([['foo', ''], ['bar', '', ''], ['', '']], 
-         ['std::map', ['std::pair', 'int', 'int'], ['std::set', 'int']], 
-         'x', 
+        ([['foo', ''], ['bar', '', ''], ['', '']],
+         ['std::map', ['std::pair', 'int', 'int'], ['std::set', 'int']],
+         'x',
          ['foo', 'bar']),
-        ([['foo', ''], ['bar', '', ''], ['baz', '']], 
-         ['std::map', ['std::pair', 'int', 'int'], ['std::set', 'int']], 
-         'x', 
+        ([['foo', ''], ['bar', '', ''], ['baz', '']],
+         ['std::map', ['std::pair', 'int', 'int'], ['std::set', 'int']],
+         'x',
          ['foo', 'bar', 'baz']),
     ]
     for exp, t, name, x in cases:
@@ -323,7 +323,7 @@ def test_canon_type():
         ('std::vector<int>', ('std::vector', 'int')),
         ('std::map<int, cyclus::Blob>', ('std::map', 'int', 'cyclus::Blob')),
         ('std::pair<int,std::string>', ('std::pair', 'int', 'std::string')),
-        ('std::map<std::pair<int, std::string>, double>', 
+        ('std::map<std::pair<int, std::string>, double>',
             ('std::map', ('std::pair', 'int', 'std::string'), 'double')),
         ]
     for t, exp in cases:
@@ -465,22 +465,22 @@ def test_itdbfilter_val():
     f = InfileToDbFilter(m)
 
     cases = [
-        ('bool', True, 'foo', None, 'bool foo = true;\n'), 
-        ('bool', False, 'foo', None, 'bool foo = false;\n'), 
-        ('int', 42, 'foo', None, 'int foo = 42;\n'), 
-        ('int', 92235, 'foo', 'nuclide', 'int foo = pyne::nucname::id(92235);\n'), 
-        ('int', 'U-235', 'foo', 'nuclide', 'int foo = pyne::nucname::id("U-235");\n'), 
-        ('float', 42.0, 'foo', None, 'double foo = 42.0;\n'), 
-        ('double', 42.0, 'foo', None, 'double foo = 42.0;\n'), 
+        ('bool', True, 'foo', None, 'bool foo = true;\n'),
+        ('bool', False, 'foo', None, 'bool foo = false;\n'),
+        ('int', 42, 'foo', None, 'int foo = 42;\n'),
+        ('int', 92235, 'foo', 'nuclide', 'int foo = pyne::nucname::id(92235);\n'),
+        ('int', 'U-235', 'foo', 'nuclide', 'int foo = pyne::nucname::id("U-235");\n'),
+        ('float', 42.0, 'foo', None, 'double foo = 42.0;\n'),
+        ('double', 42.0, 'foo', None, 'double foo = 42.0;\n'),
         ('std::string', 'wakka', 'foo', None, 'std::string foo("wakka");\n'),
         ('cyclus::Blob', 'wakka', 'foo', None, 'cyclus::Blob foo("wakka");\n'),
-        ('boost::uuids::uuid', 
-            '/#\xfb\xaf\x90\xc9N\xe9\x98:S\xea\xd6\xd6\x0fb', 'foo', None, 
+        ('boost::uuids::uuid',
+            '/#\xfb\xaf\x90\xc9N\xe9\x98:S\xea\xd6\xd6\x0fb', 'foo', None,
             'boost::uuids::uuid foo = "/#\xfb\xaf\x90\xc9N\xe9\x98:S\xea\xd6\xd6\x0fb";\n'),
-        ('boost::uuids::uuid', 
-            uuid.UUID('2f23fbaf-90c9-4ee9-983a-53ead6d60f62'), 'foo', None, 
+        ('boost::uuids::uuid',
+            uuid.UUID('2f23fbaf-90c9-4ee9-983a-53ead6d60f62'), 'foo', None,
             'boost::uuids::uuid foo = {0x2f, 0xf3, 0x2b, 0x3f, 0xf0, 0xb9, 0xae, 0xf9, 0x98, 0x0a, 0xc3, 0x9a, 0x46, 0xe6, 0xef, 0x92};\n'),
-        (('std::vector', 'int'), [42], 'foo', None, 
+        (('std::vector', 'int'), [42], 'foo', None,
             ('std::vector< int > foo;\n'
              'foo.resize(1);\n'
              '{\n'
@@ -490,7 +490,7 @@ def test_itdbfilter_val():
              '  }\n'
              '}\n'),
             ),
-        (('std::vector', 'int'), [92235], 'foo', [None, 'nuclide'], 
+        (('std::vector', 'int'), [92235], 'foo', [None, 'nuclide'],
             ('std::vector< int > foo;\n'
              'foo.resize(1);\n'
              '{\n'
@@ -500,7 +500,7 @@ def test_itdbfilter_val():
              '  }\n'
              '}\n'),
             ),
-        (('std::set', 'int'), [42, 65], 'foo', None, 
+        (('std::set', 'int'), [42, 65], 'foo', None,
             ('std::set< int > foo;\n'
              '{\n'
              '  {\n'
@@ -513,7 +513,7 @@ def test_itdbfilter_val():
              '  }\n'
              '}\n'),
             ),
-        (('std::list', 'int'), [42, 65], 'foo', None, 
+        (('std::list', 'int'), [42, 65], 'foo', None,
             ('std::list< int > foo;\n'
              '{\n'
              '  {\n'
@@ -526,7 +526,7 @@ def test_itdbfilter_val():
              '  }\n'
              '}\n'),
             ),
-        (('std::pair', 'int', 'double'), [42, 65.0], 'foo', None, 
+        (('std::pair', 'int', 'double'), [42, 65.0], 'foo', None,
             ('std::pair< int, double > foo;\n'
              '{\n'
              '  int first = 42;\n'
@@ -535,7 +535,7 @@ def test_itdbfilter_val():
              '  foo.second = second;\n'
              '}\n'),
             ),
-        (('std::map', 'int', 'double'), {42: 65.0}, 'foo', None, 
+        (('std::map', 'int', 'double'), {42: 65.0}, 'foo', None,
             ('std::map< int, double > foo;\n'
              '{\n'
              '  {\n'
@@ -799,9 +799,9 @@ def test_infiletodb_read_member1():
             ]))
             ])}
     f = InfileToDbFilter(m)
-    
-    cpptype = ('std::map', 'std::string', ('std::vector', 
-                ('std::vector', ('std::pair', 'double', 
+
+    cpptype = ('std::map', 'std::string', ('std::vector',
+                ('std::vector', ('std::pair', 'double',
                   ('std::pair', 'int', ('std::list', ('std::set', 'bool')))))))
     alias = ['streams', 'name', ['efficiencies', 'val']]
     gen = f.read_member('mymap', alias, cpptype, uitype=None)
@@ -897,7 +897,7 @@ def test_infiletodb_read_member1():
         '    }\n'
         '    mymap = mymap_in;\n'
         '  }\n')
-    
+
     ## useful for debugging test failures
     #print(gen)
     #print(exp_gen)
@@ -976,7 +976,7 @@ def test_infiletodb_read_map():
             ])}
     f = InfileToDbFilter(m)
 
-    cpptype = ('std::map', 'int', 'double') 
+    cpptype = ('std::map', 'int', 'double')
     alias = [['streams', 'entry'], 'id', 'mass']
     obs = f.read_member('mymap', alias, cpptype, uitype=None)
 
@@ -1184,6 +1184,6 @@ def test_integration():
     cmd = 'cycpp.py {} -o {} --cpp-path `which g++`'.format(inf, outf.name)
     p = Popen(cmd, shell=True, stdin=PIPE, stdout=PIPE, stderr=STDOUT, close_fds=True)
     assert_equal('', p.stdout.read().decode())
-    
+
 if __name__ == "__main__":
     nose.runmodule()


### PR DESCRIPTION
On boost v1.60.0, there are some terrible anonymous namespaces that are hidden by a macro call stack. In particular in `boost/type_traits/detail/has_postfix_operator.hpp`, we have effectively, 

```C++
namespace boost {
namespace detail {

// This namespace ensures that argument-dependent name lookup does not mess things up.
namespace BOOST_JOIN(BOOST_TT_TRAIT_NAME,_impl) {

struct no_operator { };
}
}
}
```

Where the `BOOST_JOIN()` macro is defined as, 

```C++
#define BOOST_JOIN( X, Y ) BOOST_DO_JOIN( X, Y )
#define BOOST_DO_JOIN( X, Y ) BOOST_DO_JOIN2(X,Y)
#define BOOST_DO_JOIN2( X, Y ) X##Y
```

This was causing cycpp to fail with the following error:

```console
Traceback (most recent call last):
  File "/home/scopatz/miniconda3/conda-bld/work/cyclus-cd572972b3dbf4b6d24a8e500ff270a42e8b2c7d/cli/cycpp.py", line 2317, in <module>
    main()
  File "/home/scopatz/miniconda3/conda-bld/work/cyclus-cd572972b3dbf4b6d24a8e500ff270a42e8b2c7d/cli/cycpp.py", line 2301, in main
    context, superclasses = accumulate_state(canon)   # pass 2
  File "/home/scopatz/miniconda3/conda-bld/work/cyclus-cd572972b3dbf4b6d24a8e500ff270a42e8b2c7d/cli/cycpp.py", line 861, in accumulate_state
    state.accumulate(statement, sep)
  File "/home/scopatz/miniconda3/conda-bld/work/cyclus-cd572972b3dbf4b6d24a8e500ff270a42e8b2c7d/cli/cycpp.py", line 713, in accumulate
    filter.transform(statement, sep)
  File "/home/scopatz/miniconda3/conda-bld/work/cyclus-cd572972b3dbf4b6d24a8e500ff270a42e8b2c7d/cli/cycpp.py", line 367, in transform
    classname = state.classname()
  File "/home/scopatz/miniconda3/conda-bld/work/cyclus-cd572972b3dbf4b6d24a8e500ff270a42e8b2c7d/cli/cycpp.py", line 685, in classname
    return "::".join(names)
TypeError: sequence item 2: expected str instance, NoneType found
```

because the particular `BOOST_JOIN` happened to evaluate to an empty string, creating an anonymous namespace, and thus the cycpp `self.namespaces == ['boost', 'detail', None, 'no_operator']`.

This PR replaces the None with `'<anonymous>'`. This will allow cycpp to skip such crazy cases, while also allowing it to fail at compile time if anyone tries to code generate to a class in an anonymous namespace (which is not allowed).

@hodger or @FlanFlanagan, would you mind taking a look at this and merging it.  I need this to proceed with conda-forge packages.