### PR TITLE
clang-format config file: Small tweaks from Google Style Guide in mostly optional parts.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,13 @@
+---
+Language:        Cpp
+BasedOnStyle:  Google
+# only allow single line functions if they are inlined in class def'n
+AllowShortFunctionsOnASingleLine: Inline
+# do not force new line after template declarations
+AlwaysBreakTemplateDeclarations: false
+# Automatically detect whether a given fuction's arguments are one-per-line
+ExperimentalAutoDetectBinPacking: true
+# Use C++11 standard
+Standard:        Cpp11
+...
+


### PR DESCRIPTION
Offering a clang-format file that has a couple of tweaks on topics that are considered optional in GSG.

Still no remedy to avoid reformatting std::operator<< calls.