### PR TITLE
Correct the way sell_mat_policy (SMP) was handling the Pop() on ResBuf

### DIFF
--- a/src/toolkit/matl_sell_policy.cc
+++ b/src/toolkit/matl_sell_policy.cc
@@ -176,7 +176,7 @@ void MatlSellPolicy::GetMatlTrades(
   for (it = trades.begin(); it != trades.end(); ++it) {
     double qty = it->amt;
     LGH(INFO3) << " sending " << qty << " kg of " << it->request->commodity();
-    Material::Ptr mat = buf_->Pop(qty, buf_->quantity() * 1e-12);
+    Material::Ptr mat = buf_->Pop(qty, cyclus::eps()*qty);
     if (ignore_comp_)
       mat->Transmute(it->request->target()->comp());
     responses.push_back(std::make_pair(*it, mat));

--- a/src/toolkit/matl_sell_policy.cc
+++ b/src/toolkit/matl_sell_policy.cc
@@ -176,7 +176,7 @@ void MatlSellPolicy::GetMatlTrades(
   for (it = trades.begin(); it != trades.end(); ++it) {
     double qty = it->amt;
     LGH(INFO3) << " sending " << qty << " kg of " << it->request->commodity();
-    Material::Ptr mat = buf_->Pop(qty, cyclus::eps()*qty);
+    Material::Ptr mat = buf_->Pop(qty, cyclus::eps_rsrc());
     if (ignore_comp_)
       mat->Transmute(it->request->target()->comp());
     responses.push_back(std::make_pair(*it, mat));


### PR DESCRIPTION
Before SMP was Poping mat from ResBuf using Pop(qty,eps) but using a relative eps of 1e-12.

As [discussed](https://groups.google.com/forum/#!topic/cyclus-dev/d25nGI9dYH0), I change it to absolute value for eps: `cyclus:eps_rsrc()`