### PR TITLE
Add include flag

### DIFF
--- a/DEPENDENCIES.rst
+++ b/DEPENDENCIES.rst
@@ -16,6 +16,7 @@ the `Cyclus Homepage`_.
 Dependencies
 ************
 
+.. website_include_start
 In order to facilitate future compatibility with multiple platforms,
 Cyclus is built using CMake_. A full list of the Cyclus package
 dependencies is shown below:
@@ -32,6 +33,8 @@ Package                Minimum Version
 `HDF5`                 1.8.4
 `Coin-Cbc`             2.5
 ====================   ==================
+
+.. website_include_stop
 
 On some platforms, such as Ubuntu 14.04, the following are also necessary:
 

--- a/DEPENDENCIES.rst
+++ b/DEPENDENCIES.rst
@@ -34,7 +34,7 @@ Package                Minimum Version
 `Coin-Cbc`             2.5
 ====================   ==================
 
-.. website_include_stop
+.. website_include_end
 
 On some platforms, such as Ubuntu 14.04, the following are also necessary:
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -33,6 +33,7 @@ the major supported system.
 ************
 Installation
 ************
+.. website_include_start
 
 Before going further on the installation procedure be sure you have installed
 all the required dependencies listed above. You can also find `here <DEPENDENCIES.rst>`_ 
@@ -165,6 +166,7 @@ The main variable used are:
 
 All variable can be set using ``-DMY_VARIABLE=MY_VARIABLES_VALUE``.
 
+.. website_include_stop
 
 *************
 Running Tests

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -166,7 +166,7 @@ The main variable used are:
 
 All variable can be set using ``-DMY_VARIABLE=MY_VARIABLES_VALUE``.
 
-.. website_include_stop
+.. website_include_end
 
 *************
 Running Tests


### PR DESCRIPTION
Add include flag in `INSTALL.rst` and `DEPENDENCY.rst` to allow automatic hook in some page of the fuel cycle.org website.
@gonuke @mbmcgarry: could you review that quickly so I can try if everything is working as expected (already a part of it, just want to be sure it is fully working -- from the wget to the inclusion...)
thx