### PR TITLE
[Fix proposition 2/2] fix proposition cycamore issue #419 

### DIFF
--- a/cmake/UseCyclus.cmake
+++ b/cmake/UseCyclus.cmake
@@ -272,21 +272,9 @@ MACRO(INSTALL_AGENT_LIB_ lib_name lib_src lib_h inst_dir)
         )
     SET(${lib_name}_LIB ${lib_name} CACHE INTERNAL "Agent library alias." FORCE)
 
-    # install headers
-    IF(NOT "${lib_h}" STREQUAL "")
-        INSTALL(FILES ${lib_h} DESTINATION include/cyclus COMPONENT "${lib_name}")
-    ENDIF(NOT "${lib_h}" STREQUAL "")
 ENDMACRO()
 
 MACRO(INSTALL_AGENT_TESTS_ lib_name test_src test_h driver inst_dir)
-    # install test header
-    IF(NOT "${test_h}" STREQUAL "")
-        INSTALL(
-            FILES ${test_h}
-            DESTINATION include/cyclus/${inst_dir}
-            COMPONENT ${lib_name}
-            )
-    ENDIF(NOT "${test_h}" STREQUAL "")
 
     # build & install test impl
     IF(NOT "${test_src}" STREQUAL "" AND NOT "${driver}" STREQUAL "NONE")


### PR DESCRIPTION
This is a "hard" proposition to solve cycamore issue [#419](https://github.com/cyclus/cycamore/issues/419#issuecomment-239237669).

This solution is simply a suppression of the HEADER installation instruction from the UseCyclus.cmake file, as it is also present in the src/CMakefile.txt of Cycamore or the other cystub-ed modules....

The other proposition change the cyclus in the INSTALL header path by ${lib_name}, which is the name used actually to install other cyclus modules headers.

Please see for the PR #1268 for the first fixing proposition