### PR TITLE
Installation Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,4 @@ src/pyne_decay.h
 src/pyne_decay.cc
 src/hdf5_back.cc
 share/dbtypes.json
-
+tests/db.h5

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,7 @@ IF(NOT CYCLUS_DOC_ONLY)
     MESSAGE("--    HDF5 Include directory: ${HDF5_INCLUDE_DIR}")
     MESSAGE("--    HDF5 Library directories: ${HDF5_LIBRARY_DIRS}")
     MESSAGE("--    HDF5 Libraries: ${HDF5_LIBRARIES}")
-    
+
     # Include the boost header files and the program_options library
     # Please be sure to use Boost rather than BOOST.
     # Capitalization matters on some platforms
@@ -181,6 +181,58 @@ IF(NOT CYCLUS_DOC_ONLY)
     FIND_PACKAGE( COIN REQUIRED )
     set(LIBS ${LIBS} ${COIN_LIBRARIES})
 
+    #
+    # Some optional libraries to link in, as availble. Required for conda.
+    #
+    # pcre
+    FIND_LIBRARY(PRCE_LIBRARIES pcre)
+    MESSAGE("-- Found PRCE Libraries (optional): ${PRCE_LIBRARIES}")
+    IF("$PRCE_LIBRARIES")
+        set(LIBS ${LIBS} ${PCRE_LIBRARIES})
+    ENDIF("$PRCE_LIBRARIES")
+
+    # openblas
+    FIND_LIBRARY(OPENBLAS_LIBRARIES openblas)
+    MESSAGE("-- Found OPENBLAS Libraries (optional): ${OPENBLAS_LIBRARIES}")
+    IF("$OPENBLAS_LIBRARIES")
+        set(LIBS ${LIBS} ${OPENBLAS_LIBRARIES})
+    ENDIF("$OPENBLAS_LIBRARIES")
+
+    # ClpSolver
+    FIND_LIBRARY(CLPSOLVER_LIBRARIES ClpSolver)
+    MESSAGE("-- Found CLPSOLVER Libraries (optional): ${CLPSOLVER_LIBRARIES}")
+    IF("$CLPSOLVER_LIBRARIES")
+        set(LIBS ${LIBS} ${CLPSOLVER_LIBRARIES})
+    ENDIF("$CLPSOLVER_LIBRARIES")
+
+    # iconv
+    FIND_LIBRARY(ICONV_LIBRARIES iconv)
+    MESSAGE("-- Found ICONV Libraries (optional): ${ICONV_LIBRARIES}")
+    IF("$ICONV_LIBRARIES")
+        set(LIBS ${LIBS} ${ICONV_LIBRARIES})
+    ENDIF("$ICONV_LIBRARIES")
+
+    # icudata
+    FIND_LIBRARY(ICUDATA_LIBRARIES icudata)
+    MESSAGE("-- Found ICUDATA Libraries (optional): ${ICUDATA_LIBRARIES}")
+    IF("$ICUDATA_LIBRARIES")
+        set(LIBS ${LIBS} ${ICUDATA_LIBRARIES})
+    ENDIF("$ICUDATA_LIBRARIES")
+
+    # icui18n
+    FIND_LIBRARY(ICUI18N_LIBRARIES icui18n)
+    MESSAGE("-- Found ICUI18N Libraries (optional): ${ICUI18N_LIBRARIES}")
+    IF("$ICUI18N_LIBRARIES")
+        set(LIBS ${LIBS} ${ICUI18N_LIBRARIES})
+    ENDIF("$ICUI18N_LIBRARIES")
+
+    # icuuc
+    FIND_LIBRARY(ICUUC_LIBRARIES icuuc)
+    MESSAGE("-- Found ICUUC Libraries (optional): ${ICUUC_LIBRARIES}")
+    IF("$ICUUC_LIBRARIES")
+        set(LIBS ${LIBS} ${ICUUC_LIBRARIES})
+    ENDIF("$ICUUC_LIBRARIES")
+
     ##############################################################################################
     #################################### end find libraries ######################################
     ##############################################################################################
@@ -194,15 +246,15 @@ IF(NOT CYCLUS_DOC_ONLY)
     # ${Glibmm_INCLUDE_DIRS} breaks Ubuntu 12.04
     INCLUDE_DIRECTORIES("${LIBXML2_INCLUDE_DIR}"
         "${LibXML++_INCLUDE_DIR}"
-        ${Glibmm_INCLUDE_DIRS}
+        "${Glibmm_INCLUDE_DIRS}"
         "${LibXML++Config_INCLUDE_DIR}"
         "${SQLITE3_INCLUDE_DIR}"
         "${HDF5_INCLUDE_DIRS}"
         "${Boost_INCLUDE_DIR}"
         "${COIN_INCLUDE_DIRS}")
-    
+
     EXECUTE_PROCESS(COMMAND git describe --tags OUTPUT_VARIABLE core_version OUTPUT_STRIP_TRAILING_WHITESPACE)
-    
+
     IF("${core_version}" STREQUAL "")
       MESSAGE(WARNING "Unable to read current core version, falling back to previous version. Core version will be set to -1")
       SET(core_version "-1")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,53 +185,53 @@ IF(NOT CYCLUS_DOC_ONLY)
     # Some optional libraries to link in, as availble. Required for conda.
     #
     # pcre
-    FIND_LIBRARY(PRCE_LIBRARIES pcre)
-    MESSAGE("-- Found PRCE Libraries (optional): ${PRCE_LIBRARIES}")
-    IF("$PRCE_LIBRARIES")
+    FIND_LIBRARY(PCRE_LIBRARIES pcre)
+    MESSAGE("-- Found PCRE Libraries (optional): ${PCRE_LIBRARIES}")
+    IF(PCRE_LIBRARIES)
         set(LIBS ${LIBS} ${PCRE_LIBRARIES})
-    ENDIF("$PRCE_LIBRARIES")
+    ENDIF(PCRE_LIBRARIES)
 
     # openblas
     FIND_LIBRARY(OPENBLAS_LIBRARIES openblas)
     MESSAGE("-- Found OPENBLAS Libraries (optional): ${OPENBLAS_LIBRARIES}")
-    IF("$OPENBLAS_LIBRARIES")
+    IF(OPENBLAS_LIBRARIES)
         set(LIBS ${LIBS} ${OPENBLAS_LIBRARIES})
-    ENDIF("$OPENBLAS_LIBRARIES")
+    ENDIF(OPENBLAS_LIBRARIES)
 
     # ClpSolver
     FIND_LIBRARY(CLPSOLVER_LIBRARIES ClpSolver)
     MESSAGE("-- Found CLPSOLVER Libraries (optional): ${CLPSOLVER_LIBRARIES}")
-    IF("$CLPSOLVER_LIBRARIES")
+    IF(CLPSOLVER_LIBRARIES)
         set(LIBS ${LIBS} ${CLPSOLVER_LIBRARIES})
-    ENDIF("$CLPSOLVER_LIBRARIES")
+    ENDIF(CLPSOLVER_LIBRARIES)
 
     # iconv
     FIND_LIBRARY(ICONV_LIBRARIES iconv)
     MESSAGE("-- Found ICONV Libraries (optional): ${ICONV_LIBRARIES}")
-    IF("$ICONV_LIBRARIES")
+    IF(ICONV_LIBRARIES)
         set(LIBS ${LIBS} ${ICONV_LIBRARIES})
-    ENDIF("$ICONV_LIBRARIES")
+    ENDIF(ICONV_LIBRARIES)
 
     # icudata
     FIND_LIBRARY(ICUDATA_LIBRARIES icudata)
     MESSAGE("-- Found ICUDATA Libraries (optional): ${ICUDATA_LIBRARIES}")
-    IF("$ICUDATA_LIBRARIES")
+    IF(ICUDATA_LIBRARIES)
         set(LIBS ${LIBS} ${ICUDATA_LIBRARIES})
-    ENDIF("$ICUDATA_LIBRARIES")
+    ENDIF(ICUDATA_LIBRARIES)
 
     # icui18n
     FIND_LIBRARY(ICUI18N_LIBRARIES icui18n)
     MESSAGE("-- Found ICUI18N Libraries (optional): ${ICUI18N_LIBRARIES}")
-    IF("$ICUI18N_LIBRARIES")
+    IF(ICUI18N_LIBRARIES)
         set(LIBS ${LIBS} ${ICUI18N_LIBRARIES})
-    ENDIF("$ICUI18N_LIBRARIES")
+    ENDIF(ICUI18N_LIBRARIES)
 
     # icuuc
     FIND_LIBRARY(ICUUC_LIBRARIES icuuc)
     MESSAGE("-- Found ICUUC Libraries (optional): ${ICUUC_LIBRARIES}")
-    IF("$ICUUC_LIBRARIES")
+    IF(ICUUC_LIBRARIES)
         set(LIBS ${LIBS} ${ICUUC_LIBRARIES})
-    ENDIF("$ICUUC_LIBRARIES")
+    ENDIF(ICUUC_LIBRARIES)
 
     ##############################################################################################
     #################################### end find libraries ######################################

--- a/install.py
+++ b/install.py
@@ -69,7 +69,7 @@ def install_cyclus(args):
         if args.boost_root:
             cmake_cmd += ['-DBOOST_ROOT=' + absexpanduser(args.boost_root)]
         if args.hdf5_root:
-            h5root = absexpanduser(args.boost_root)
+            h5root = absexpanduser(args.hdf5_root)
             cmake_cmd += ['-DHDF5_ROOT=' + h5root,
                           '-DHDF5_LIBRARIES={0}/lib/libhdf5{1};{0}/lib/libhdf5_hl{1}'.format(h5root, libext),
                           '-DHDF5_LIBRARY_DIRS=' + h5root + '/lib',


### PR DESCRIPTION
These are in support of building on a conda-forge based environment. Using `./install.py --hdf5_root=/path/to/conda` will build on this branch. Note that there are some coin-based segfaults in testing I am seeing locally, but I don't think that this is the fault of these changes.