### PR TITLE
I don't understand why... Abi fix

### DIFF
--- a/src/bid.h
+++ b/src/bid.h
@@ -10,15 +10,14 @@
 namespace cyclus {
 
 class Trader;
-template<class T> class BidPortfolio;
+template <class T> class BidPortfolio;
 
 /// @class Bid
 ///
 /// @brief A Bid encapsulates all the information required to communicate a bid
 /// response to a request for a resource, including the resource bid and the
 /// bidder.
-template <class T>
-class Bid {
+template <class T> class Bid {
  public:
   /// @brief a factory method for a bid
   /// @param request the request being responded to by this bid
@@ -26,13 +25,14 @@ class Bid {
   /// @param bidder the bidder
   /// @param portfolio the porftolio of which this bid is a part
   /// @param exclusive flag for whether the bid is exclusive
-  /// @param preference specifies the preference of a bid in a request 
-  ///        to bid arc. If NaN the request preference is used. 
+  /// @param preference specifies the preference of a bid in a request
+  ///        to bid arc. If NaN the request preference is used.
   ///        WARNING: This should only be set by the bidder using the
-  ///        requests callback cost function. Bidders should not 
-  ///        arbitrarily set this preference. 
+  ///        requests callback cost function. Bidders should not
+  ///        arbitrarily set this preference.
   inline static Bid<T>* Create(Request<T>* request,
-                               boost::shared_ptr<T> offer,
+                               boost::shared_ptr<T>
+                                   offer,
                                Trader* bidder,
                                typename BidPortfolio<T>::Ptr portfolio,
                                bool exclusive,
@@ -47,11 +47,13 @@ class Bid {
   /// @param portfolio the porftolio of which this bid is a part
   /// @param exclusive flag for whether the bid is exclusive
   inline static Bid<T>* Create(Request<T>* request,
-                               boost::shared_ptr<T> offer,
+                               boost::shared_ptr<T>
+                                   offer,
                                Trader* bidder,
                                typename BidPortfolio<T>::Ptr portfolio,
                                bool exclusive = false) {
-    return Create(request, offer, bidder, portfolio, exclusive, std::numeric_limits<double>::quiet_NaN());
+    return Create(request, offer, bidder, portfolio, exclusive,
+                  std::numeric_limits<double>::quiet_NaN());
   }
   /// @brief a factory method for a bid for a bid without a portfolio
   /// @warning this factory should generally only be used for testing
@@ -64,53 +66,48 @@ class Bid {
   /// @warning this factory should generally only be used for testing
   inline static Bid<T>* Create(Request<T>* request, boost::shared_ptr<T> offer,
                                Trader* bidder, bool exclusive = false) {
-    return  Create(request, offer, bidder, exclusive, std::numeric_limits<double>::quiet_NaN());
+    return Create(request, offer, bidder, exclusive,
+                  std::numeric_limits<double>::quiet_NaN());
   }
 
   /// @return the request being responded to
-  inline Request<T>* request() const {
-    return request_;
-  }
+  inline Request<T>* request() const { return request_; }
 
   /// @return the bid object for the request
-  inline boost::shared_ptr<T> offer() const {
-    return offer_;
-  }
+  inline boost::shared_ptr<T> offer() const { return offer_; }
 
   /// @return the agent responding the request
-  inline Trader* bidder() const {
-    return bidder_;
-  }
+  inline Trader* bidder() const { return bidder_; }
 
   /// @return the portfolio of which this bid is a part
-  inline typename BidPortfolio<T>::Ptr portfolio() {
-    return portfolio_.lock();
-  }
+  inline typename BidPortfolio<T>::Ptr portfolio() { return portfolio_.lock(); }
 
   /// @return whether or not this an exclusive bid
-  inline bool exclusive() const {
-    return exclusive_;
-  }
+  inline bool exclusive() const { return exclusive_; }
 
   /// @return the preference of this bid
-  inline double preference() const {
-    return preference_;
-  }
+  inline double preference() const { return preference_; }
 
  private:
   /// @brief constructors are private to require use of factory methods
   Bid(Request<T>* request, boost::shared_ptr<T> offer, Trader* bidder,
-      bool exclusive = false, 
-      double preference = std::numeric_limits<double>::quiet_NaN())
+      bool exclusive, double preference)
       : request_(request),
         offer_(offer),
         bidder_(bidder),
         exclusive_(exclusive),
         preference_(preference) {}
+  /// @brief constructors are private to require use of factory methods
+  Bid(Request<T>* request, boost::shared_ptr<T> offer, Trader* bidder,
+      bool exclusive = false)
+      : request_(request),
+        offer_(offer),
+        bidder_(bidder),
+        exclusive_(exclusive),
+        preference_(std::numeric_limits<double>::quiet_NaN()) {}
 
   Bid(Request<T>* request, boost::shared_ptr<T> offer, Trader* bidder,
-      typename BidPortfolio<T>::Ptr portfolio, bool exclusive = false,
-      double preference = std::numeric_limits<double>::quiet_NaN())
+      typename BidPortfolio<T>::Ptr portfolio, bool exclusive, double preference)
       : request_(request),
         offer_(offer),
         bidder_(bidder),
@@ -118,14 +115,22 @@ class Bid {
         exclusive_(exclusive),
         preference_(preference) {}
 
+  Bid(Request<T>* request, boost::shared_ptr<T> offer, Trader* bidder,
+      typename BidPortfolio<T>::Ptr portfolio, bool exclusive = false)
+      : request_(request),
+        offer_(offer),
+        bidder_(bidder),
+        portfolio_(portfolio),
+        exclusive_(exclusive),
+        preference_(std::numeric_limits<double>::quiet_NaN()) {}
+
   Request<T>* request_;
   boost::shared_ptr<T> offer_;
   Trader* bidder_;
-  boost::weak_ptr<BidPortfolio<T> > portfolio_;
+  boost::weak_ptr<BidPortfolio<T>> portfolio_;
   bool exclusive_;
   double preference_;
 };
 
 }  // namespace cyclus
-
 #endif  // CYCLUS_SRC_BID_H_

--- a/src/bid.h
+++ b/src/bid.h
@@ -35,17 +35,36 @@ class Bid {
                                boost::shared_ptr<T> offer,
                                Trader* bidder,
                                typename BidPortfolio<T>::Ptr portfolio,
-                               bool exclusive = false,
-                               double preference = std::numeric_limits<double>::quiet_NaN()) {
+                               bool exclusive,
+                               double preference) {
     return new Bid<T>(request, offer, bidder, portfolio, exclusive, preference);
   }
 
+  /// @brief a factory method for a bid
+  /// @param request the request being responded to by this bid
+  /// @param offer the resource being offered in response to the request
+  /// @param bidder the bidder
+  /// @param portfolio the porftolio of which this bid is a part
+  /// @param exclusive flag for whether the bid is exclusive
+  inline static Bid<T>* Create(Request<T>* request,
+                               boost::shared_ptr<T> offer,
+                               Trader* bidder,
+                               typename BidPortfolio<T>::Ptr portfolio,
+                               bool exclusive = false) {
+    return Create(request, offer, bidder, portfolio, exclusive, std::numeric_limits<double>::quiet_NaN());
+  }
   /// @brief a factory method for a bid for a bid without a portfolio
   /// @warning this factory should generally only be used for testing
   inline static Bid<T>* Create(Request<T>* request, boost::shared_ptr<T> offer,
-                               Trader* bidder, bool exclusive = false,
-                               double preference = std::numeric_limits<double>::quiet_NaN()) {
+                               Trader* bidder, bool exclusive,
+                               double preference) {
     return new Bid<T>(request, offer, bidder, exclusive, preference);
+  }
+  /// @brief a factory method for a bid for a bid without a portfolio
+  /// @warning this factory should generally only be used for testing
+  inline static Bid<T>* Create(Request<T>* request, boost::shared_ptr<T> offer,
+                               Trader* bidder, bool exclusive = false) {
+    return  Create(request, offer, bidder, exclusive, std::numeric_limits<double>::quiet_NaN());
   }
 
   /// @return the request being responded to

--- a/src/bid_portfolio.h
+++ b/src/bid_portfolio.h
@@ -56,8 +56,7 @@ class BidPortfolio : public boost::enable_shared_from_this< BidPortfolio<T> > {
   /// @throws KeyError if a bid is added from a different bidder than the
   /// original
   Bid<T>* AddBid(Request<T>* request, boost::shared_ptr<T> offer,
-                 Trader* bidder, bool exclusive = false, 
-                 double preference = std::numeric_limits<double>::quiet_NaN()) {
+                 Trader* bidder, bool exclusive, double preference) {
     Bid<T>* b =
         Bid<T>::Create(request, offer, bidder, this->shared_from_this(),
                        exclusive, preference);
@@ -72,6 +71,19 @@ class BidPortfolio : public boost::enable_shared_from_this< BidPortfolio<T> > {
     return b;
   }
 
+  /// @brief add a bid to the portfolio
+  /// @param request the request being responded to by this bid
+  /// @param offer the resource being offered in response to the request
+  /// @param bidder the bidder
+  /// @param exclusive indicates whether the bid is exclusive
+  /// @throws KeyError if a bid is added from a different bidder than the
+  /// original
+  Bid<T>* AddBid(Request<T>* request, boost::shared_ptr<T> offer,
+                 Trader* bidder, bool exclusive = false) {
+    return AddBid(request, offer, bidder, exclusive, std::numeric_limits<double>::quiet_NaN());
+  }
+    
+    
   /// @brief add a capacity constraint associated with the portfolio
   /// @param c the constraint to add
   inline void AddConstraint(const CapacityConstraint<T>& c) {

--- a/src/bid_portfolio.h
+++ b/src/bid_portfolio.h
@@ -2,8 +2,8 @@
 #define CYCLUS_SRC_BID_PORTFOLIO_H_
 
 #include <set>
-#include <string>
 #include <sstream>
+#include <string>
 
 #include <boost/shared_ptr.hpp>
 
@@ -15,10 +15,8 @@ namespace cyclus {
 
 class Trader;
 
-
 std::string GetTraderPrototype(Trader* bidder);
 std::string GetTraderSpec(Trader* bidder);
-
 
 /// @class BidPortfolio
 ///
@@ -31,9 +29,9 @@ std::string GetTraderSpec(Trader* bidder);
 /// portfolio. Responses are grouped by the bidder. Constraints are assumed to
 /// act over the entire set of possible bids.
 template <class T>
-class BidPortfolio : public boost::enable_shared_from_this< BidPortfolio<T> > {
+class BidPortfolio : public boost::enable_shared_from_this<BidPortfolio<T>> {
  public:
-  typedef boost::shared_ptr< BidPortfolio<T> > Ptr;
+  typedef boost::shared_ptr<BidPortfolio<T>> Ptr;
 
   /// @brief default constructor
   BidPortfolio() : bidder_(NULL) {}
@@ -52,20 +50,20 @@ class BidPortfolio : public boost::enable_shared_from_this< BidPortfolio<T> > {
   /// @param bidder the bidder
   /// @param exclusive indicates whether the bid is exclusive
   /// @param preference sets the preference of the bid on a request
-  ///        bid arc. 
+  ///        bid arc.
   /// @throws KeyError if a bid is added from a different bidder than the
   /// original
   Bid<T>* AddBid(Request<T>* request, boost::shared_ptr<T> offer,
                  Trader* bidder, bool exclusive, double preference) {
-    Bid<T>* b =
-        Bid<T>::Create(request, offer, bidder, this->shared_from_this(),
-                       exclusive, preference);
+    Bid<T>* b = Bid<T>::Create(request, offer, bidder, this->shared_from_this(),
+                               exclusive, preference);
     VerifyResponder_(b);
-    if(offer->quantity() > 0 )
+    if (offer->quantity() > 0)
       bids_.insert(b);
-    else{
+    else {
       std::stringstream ss;
-      ss << GetTraderPrototype(bidder) << " from " << GetTraderSpec(bidder) << " is offering a bid quantity <= 0, Q = " << offer->quantity() ;
+      ss << GetTraderPrototype(bidder) << " from " << GetTraderSpec(bidder)
+         << " is offering a bid quantity <= 0, Q = " << offer->quantity();
       throw ValueError(ss.str());
     }
     return b;
@@ -80,10 +78,10 @@ class BidPortfolio : public boost::enable_shared_from_this< BidPortfolio<T> > {
   /// original
   Bid<T>* AddBid(Request<T>* request, boost::shared_ptr<T> offer,
                  Trader* bidder, bool exclusive = false) {
-    return AddBid(request, offer, bidder, exclusive, std::numeric_limits<double>::quiet_NaN());
+    return AddBid(request, offer, bidder, exclusive,
+                  std::numeric_limits<double>::quiet_NaN());
   }
-    
-    
+
   /// @brief add a capacity constraint associated with the portfolio
   /// @param c the constraint to add
   inline void AddConstraint(const CapacityConstraint<T>& c) {
@@ -92,22 +90,16 @@ class BidPortfolio : public boost::enable_shared_from_this< BidPortfolio<T> > {
 
   /// @return the agent associated with the portfolio. If no bids have
   /// been added, the bidder is NULL.
-  inline Trader* bidder() const {
-    return bidder_;
-  }
+  inline Trader* bidder() const { return bidder_; }
 
   /// @return *deprecated* the commodity associated with the portfolio.
-  inline std::string commodity() const { 
-    return "";
-  }
+  inline std::string commodity() const { return ""; }
 
   /// @return const access to the bids
-  inline const std::set<Bid<T>*>& bids() const {
-    return bids_;
-  }
+  inline const std::set<Bid<T>*>& bids() const { return bids_; }
 
   /// @return the set of constraints over the bids
-  inline const std::set< CapacityConstraint<T> >& constraints() const {
+  inline const std::set<CapacityConstraint<T>>& constraints() const {
     return constraints_;
   }
 
@@ -139,14 +131,14 @@ class BidPortfolio : public boost::enable_shared_from_this< BidPortfolio<T> > {
   }
 
   /// @brief *deprecated*
-  void VerifyCommodity_(const Bid<T>* r) { }
-  
+  void VerifyCommodity_(const Bid<T>* r) {}
+
   // bid_ is a set because there is a one-to-one correspondence between a
   // bid and a request, i.e., bids are unique
   std::set<Bid<T>*> bids_;
 
   // constraints_ is a set because constraints are assumed to be unique
-  std::set< CapacityConstraint<T> > constraints_;
+  std::set<CapacityConstraint<T>> constraints_;
 
   Trader* bidder_;
 };

--- a/src/request.h
+++ b/src/request.h
@@ -147,9 +147,9 @@ class Request {
 
   Request(boost::shared_ptr<T> target, Trader* requester,
           typename RequestPortfolio<T>::Ptr portfolio,
-          std::string commodity = "", double preference = kDefaultPref,
-          bool exclusive = false,
-          cost_function_t cost_function = NULL)
+          std::string commodity, double preference,
+          bool exclusive,
+          cost_function_t cost_function)
       : target_(target),
         requester_(requester),
         commodity_(commodity),
@@ -157,6 +157,18 @@ class Request {
         portfolio_(portfolio),
         exclusive_(exclusive),
         cost_function_(cost_function) {}
+  
+  Request(boost::shared_ptr<T> target, Trader* requester,
+          typename RequestPortfolio<T>::Ptr portfolio,
+          std::string commodity = "", double preference = kDefaultPref,
+          bool exclusive = false)
+      : target_(target),
+        requester_(requester),
+        commodity_(commodity),
+        preference_(preference),
+        portfolio_(portfolio),
+        exclusive_(exclusive),
+        cost_function_(NULL) {}
 
   boost::shared_ptr<T> target_;
   Trader* requester_;

--- a/src/request.h
+++ b/src/request.h
@@ -60,12 +60,22 @@ class Request {
   inline static Request<T>* Create(
       boost::shared_ptr<T> target,
       Trader* requester,
-      std::string commodity = "",
-      double preference = kDefaultPref,
-      bool exclusive = false,
-      cost_function_t cost_function = NULL) {
+      std::string commodity,
+      double preference,
+      bool exclusive,
+      cost_function_t cost_function) {
     return new Request<T>(target, requester, commodity, preference,
                           exclusive, cost_function);
+  }
+  /// @brief a factory method for a bid for a bid without a portfolio
+  /// @warning this factory should generally only be used for testing
+  inline static Request<T>* Create(
+      boost::shared_ptr<T> target,
+      Trader* requester,
+      std::string commodity = "",
+      double preference = kDefaultPref,
+      bool exclusive = false) {
+    return Create(target, requester, commodity, preference, exclusive, NULL);
   }
 
   /// @return this request's target
@@ -96,15 +106,26 @@ class Request {
  private:
   /// @brief constructors are private to require use of factory methods
   Request(boost::shared_ptr<T> target, Trader* requester,
-          std::string commodity = "", double preference = kDefaultPref,
-          bool exclusive = false,
-          cost_function_t cost_function = NULL)
+          std::string commodity, double preference,
+          bool exclusive,
+          cost_function_t cost_function)
       : target_(target),
         requester_(requester),
         commodity_(commodity),
         preference_(preference),
         exclusive_(exclusive),
         cost_function_(cost_function) {}
+
+  /// @brief constructors are private to require use of factory methods
+  Request(boost::shared_ptr<T> target, Trader* requester,
+          std::string commodity = "", double preference = kDefaultPref,
+          bool exclusive = false)
+      : target_(target),
+        requester_(requester),
+        commodity_(commodity),
+        preference_(preference),
+        exclusive_(exclusive),
+        cost_function_(NULL) {}
 
   Request(boost::shared_ptr<T> target, Trader* requester,
           typename RequestPortfolio<T>::Ptr portfolio,

--- a/src/request.h
+++ b/src/request.h
@@ -26,8 +26,7 @@ template <class T> class RequestPortfolio;
 /// the needs of an agent in the Dynamic Resource Exchange, including the
 /// commodity it needs as well as a resource specification for that commodity.
 /// A Request is templated its resource.
-template <class T>
-class Request {
+template <class T> class Request {
  public:
   typedef std::function<double(boost::shared_ptr<T>)> cost_function_t;
 
@@ -38,21 +37,20 @@ class Request {
   /// @param commodity the commodity associated with this request
   /// @param preference the preference associated with this request (relative to
   /// others in the portfolio)
-  /// @param exclusive a flag denoting that this request must be met exclusively,
+  /// @param exclusive a flag denoting that this request must be met
+  /// exclusively,
   /// i.e., in its entirety by a single offer
   /// @param cost_function a standard function object that returns the cost of a
-  /// potential resource when called. 
-  inline static Request<T>* Create(
-      boost::shared_ptr<T> target,
-      Trader* requester,
-      typename RequestPortfolio<T>::Ptr portfolio,
-      std::string commodity,
-      double preference,
-      bool exclusive,
-      cost_function_t cost_function) {
-    return new Request<T>(target, requester, portfolio,
-                          commodity, preference, exclusive,
-                          cost_function);
+  /// potential resource when called.
+  inline static Request<T>* Create(boost::shared_ptr<T> target,
+                                   Trader* requester,
+                                   typename RequestPortfolio<T>::Ptr portfolio,
+                                   std::string commodity,
+                                   double preference,
+                                   bool exclusive,
+                                   cost_function_t cost_function) {
+    return new Request<T>(target, requester, portfolio, commodity, preference,
+                          exclusive, cost_function);
   }
   /// @brief a factory method for a request
   /// @param target the target resource associated with this request
@@ -61,38 +59,37 @@ class Request {
   /// @param commodity the commodity associated with this request
   /// @param preference the preference associated with this request (relative to
   /// others in the portfolio)
-  /// @param exclusive a flag denoting that this request must be met exclusively,
+  /// @param exclusive a flag denoting that this request must be met
+  /// exclusively,
   /// i.e., in its entirety by a single offer
-  inline static Request<T>* Create(
-      boost::shared_ptr<T> target,
-      Trader* requester,
-      typename RequestPortfolio<T>::Ptr portfolio,
-      std::string commodity = "",
-      double preference = kDefaultPref,
-      bool exclusive = false) {
-    return Create(target, requester, portfolio, commodity, preference, exclusive, NULL);
+  inline static Request<T>* Create(boost::shared_ptr<T> target,
+                                   Trader* requester,
+                                   typename RequestPortfolio<T>::Ptr portfolio,
+                                   std::string commodity = "",
+                                   double preference = kDefaultPref,
+                                   bool exclusive = false) {
+    return Create(target, requester, portfolio, commodity, preference,
+                  exclusive, NULL);
   }
 
   /// @brief a factory method for a bid for a bid without a portfolio
   /// @warning this factory should generally only be used for testing
-  inline static Request<T>* Create(
-      boost::shared_ptr<T> target,
-      Trader* requester,
-      std::string commodity,
-      double preference,
-      bool exclusive,
-      cost_function_t cost_function) {
-    return new Request<T>(target, requester, commodity, preference,
-                          exclusive, cost_function);
+  inline static Request<T>* Create(boost::shared_ptr<T> target,
+                                   Trader* requester,
+                                   std::string commodity,
+                                   double preference,
+                                   bool exclusive,
+                                   cost_function_t cost_function) {
+    return new Request<T>(target, requester, commodity, preference, exclusive,
+                          cost_function);
   }
   /// @brief a factory method for a bid for a bid without a portfolio
   /// @warning this factory should generally only be used for testing
-  inline static Request<T>* Create(
-      boost::shared_ptr<T> target,
-      Trader* requester,
-      std::string commodity = "",
-      double preference = kDefaultPref,
-      bool exclusive = false) {
+  inline static Request<T>* Create(boost::shared_ptr<T> target,
+                                   Trader* requester,
+                                   std::string commodity = "",
+                                   double preference = kDefaultPref,
+                                   bool exclusive = false) {
     return Create(target, requester, commodity, preference, exclusive, NULL);
   }
 
@@ -117,16 +114,12 @@ class Request {
   inline bool exclusive() const { return exclusive_; }
 
   /// @return the cost function for the request
-  inline cost_function_t cost_function() const {
-    return cost_function_;
-  }
+  inline cost_function_t cost_function() const { return cost_function_; }
 
  private:
   /// @brief constructors are private to require use of factory methods
-  Request(boost::shared_ptr<T> target, Trader* requester,
-          std::string commodity, double preference,
-          bool exclusive,
-          cost_function_t cost_function)
+  Request(boost::shared_ptr<T> target, Trader* requester, std::string commodity,
+          double preference, bool exclusive, cost_function_t cost_function)
       : target_(target),
         requester_(requester),
         commodity_(commodity),
@@ -146,10 +139,8 @@ class Request {
         cost_function_(NULL) {}
 
   Request(boost::shared_ptr<T> target, Trader* requester,
-          typename RequestPortfolio<T>::Ptr portfolio,
-          std::string commodity, double preference,
-          bool exclusive,
-          cost_function_t cost_function)
+          typename RequestPortfolio<T>::Ptr portfolio, std::string commodity,
+          double preference, bool exclusive, cost_function_t cost_function)
       : target_(target),
         requester_(requester),
         commodity_(commodity),
@@ -157,7 +148,7 @@ class Request {
         portfolio_(portfolio),
         exclusive_(exclusive),
         cost_function_(cost_function) {}
-  
+
   Request(boost::shared_ptr<T> target, Trader* requester,
           typename RequestPortfolio<T>::Ptr portfolio,
           std::string commodity = "", double preference = kDefaultPref,
@@ -174,7 +165,7 @@ class Request {
   Trader* requester_;
   double preference_;
   std::string commodity_;
-  boost::weak_ptr<RequestPortfolio<T> > portfolio_;
+  boost::weak_ptr<RequestPortfolio<T>> portfolio_;
   bool exclusive_;
   cost_function_t cost_function_;
 };

--- a/src/request.h
+++ b/src/request.h
@@ -46,13 +46,31 @@ class Request {
       boost::shared_ptr<T> target,
       Trader* requester,
       typename RequestPortfolio<T>::Ptr portfolio,
-      std::string commodity = "",
-      double preference = kDefaultPref,
-      bool exclusive = false,
-      cost_function_t cost_function = NULL) {
+      std::string commodity,
+      double preference,
+      bool exclusive,
+      cost_function_t cost_function) {
     return new Request<T>(target, requester, portfolio,
                           commodity, preference, exclusive,
                           cost_function);
+  }
+  /// @brief a factory method for a request
+  /// @param target the target resource associated with this request
+  /// @param requester the requester
+  /// @param portfolio the porftolio of which this request is a part
+  /// @param commodity the commodity associated with this request
+  /// @param preference the preference associated with this request (relative to
+  /// others in the portfolio)
+  /// @param exclusive a flag denoting that this request must be met exclusively,
+  /// i.e., in its entirety by a single offer
+  inline static Request<T>* Create(
+      boost::shared_ptr<T> target,
+      Trader* requester,
+      typename RequestPortfolio<T>::Ptr portfolio,
+      std::string commodity = "",
+      double preference = kDefaultPref,
+      bool exclusive = false) {
+    return Create(target, requester, portfolio, commodity, preference, exclusive, NULL);
   }
 
   /// @brief a factory method for a bid for a bid without a portfolio

--- a/src/request_portfolio.h
+++ b/src/request_portfolio.h
@@ -113,10 +113,10 @@ public boost::enable_shared_from_this< RequestPortfolio<T> > {
   /// @throws KeyError if a request is added from a different requester than the
   /// original or if the request quantity is different than the original
   Request<T>* AddRequest(boost::shared_ptr<T> target, Trader* requester,
-                         std::string commodity = "",
-                         double preference = kDefaultPref,
-                         bool exclusive = false,
-                         cost_function_t cost_function = NULL) {
+                         std::string commodity,
+                         double preference,
+                         bool exclusive,
+                         cost_function_t cost_function) {
     Request<T>* r =
         Request<T>::Create(target, requester, this->shared_from_this(),
                            commodity, preference, exclusive, cost_function);
@@ -125,6 +125,22 @@ public boost::enable_shared_from_this< RequestPortfolio<T> > {
     mass_coeffs_[r] = 1;
     qty_ += target->quantity();
     return r;
+  }
+  /// @brief add a request to the portfolio
+  /// @param target the target resource associated with this request
+  /// @param requester the requester
+  /// @param commodity the commodity associated with this request
+  /// @param preference the preference associated with this request (relative to
+  /// others in the portfolio)
+  /// @param exclusive a flag denoting that this request must be met exclusively,
+  /// i.e., in its entirety by a single offer
+  /// @throws KeyError if a request is added from a different requester than the
+  /// original or if the request quantity is different than the original
+  Request<T>* AddRequest(boost::shared_ptr<T> target, Trader* requester,
+                         std::string commodity = "",
+                         double preference = kDefaultPref,
+                         bool exclusive = false) {
+    return AddRequest(target, requester, commodity, preference, exclusive, NULL);
   }
 
   /// @brief adds a collection of requests (already having been registered with

--- a/src/request_portfolio.h
+++ b/src/request_portfolio.h
@@ -20,8 +20,7 @@ namespace cyclus {
 class Trader;
 
 /// @brief accumulator sum for request quantities
-template<class T>
-inline double SumQty(double total, Request<T>* r) {
+template <class T> inline double SumQty(double total, Request<T>* r) {
   return total += r->target()->quantity();
 }
 
@@ -30,21 +29,19 @@ inline double SumQty(double total, Request<T>* r) {
 /// Coefficients are determiend by the request portfolio and are provided to the
 /// converter. The arc and exchange context are used in order to reference the
 /// original request so that the request's coefficient can be applied.
-template<class T>
-struct QtyCoeffConverter : public Converter<T> {
+template <class T> struct QtyCoeffConverter : public Converter<T> {
   QtyCoeffConverter(const std::map<Request<T>*, double>& coeffs)
       : coeffs(coeffs) {}
 
   inline virtual double convert(
       boost::shared_ptr<T> offer,
-      Arc const * a,
-      ExchangeTranslationContext<T> const * ctx) const {
+      Arc const* a,
+      ExchangeTranslationContext<T> const* ctx) const {
     return offer->quantity() * coeffs.at(ctx->node_to_request.at(a->unode()));
   }
 
   virtual bool operator==(Converter<T>& other) const {
-    QtyCoeffConverter<T>* cast =
-        dynamic_cast<QtyCoeffConverter<T>*>(&other);
+    QtyCoeffConverter<T>* cast = dynamic_cast<QtyCoeffConverter<T>*>(&other);
     return cast != NULL && coeffs == cast->coeffs;
   }
 
@@ -58,7 +55,8 @@ struct QtyCoeffConverter : public Converter<T> {
 ///
 /// The portfolio contains a grouping of resource requests that may be mutually
 /// met by suppliers. These requests may share a common set of
-/// constraints. Take, for instance, a facility that needs fuel, of which there are
+/// constraints. Take, for instance, a facility that needs fuel, of which there
+/// are
 /// two commodity types, fuelA and fuelB. If some combination of the two suffice
 /// the facility's needs, then requests for both would be added to the portfolio
 /// along with a capacity constraint.
@@ -67,7 +65,8 @@ struct QtyCoeffConverter : public Converter<T> {
 /// accounts for mutual requests, if the portfolio has them. , e.g.,
 /// @code
 ///
-/// RequestPortfolio<SomeResource>::Ptr rp(new RequestPortfolio<SomeResource>());
+/// RequestPortfolio<SomeResource>::Ptr rp(new
+/// RequestPortfolio<SomeResource>());
 /// // add some requests
 /// rp->AddRequest(/* args */);
 /// // declare some of them as multicommodity requsts (i.e., any one will
@@ -83,11 +82,11 @@ struct QtyCoeffConverter : public Converter<T> {
 /// determine the demand as "met". In this case, the total demand is 9.5, the
 /// MOX order is given a coefficient of 9.5 / 10, and the UOX order is given a
 /// coefficient of 9.5 / 9.
-template<class T>
-class RequestPortfolio :
-public boost::enable_shared_from_this< RequestPortfolio<T> > {
+template <class T>
+class RequestPortfolio
+    : public boost::enable_shared_from_this<RequestPortfolio<T>> {
  public:
-  typedef boost::shared_ptr< RequestPortfolio<T> > Ptr;
+  typedef boost::shared_ptr<RequestPortfolio<T>> Ptr;
   typedef std::function<double(boost::shared_ptr<T>)> cost_function_t;
 
   RequestPortfolio() : requester_(NULL), qty_(0) {}
@@ -106,17 +105,16 @@ public boost::enable_shared_from_this< RequestPortfolio<T> > {
   /// @param commodity the commodity associated with this request
   /// @param preference the preference associated with this request (relative to
   /// others in the portfolio)
-  /// @param exclusive a flag denoting that this request must be met exclusively,
+  /// @param exclusive a flag denoting that this request must be met
+  /// exclusively,
   /// i.e., in its entirety by a single offer
   /// @param cost_function The cost function that the requester sets so that the
   /// bidder may evaluate many potential resources.
   /// @throws KeyError if a request is added from a different requester than the
   /// original or if the request quantity is different than the original
   Request<T>* AddRequest(boost::shared_ptr<T> target, Trader* requester,
-                         std::string commodity,
-                         double preference,
-                         bool exclusive,
-                         cost_function_t cost_function) {
+                         std::string commodity, double preference,
+                         bool exclusive, cost_function_t cost_function) {
     Request<T>* r =
         Request<T>::Create(target, requester, this->shared_from_this(),
                            commodity, preference, exclusive, cost_function);
@@ -132,7 +130,8 @@ public boost::enable_shared_from_this< RequestPortfolio<T> > {
   /// @param commodity the commodity associated with this request
   /// @param preference the preference associated with this request (relative to
   /// others in the portfolio)
-  /// @param exclusive a flag denoting that this request must be met exclusively,
+  /// @param exclusive a flag denoting that this request must be met
+  /// exclusively,
   /// i.e., in its entirety by a single offer
   /// @throws KeyError if a request is added from a different requester than the
   /// original or if the request quantity is different than the original
@@ -140,7 +139,8 @@ public boost::enable_shared_from_this< RequestPortfolio<T> > {
                          std::string commodity = "",
                          double preference = kDefaultPref,
                          bool exclusive = false) {
-    return AddRequest(target, requester, commodity, preference, exclusive, NULL);
+    return AddRequest(target, requester, commodity, preference, exclusive,
+                      NULL);
   }
 
   /// @brief adds a collection of requests (already having been registered with
@@ -178,12 +178,10 @@ public boost::enable_shared_from_this< RequestPortfolio<T> > {
   inline double qty() const { return qty_; }
 
   /// @return const access to the unconstrained requests
-  inline const std::vector<Request<T>*>& requests() const {
-    return requests_;
-  }
+  inline const std::vector<Request<T>*>& requests() const { return requests_; }
 
   /// @return const access to the request constraints
-  inline const std::set< CapacityConstraint<T> >& constraints() const {
+  inline const std::set<CapacityConstraint<T>>& constraints() const {
     return constraints_;
   }
 
@@ -207,7 +205,8 @@ public boost::enable_shared_from_this< RequestPortfolio<T> > {
   }
 
   /// @brief if the requester has not been determined yet, it is set. otherwise
-  /// VerifyRequester() verifies the the request is associated with the portfolio's
+  /// VerifyRequester() verifies the the request is associated with the
+  /// portfolio's
   /// requester
   /// @throws KeyError if a request is added from a different requester than the
   /// original
@@ -228,7 +227,7 @@ public boost::enable_shared_from_this< RequestPortfolio<T> > {
   std::map<Request<T>*, double> mass_coeffs_;
 
   /// constraints_ is a set because constraints are assumed to be unique
-  std::set< CapacityConstraint<T> > constraints_;
+  std::set<CapacityConstraint<T>> constraints_;
 
   /// the total quantity of resources assocaited with the portfolio
   double qty_;


### PR DESCRIPTION
This supposedly fix the following ABI change:

> -cyclus::Bid<cyclus::Material>::Bid(cyclus::Request<cyclus::Material>*, boost::shared_ptr<cyclus::Material>, cyclus::Trader*, boost::shared_ptr<cyclus::              BidPortfolio<cyclus::Material> >, bool) +cyclus::Bid<cyclus::Material>::Bid(cyclus::Request<cyclus::Material>*, boost::shared_ptr<cyclus::Material>, cyclus::Trader*, boost::shared_ptr<cyclus::              BidPortfolio<cyclus::Material> >, bool, double)
> 
> -cyclus::Bid<cyclus::Material>::Bid(cyclus::Request<cyclus::Material>*, boost::shared_ptr<cyclus::Material>, cyclus::Trader*, boost::shared_ptr<cyclus::BidPortfolio<cyclus::Material> >, bool)
> +cyclus::Bid<cyclus::Material>::Bid(cyclus::Request<cyclus::Material>*, boost::shared_ptr<cyclus::Material>, cyclus::Trader*, boost::shared_ptr<cyclus::BidPortfolio<cyclus::Material> >, bool, double)
> 
> -cyclus::Bid<cyclus::Material>::Bid(cyclus::Request<cyclus::Material>*, boost::shared_ptr<cyclus::Material>, cyclus::Trader*, boost::shared_ptr<cyclus::BidPortfolio<cyclus::Material> >, bool)
> +cyclus::Bid<cyclus::Material>::Bid(cyclus::Request<cyclus::Material>*, boost::shared_ptr<cyclus::Material>, cyclus::Trader*, boost::shared_ptr<cyclus::BidPortfolio<cyclus::Material> >, bool, double)
> 

but it don't and I don't understand why...