### PR TITLE
Deprecate `ProgTranslator::Context` without changing API/ABI.

### DIFF
--- a/src/error.h
+++ b/src/error.h
@@ -73,6 +73,13 @@ class ValidationError : public Error {
   ValidationError(std::string msg) : Error(msg) {}
 };
 
+/// For depricating API until a next major release
+class DepricatedApiError : public Error {
+ public:
+  DepricatedApiError(std::string msg) : Error(msg) {}
+};
+
+
 enum Warnings {
   WARNING = 0,
   VALUE_WARNING,

--- a/src/error.h
+++ b/src/error.h
@@ -74,9 +74,9 @@ class ValidationError : public Error {
 };
 
 /// For depricating API until a next major release
-class DepricatedApiError : public Error {
+class DepricationError : public Error {
  public:
-  DepricatedApiError(std::string msg) : Error(msg) {}
+  DepricationError(std::string msg) : Error(msg) {}
 };
 
 

--- a/src/prog_translator.cc
+++ b/src/prog_translator.cc
@@ -231,11 +231,13 @@ void ProgTranslator::FromProg() {
 }
 
 ProgTranslator::Context::Context() {
-  throw DepricatedApiError("Class ProgTranslator::Context is now deprecated in favor of ProgTranslatorContext.");
+  throw DepricationError("Class ProgTranslator::Context is now deprecated "
+                         "in favor of ProgTranslatorContext.");
 }
 
 ProgTranslator::Context::~Context() {
-  throw DepricatedApiError("Class ProgTranslator::Context is now deprecated in favor of ProgTranslatorContext.");
+  throw DepricationError("Class ProgTranslator::Context is now deprecated "
+                         "in favor of ProgTranslatorContext.");
 }
 
 

--- a/src/prog_translator.cc
+++ b/src/prog_translator.cc
@@ -230,4 +230,13 @@ void ProgTranslator::FromProg() {
   }
 }
 
+ProgTranslator::Context::Context() {
+  throw DepricatedApiError("Class ProgTranslator::Context is not deprecated in favor of ProgTranslatorContext.");
+}
+
+ProgTranslator::Context::~Context() {
+  throw DepricatedApiError("Class ProgTranslator::Context is not deprecated in favor of ProgTranslatorContext.");
+}
+
+
 }  // namespace cyclus

--- a/src/prog_translator.cc
+++ b/src/prog_translator.cc
@@ -231,11 +231,11 @@ void ProgTranslator::FromProg() {
 }
 
 ProgTranslator::Context::Context() {
-  throw DepricatedApiError("Class ProgTranslator::Context is not deprecated in favor of ProgTranslatorContext.");
+  throw DepricatedApiError("Class ProgTranslator::Context is now deprecated in favor of ProgTranslatorContext.");
 }
 
 ProgTranslator::Context::~Context() {
-  throw DepricatedApiError("Class ProgTranslator::Context is not deprecated in favor of ProgTranslatorContext.");
+  throw DepricatedApiError("Class ProgTranslator::Context is now deprecated in favor of ProgTranslatorContext.");
 }
 
 

--- a/src/prog_translator.h
+++ b/src/prog_translator.h
@@ -27,7 +27,10 @@ class ExchangeNodeGroup;
 class ProgTranslator {
  public:
   /// @brief This class is now deprecated.
-  struct Context { Context(); ~Context(); };
+  struct Context { 
+    Context(); 
+    ~Context(); 
+  };
 
   /// constructor
   ///

--- a/src/prog_translator.h
+++ b/src/prog_translator.h
@@ -12,6 +12,15 @@ namespace cyclus {
 class ExchangeGraph;
 class ExchangeNodeGroup;
 
+/// @brief struct to hold all problem instance state
+struct ProgTranslatorContext {
+  std::vector<double> obj_coeffs;
+  std::vector<double> row_ubs;
+  std::vector<double> row_lbs;
+  std::vector<double> col_ubs;
+  std::vector<double> col_lbs;
+  CoinPackedMatrix m;
+};
 
 /// a helper class to translate a product exchange into a mathematical
 /// program.

--- a/src/prog_translator.h
+++ b/src/prog_translator.h
@@ -26,15 +26,8 @@ class ExchangeNodeGroup;
 /// @endcode
 class ProgTranslator {
  public:
-  /// @brief struct to hold all problem instance state
-  struct Context {
-    std::vector<double> obj_coeffs;
-    std::vector<double> row_ubs;
-    std::vector<double> row_lbs;
-    std::vector<double> col_ubs;
-    std::vector<double> col_lbs;
-    CoinPackedMatrix m;
-  };
+  /// @brief This class is now deprecated.
+  struct Context { Context(); ~Context(); };
 
   /// constructor
   ///
@@ -63,7 +56,7 @@ class ProgTranslator {
   /// @brief translates solution from iface back into graph matches
   void FromProg();
 
-  const ProgTranslator::Context& ctx() const { return ctx_; }
+  const ProgTranslatorContext& ctx() const { return ctx_; }
 
  private:
   void Init();
@@ -80,7 +73,7 @@ class ProgTranslator {
   OsiSolverInterface* iface_;
   bool excl_;
   int arc_offset_;
-  ProgTranslator::Context ctx_;
+  ProgTranslatorContext ctx_;
   double pseudo_cost_;
 };
 

--- a/src/toolkit/building_manager.cc
+++ b/src/toolkit/building_manager.cc
@@ -20,7 +20,7 @@ std::vector<BuildOrder> BuildingManager::MakeBuildDecision(Commodity& commodity,
   std::vector<BuildOrder> orders;
   if (demand > 0) {
     OsiCbcSolverInterface iface;
-    ProgTranslator::Context ctx;
+    ProgTranslatorContext ctx;
     std::map<CommodityProducer*, Builder*> p_to_b;
     std::map<int, CommodityProducer*> idx_to_p;
     SetUp_(iface, ctx, p_to_b, idx_to_p, commodity, demand);
@@ -30,7 +30,7 @@ std::vector<BuildOrder> BuildingManager::MakeBuildDecision(Commodity& commodity,
 }
 
 void BuildingManager::SetUp_(OsiCbcSolverInterface& iface,
-                             ProgTranslator::Context& ctx,
+                             ProgTranslatorContext& ctx,
                              std::map<CommodityProducer*, Builder*>& p_to_b,
                              std::map<int, CommodityProducer*>& idx_to_p,
                              Commodity& commodity,
@@ -64,7 +64,7 @@ void BuildingManager::SetUp_(OsiCbcSolverInterface& iface,
 }
 
 void BuildingManager::Solve_(OsiCbcSolverInterface& iface,
-                             ProgTranslator::Context& ctx,
+                             ProgTranslatorContext& ctx,
                              std::map<CommodityProducer*, Builder*>& p_to_b,
                              std::map<int, CommodityProducer*>& idx_to_p,
                              std::vector<BuildOrder>& orders) {

--- a/src/toolkit/building_manager.h
+++ b/src/toolkit/building_manager.h
@@ -7,11 +7,12 @@
 #include "agent_managed.h"
 #include "builder.h"
 #include "commodity_producer.h"
-#include "prog_translator.h"
 
 class OsiCbcSolverInterface;
 
 namespace cyclus {
+
+class ProgTranslatorContext;
 
 namespace toolkit {
 
@@ -72,14 +73,14 @@ class BuildingManager : public AgentManaged {
   std::set<Builder*> builders_;
 
   void SetUp_(OsiCbcSolverInterface& iface,
-              ProgTranslator::Context& ctx,
+              ProgTranslatorContext& ctx,
               std::map<CommodityProducer*, Builder*>& p_to_b,
               std::map<int, CommodityProducer*>& idx_to_p,
               Commodity& commodity,
               double demand);
 
   void Solve_(OsiCbcSolverInterface& iface,
-              ProgTranslator::Context& ctx,
+              ProgTranslatorContext& ctx,
               std::map<CommodityProducer*, Builder*>& p_to_b,
               std::map<int, CommodityProducer*>& idx_to_p,
               std::vector<BuildOrder>& orders);

--- a/tests/prog_translator_tests.cc
+++ b/tests/prog_translator_tests.cc
@@ -8,6 +8,7 @@
 #include "OsiSolverInterface.hpp"
 
 #include "coin_helpers.h"
+#include "error.h"
 #include "equality_helpers.h"
 #include "exchange_graph.h"
 #include "logger.h"
@@ -277,5 +278,12 @@ TEST(ProgTranslatorTests, translation) {
 
   delete iface;
 }
+
+TEST(ProgTranslatorTests, depricated) {
+
+  // confirm depricated error is thrown
+  ASSERT_THROW(new ProgTranslator::Context(),DepricatedApiError);
+}
+
 
 }  // namespace cyclus

--- a/tests/prog_translator_tests.cc
+++ b/tests/prog_translator_tests.cc
@@ -282,7 +282,7 @@ TEST(ProgTranslatorTests, translation) {
 TEST(ProgTranslatorTests, depricated) {
 
   // confirm depricated error is thrown
-  ASSERT_THROW(new ProgTranslator::Context(),DepricatedApiError);
+  ASSERT_THROW(new ProgTranslator::Context(), DepricationError);
 }
 
 


### PR DESCRIPTION
This addresses #1279 by returning to the situation where there is no leakage of COIN headers and thus no need for any archetypes that use the `building_manager` to know about COIN headers.

The previous version of this caused an API/ABI change that, although unlikely to be a problem for anyone, is contrary to our stability philosophy.  This version maintains the API/ABI stability by

* changing all references (2 in `prog_translator.h` & 3 in `building_manager.cc`) of `ProgTranslator::Context` to refer to `ProgTranslatorContext`
* reintroducing the `ProgTranslator::Context` class
* explicitly defining its constructor and destructor
* implementing said con/destructors to throw a DepricatedApiError
* adding the DepricatedApiError
* adding a test to demonstrate that this error is thrown