### PR TITLE
[Fix proposition 1/2] fix proposition cycamore issue #419

### DIFF
--- a/cmake/UseCyclus.cmake
+++ b/cmake/UseCyclus.cmake
@@ -274,7 +274,7 @@ MACRO(INSTALL_AGENT_LIB_ lib_name lib_src lib_h inst_dir)
 
     # install headers
     IF(NOT "${lib_h}" STREQUAL "")
-        INSTALL(FILES ${lib_h} DESTINATION include/cyclus COMPONENT "${lib_name}")
+        INSTALL(FILES ${lib_h} DESTINATION include/${lib_name} COMPONENT "${lib_name}")
     ENDIF(NOT "${lib_h}" STREQUAL "")
 ENDMACRO()
 
@@ -283,7 +283,7 @@ MACRO(INSTALL_AGENT_TESTS_ lib_name test_src test_h driver inst_dir)
     IF(NOT "${test_h}" STREQUAL "")
         INSTALL(
             FILES ${test_h}
-            DESTINATION include/cyclus/${inst_dir}
+            DESTINATION include/${lib_name}/${inst_dir}
             COMPONENT ${lib_name}
             )
     ENDIF(NOT "${test_h}" STREQUAL "")


### PR DESCRIPTION
This is a soft proposition to solve `cycamore` issue [#419](https://github.com/cyclus/cycamore/issues/419#issuecomment-239237669).

This just change the `cyclus` in the INSTALL header path by `${lib_name}`, which is the name used actually to install other cyclus modules headers.

The other solution is simply a suppression of the HEADER installation instruction from the `UseCyclus.cmake` file, as it is also present in the src/CMakefile.txt of Cycamore or the other cystub-ed modules....
Please see for the PR #1269 for the second fixing proposition