### PR TITLE
Fix for python2

### DIFF
--- a/src/hdf5_back_gen.py
+++ b/src/hdf5_back_gen.py
@@ -121,7 +121,7 @@ class PrettyFormatter(Visitor):
     """Formats a tree of nodes into a pretty string"""
 
     def __init__(self, tree=None, indent=' '):
-        super().__init__(tree=tree)
+        super(PrettyFormatter, self).__init__(tree=tree)
         self.level = 0
         self.indent = indent
 
@@ -143,7 +143,7 @@ class PrettyFormatter(Visitor):
 
 class CppGen(Visitor):
     def __init__(self, tree=None, indent='  '):
-        super().__init__(tree=tree)
+        super(CppGen, self).__init__(tree=tree)
         self.level = 0
         self.indent = indent
         


### PR DESCRIPTION
I encountered errors with incorrect syntax for python2 here.

```
Traceback (most recent call last):
  File "/home/wilsonp/UW/research/software/cyclus/cyclus/src/hdf5_back_gen.py", line 1093, in <module>
    main()
  File "/home/wilsonp/UW/research/software/cyclus/cyclus/src/hdf5_back_gen.py", line 1082, in main
    CPPGEN = CppGen()
  File "/home/wilsonp/UW/research/software/cyclus/cyclus/src/hdf5_back_gen.py", line 146, in __init__
    super().__init__(tree=tree)
TypeError: super() takes at least 1 argument (0 given)
```

I'm not sure why we haven't noticed before, but it scrolls past quickly and doesn't cause failure.  Perhaps our build process should fail when this step fails - I think errors at this step has been an issue before.

I need someone else to test on Python3 ( @hodger , @scopatz )