### PR TITLE
Pyth dep

### DIFF
--- a/DEPENDENCIES.rst
+++ b/DEPENDENCIES.rst
@@ -114,14 +114,13 @@ and (optionally):
 #. libblas-dev
 #. liblapack-dev
 #. libgoogle-perftools-dev
-#. python3
-#. python3-dev
-#. python3-tables
-#. python3-pandas
-#. python3-numpy
-#. python3-nose
-#. python3-jinja2
-#. cython3
+#. python-dev
+#. python-tables
+#. python-pandas
+#. python-numpy
+#. python-nose
+#. python-jinja2
+#. cython
 
 For example, in order to install libxml++ (and libxml2) on your system, type:
 
@@ -129,12 +128,21 @@ For example, in order to install libxml++ (and libxml2) on your system, type:
 
   sudo apt-get install libxml++2.6-dev
 
-If you'd prefer to copy/paste, the following line will install all *Cyclus*
-dependencies:
+If you'd prefer to copy/paste, the following line will install all require
+*Cyclus* dependencies:
 
 .. code-block:: bash
 
-   sudo apt-get install -y cmake make libboost-all-dev libxml2-dev libxml++2.6-dev libsqlite3-dev libhdf5-serial-dev libbz2-dev coinor-libcbc-dev coinor-libcoinutils-dev coinor-libosi-dev coinor-libclp-dev coinor-libcgl-dev libblas-dev liblapack-dev g++ libgoogle-perftools-dev
+   sudo apt-get install -y cmake make libboost-all-dev libxml2-dev libxml++2.6-dev libsqlite3-dev libhdf5-serial-dev libbz2-dev coinor-libcbc-dev coinor-libcoinutils-dev coinor-libosi-dev coinor-libclp-dev coinor-libcgl-dev
+
+And to install all *Cyclus* dependencies (required and optionnal):
+
+.. code-block:: bash
+
+   sudo apt-get install -y cmake make libboost-all-dev libxml2-dev libxml++2.6-dev libsqlite3-dev libhdf5-serial-dev libbz2-dev coinor-libcbc-dev coinor-libcoinutils-dev coinor-libosi-dev coinor-libclp-dev coinor-libcgl-dev libblas-dev liblapack-dev g++ libgoogle-perftools-dev python-dev python-tables python-pandas python-numpy python-nose python-jinja2 cython
+
+
+
 
 Boost Note
 ^^^^^^^^^^

--- a/DEPENDENCIES.rst
+++ b/DEPENDENCIES.rst
@@ -114,13 +114,13 @@ and (optionally):
 #. libblas-dev
 #. liblapack-dev
 #. libgoogle-perftools-dev
-#. python-dev
-#. python-tables
-#. python-pandas
-#. python-numpy
-#. python-nose
-#. python-jinja2
-#. cython
+#. python2-dev    or  python3-dev
+#. python2-tables or  python3-tables
+#. python2-pandas or  python3-pandas
+#. python2-numpy  or  python3-numpy
+#. python2-nose   or  python3-nose
+#. python2-jinja2 or  python3-jinja2
+#. cython2        or  cython3       
 
 For example, in order to install libxml++ (and libxml2) on your system, type:
 
@@ -128,21 +128,41 @@ For example, in order to install libxml++ (and libxml2) on your system, type:
 
   sudo apt-get install libxml++2.6-dev
 
-If you'd prefer to copy/paste, the following line will install all require
+If you'd prefer to copy/paste, the following line will install all required
 *Cyclus* dependencies:
 
 .. code-block:: bash
 
-   sudo apt-get install -y cmake make libboost-all-dev libxml2-dev libxml++2.6-dev libsqlite3-dev libhdf5-serial-dev libbz2-dev coinor-libcbc-dev coinor-libcoinutils-dev coinor-libosi-dev coinor-libclp-dev coinor-libcgl-dev
+   sudo apt-get install -y cmake make libboost-all-dev libxml2-dev libxml++2.6-dev \
+   libsqlite3-dev libhdf5-serial-dev libbz2-dev coinor-libcbc-dev coinor-libcoinutils-dev \
+   coinor-libosi-dev coinor-libclp-dev coinor-libcgl-dev
 
-And to install all *Cyclus* dependencies (required and optionnal):
+And to install all *Cyclus* dependencies (required and optional):
+- if using python 2.7:
 
 .. code-block:: bash
 
-   sudo apt-get install -y cmake make libboost-all-dev libxml2-dev libxml++2.6-dev libsqlite3-dev libhdf5-serial-dev libbz2-dev coinor-libcbc-dev coinor-libcoinutils-dev coinor-libosi-dev coinor-libclp-dev coinor-libcgl-dev libblas-dev liblapack-dev g++ libgoogle-perftools-dev python-dev python-tables python-pandas python-numpy python-nose python-jinja2 cython
+   sudo apt-get install -y cmake make libboost-all-dev libxml2-dev libxml++2.6-dev \
+   libsqlite3-dev libhdf5-serial-dev libbz2-dev coinor-libcbc-dev coinor-libcoinutils-dev \
+   coinor-libosi-dev coinor-libclp-dev coinor-libcgl-dev libblas-dev liblapack-dev g++ \
+   libgoogle-perftools-dev python-dev python-tables python-pandas python-numpy python-nose \
+   python-jinja2 cython
 
+- if using python 3.5:
 
+.. code-block:: bash
 
+   sudo apt-get install -y cmake make libboost-all-dev libxml2-dev libxml++2.6-dev \
+   libsqlite3-dev libhdf5-serial-dev libbz2-dev coinor-libcbc-dev coinor-libcoinutils-dev \
+   coinor-libosi-dev coinor-libclp-dev coinor-libcgl-dev libblas-dev liblapack-dev g++ \
+   libgoogle-perftools-dev python3-dev python3-tables python3-pandas python3-numpy python3-nose \
+   python3-jinja2 cython
+
+To determine which version of Python is already installed on your computer, run:
+
+.. code-block:: bash
+
+   python -V
 
 Boost Note
 ^^^^^^^^^^

--- a/DEPENDENCIES.rst
+++ b/DEPENDENCIES.rst
@@ -114,13 +114,13 @@ and (optionally):
 #. libblas-dev
 #. liblapack-dev
 #. libgoogle-perftools-dev
-#. python2-dev    or  python3-dev
-#. python2-tables or  python3-tables
-#. python2-pandas or  python3-pandas
-#. python2-numpy  or  python3-numpy
-#. python2-nose   or  python3-nose
-#. python2-jinja2 or  python3-jinja2
-#. cython2        or  cython3       
+#. python-dev    or  python3-dev
+#. python-tables or  python3-tables
+#. python-pandas or  python3-pandas
+#. python-numpy  or  python3-numpy
+#. python-nose   or  python3-nose
+#. python-jinja2 or  python3-jinja2
+#. cython        or  cython3       
 
 For example, in order to install libxml++ (and libxml2) on your system, type:
 

--- a/DEPENDENCIES.rst
+++ b/DEPENDENCIES.rst
@@ -138,6 +138,7 @@ If you'd prefer to copy/paste, the following line will install all required
    coinor-libosi-dev coinor-libclp-dev coinor-libcgl-dev
 
 And to install all *Cyclus* dependencies (required and optional):
+
 - if using python 2.7:
 
 .. code-block:: bash

--- a/DEPENDENCIES.rst
+++ b/DEPENDENCIES.rst
@@ -157,7 +157,7 @@ And to install all *Cyclus* dependencies (required and optional):
    libsqlite3-dev libhdf5-serial-dev libbz2-dev coinor-libcbc-dev coinor-libcoinutils-dev \
    coinor-libosi-dev coinor-libclp-dev coinor-libcgl-dev libblas-dev liblapack-dev g++ \
    libgoogle-perftools-dev python3-dev python3-tables python3-pandas python3-numpy python3-nose \
-   python3-jinja2 cython
+   python3-jinja2 cython3
 
 To determine which version of Python is already installed on your computer, run:
 

--- a/DEPENDENCIES.rst
+++ b/DEPENDENCIES.rst
@@ -139,7 +139,7 @@ If you'd prefer to copy/paste, the following line will install all required
 
 And to install all *Cyclus* dependencies (required and optional):
 
-- if using python 2.7:
+- if using python 2.x:
 
 .. code-block:: bash
 
@@ -149,7 +149,7 @@ And to install all *Cyclus* dependencies (required and optional):
    libgoogle-perftools-dev python-dev python-tables python-pandas python-numpy python-nose \
    python-jinja2 cython
 
-- if using python 3.5:
+- if using python 3.x:
 
 .. code-block:: bash
 

--- a/DEPENDENCIES.rst
+++ b/DEPENDENCIES.rst
@@ -128,7 +128,7 @@ For example, in order to install libxml++ (and libxml2) on your system, type:
 
   sudo apt-get install libxml++2.6-dev
 
-If you'd prefer to copy/paste, the following line will install all required
+If you'd prefer to copy/paste, the following line will install all **required**
 *Cyclus* dependencies:
 
 .. code-block:: bash
@@ -137,7 +137,7 @@ If you'd prefer to copy/paste, the following line will install all required
    libsqlite3-dev libhdf5-serial-dev libbz2-dev coinor-libcbc-dev coinor-libcoinutils-dev \
    coinor-libosi-dev coinor-libclp-dev coinor-libcgl-dev
 
-And to install all *Cyclus* dependencies (required and optional):
+And to install all *Cyclus* dependencies (**required and optional**):
 
 - if using python 2.x:
 


### PR DESCRIPTION
this change:
- the existing apt-get line to install only require package
- add a new apt-get line to install all Cyclus dependencies (require and optional)
- change de python dependencies to pyhon-xx only (I remove the python3 line in optional as python is the require dependencies)

**Question:** python is a require dependency by not in the apt-get **require** package ?! Shall I change that to ?