### PR TITLE
Fix header install path: addressing cycamore issue #419

### DIFF
--- a/cmake/UseCyclus.cmake
+++ b/cmake/UseCyclus.cmake
@@ -272,21 +272,9 @@ MACRO(INSTALL_AGENT_LIB_ lib_name lib_src lib_h inst_dir)
         )
     SET(${lib_name}_LIB ${lib_name} CACHE INTERNAL "Agent library alias." FORCE)
 
-    # install headers
-    IF(NOT "${lib_h}" STREQUAL "")
-        INSTALL(FILES ${lib_h} DESTINATION include/cyclus COMPONENT "${lib_name}")
-    ENDIF(NOT "${lib_h}" STREQUAL "")
 ENDMACRO()
 
 MACRO(INSTALL_AGENT_TESTS_ lib_name test_src test_h driver inst_dir)
-    # install test header
-    IF(NOT "${test_h}" STREQUAL "")
-        INSTALL(
-            FILES ${test_h}
-            DESTINATION include/cyclus/${inst_dir}
-            COMPONENT ${lib_name}
-            )
-    ENDIF(NOT "${test_h}" STREQUAL "")
 
     # build & install test impl
     IF(NOT "${test_src}" STREQUAL "" AND NOT "${driver}" STREQUAL "NONE")

--- a/stubs/src/CMakeLists.txt
+++ b/stubs/src/CMakeLists.txt
@@ -5,4 +5,3 @@ INSTALL_CYCLUS_MODULE("@lib_name@" "@lib_path@")
 
 # install header files
 FILE(GLOB h_files "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
-INSTALL(FILES ${h_files} DESTINATION include/@lib_name@ COMPONENT @lib_name@)


### PR DESCRIPTION
This is an alternative solution to cycamore issue [#419](https://github.com/cyclus/cycamore/issues/419#issuecomment-239237669) from #1268 and #1269.

This solution is simply a suppression of the HEADER installation instruction from the UseCyclus.cmake file, as well as the src/CMakefile.txt of the cystub....

Please see for the PR #1268 and #1269 for the other fixing proposition