### PR TITLE
more robust core version handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,12 +271,19 @@ IF(NOT CYCLUS_DOC_ONLY)
         "${Boost_INCLUDE_DIR}"
         "${COIN_INCLUDE_DIRS}")
 
-    EXECUTE_PROCESS(COMMAND git describe --tags OUTPUT_VARIABLE core_version OUTPUT_STRIP_TRAILING_WHITESPACE)
-
+    # set core version, one way or the other
+    IF(NOT "${CORE_VERSION}" STREQUAL "")
+        SET(core_version "${CORE_VERSION}")
+    ELSE(NOT "${CORE_VERSION}" STREQUAL "")
+        EXECUTE_PROCESS(COMMAND git describe --tags
+                        OUTPUT_VARIABLE core_version
+                        OUTPUT_STRIP_TRAILING_WHITESPACE)
+    ENDIF(NOT "${CORE_VERSION}" STREQUAL "")
     IF("${core_version}" STREQUAL "")
       MESSAGE(WARNING "Unable to read current core version, falling back to previous version. Core version will be set to -1")
       SET(core_version "-1")
     ENDIF()
+    MESSAGE("-- core version set to: ${core_version}")
 
     ADD_SUBDIRECTORY("${CYCLUS_SHARE_DIR}")
     ADD_SUBDIRECTORY("${CYCLUS_SOURCE_DIR}")
@@ -342,7 +349,7 @@ IF(NOT CYCLUS_DOC_ONLY)
 
     # Here's where we package it with CPack
     SET(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Cyclus : A nuclear fuel cycle simulator from UW-Madison.")
-    
+
     # Here we set some components for installation with cpack
     SET(CPACK_COMPONENTS_ALL cyclus testing libraries data core)
     SET(CPACK_GENERATOR "DEB")
@@ -356,7 +363,7 @@ IF(NOT CYCLUS_DOC_ONLY)
     # Version
     SET(CPACK_PACKAGE_VERSION_MAJOR "1")
     SET(CPACK_PACKAGE_VERSION_MINOR "4")
-    SET(CPACK_PACKAGE_VERSION_PATCH "0") 
+    SET(CPACK_PACKAGE_VERSION_PATCH "0")
 
     # Dependencies
     SET(CPACK_DEBIAN_PACKAGE_DEPENDS "libtcmalloc-minimal4 (>= 2.1)")
@@ -373,7 +380,7 @@ IF(NOT CYCLUS_DOC_ONLY)
     SET(CPACK_PACKAGE_INSTALL_DIRECTORY "cyclus_${CPACK_PACKAGE_VERSION_MAJOR}")
     SET(CPACK_PACKAGE_INSTALL_DIRECTORY "${CPACK_PACKAGE_INSTALL_DIRECTORY}.${CPACK_PACKAGE_VERSION_MINOR}")
     SET(CPACK_PACKAGE_INSTALL_DIRECTORY "${CPACK_PACKAGE_INSTALL_DIRECTORY}.${CPACK_PACKAGE_VERSION_PATCH}")
-    
+
     SET(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}")
     SET(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_FILE_NAME}_${CPACK_PACKAGE_VERSION_MAJOR}")
     SET(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_FILE_NAME}.${CPACK_PACKAGE_VERSION_MINOR}")
@@ -390,7 +397,7 @@ IF(NOT CYCLUS_DOC_ONLY)
       )
     SET(CPACK_PROJECT_CONFIG_FILE "${CYCLUS_BINARY_DIR}/cmake/CyclusCPackOptions.cmake")
     SET(CPACK_PACKAGE_EXECUTABLES "cyclus" "CyclusUnitTestDriver")
-    
+
     INCLUDE(CPack)
 
     ##############################################################################################

--- a/install.py
+++ b/install.py
@@ -83,6 +83,8 @@ def install_cyclus(args):
                           ]
         if args.build_type:
             cmake_cmd += ['-DCMAKE_BUILD_TYPE=' + args.build_type]
+        if args.core_version:
+            cmake_cmd += ['-DCORE_VERSION=' + args.core_version]
         if args.D is not None:
             cmake_cmd += ['-D' + x for x in args.D]
         check_windows_cmake(cmake_cmd)
@@ -182,6 +184,9 @@ def main():
 
     build_type = "the CMAKE_BUILD_TYPE"
     parser.add_argument('--build-type', '--build_type', help=build_type)
+
+    parser.add_argument('--core-version', dest='core_version', default=None,
+                        help='Sets the core version number.')
 
     parser.add_argument('-D', metavar='VAR', action='append',
                         help='Set enviornment variable(s).')


### PR DESCRIPTION
This extends the CMake version handling to extend beyond the case where the full git repo and git binary are available, such as in certain conda recipes or when building directly from a tarball.  This adds the `CORE_VERSION` variable to the build system and allows it to be set via `install.py --core-version=X.X.X`

Proof that this works is available in https://github.com/conda-forge/cyclus-feedstock/pull/3, which was failing on the 1.4.0-rc3 tag but works with my branch.