### PR TITLE
install cyclus python lib in the default path if path is not specified

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,19 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
 #taken from http://geant4.cern.ch/support/source/geant4/CMakeLists.txt
 IF(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
-    message(STATUS "Cyclus requires an out-of-source build.")
-    message(STATUS "Please remove these files from ${CMAKE_BINARY_DIR} first:")
-    message(STATUS "CMakeCache.txt")
-    message(STATUS "CMakeFiles")
-    message(STATUS "Once these files are removed, create a separate directory")
-    message(STATUS "and run CMake from there")
-    message(FATAL_ERROR "in-source build detected")
+    MESSAGE(STATUS "Cyclus requires an out-of-source build.")
+    MESSAGE(STATUS "Please remove these files from ${CMAKE_BINARY_DIR} first:")
+    MESSAGE(STATUS "CMakeCache.txt")
+    MESSAGE(STATUS "CMakeFiles")
+    MESSAGE(STATUS "Once these files are removed, create a separate directory")
+    MESSAGE(STATUS "and run CMake from there")
+    MESSAGE(FATAL_ERROR "in-source build detected")
+ENDIF()
+
+MESSAGE(STATUS "USER_SET_PREFIX ${USER_SET_PREFIX}")
+IF(NOT ${USER_SET_PREFIX})
+  SET(CMAKE_PREFIX_PATH "~/.local")
+  MESSAGE(STATUS "CMAKE_USER_PREFIX set to ~/.local")
 ENDIF()
 
 # This project name is cyclus.

--- a/cmake/SetupPyInstall.cmake.in
+++ b/cmake/SetupPyInstall.cmake.in
@@ -10,9 +10,15 @@ message("  PYTHON_EXECUTABLE: ${PYTHON_EXECUTABLE}")
 message("  CYCLUS_CORE_VERSION: $ENV{CYCLUS_CORE_VERSION}")
 message("  CMAKE_INSTALL_PREFIX: ${CMAKE_INSTALL_PREFIX}")
 message("  CMAKE_CURRENT_BINARY_DIR: ${CMAKE_CURRENT_BINARY_DIR}")
-execute_process(COMMAND ${PYTHON_EXECUTABLE} setup.py install "--prefix=${CMAKE_INSTALL_PREFIX}"
-                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-                RESULT_VARIABLE res_var)
+if(${USER_SET_PREFIX})
+  execute_process(COMMAND ${PYTHON_EXECUTABLE} setup.py install "--prefix=${CMAKE_INSTALL_PREFIX}"
+                  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                  RESULT_VARIABLE res_var)
+else()
+  execute_process(COMMAND ${PYTHON_EXECUTABLE} setup.py install "--user"
+                  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                  RESULT_VARIABLE res_var)
+endif()
 if(NOT "${res_var}" STREQUAL "0")
   message(FATAL_ERROR "Process setup.py install failed, res_var = '${res_var}'")
 endif()

--- a/install.py
+++ b/install.py
@@ -61,9 +61,13 @@ def install_cyclus(args):
         if args.prefix:
             cmake_cmd += ['-DCMAKE_INSTALL_PREFIX=' +
                           absexpanduser(args.prefix)]
+            cmake_cmd += ['-DUSER_SET_PREFIX=' + 'TRUE']
         if args.cmake_prefix_path:
             cmake_cmd += ['-DCMAKE_PREFIX_PATH=' +
                           absexpanduser(args.cmake_prefix_path)]
+            cmake_cmd += ['-DUSER_SET_PREFIX=' + 'TRUE']
+        if not (args.prefix or args.prefix) :
+            cmake_cmd += ['-DUSER_SET_PREFIX=' + 'FALSE']
         cmake_cmd += ['-DDEFAULT_ALLOW_MILPS=' +
                       ('TRUE' if args.allow_milps else 'FALSE')]
         if args.deps_root:
@@ -120,7 +124,6 @@ def uninstall_cyclus(args):
 
 
 def main():
-    localdir = absexpanduser('~/.local')
 
     description = "A Cyclus installation helper script. " +\
         "For more information, please see cyclus.github.com."
@@ -142,8 +145,8 @@ def main():
     threads = "the number of threads to use in the make step"
     parser.add_argument('-j', '--threads', type=int, help=threads)
 
-    prefix = "the relative path to the installation directory"
-    parser.add_argument('--prefix', help=prefix, default=localdir)
+    prefix = "the relative path to the installation directory, default ~/.local/"
+    parser.add_argument('--prefix', help=prefix)
 
     config_only = 'only configure the package, do not build or install'
     parser.add_argument('--config-only', action='store_true', help=config_only)


### PR DESCRIPTION
this check if a `--prefix` or a `-DCMAKE_PREFIX_PATH`flag  are provided, and install the cyclus python lib:
 - with `--user` flag if no `--prefix`  or a `-DCMAKE_PREFIX_PATH` flag are given 
- with `--prefix=${CMAKE_PREFIX_PTH}` if one of them is given


this is the other solution to fix #1324 issue