### PR TITLE
Fixed numpy segfault

### DIFF
--- a/src/mock_sim.cc
+++ b/src/mock_sim.cc
@@ -200,19 +200,14 @@ void MockSim::AddRecipe(std::string name, Composition::Ptr c) {
 
 int MockSim::Run() {
   // Initialize Python functionality
-  #ifdef CYCLUS_WITH_PYTHON
-  Py_Initialize();
-  PyInitHooks();
-  #endif
+  PyStart();
 
   agent->Build(NULL);
   int id = agent->id();
   ti_.RunSim();
   rec_.Flush();
 
-  #ifdef CYCLUS_WITH_PYTHON
-  Py_Finalize();
-  #endif
+  PyStop();
   return id;
 }
 

--- a/src/pyhooks.cc
+++ b/src/pyhooks.cc
@@ -1,0 +1,58 @@
+#include "pyhooks.h"
+
+#ifdef CYCLUS_WITH_PYTHON
+#include <stdlib.h>
+
+#include "Python.h"
+
+extern "C" {
+#include "eventhooks.h"
+}
+
+namespace cyclus {
+int PY_INTERP_COUNT = 0;
+bool PY_INTERP_INIT = false;
+
+void PyInitHooks(void) {
+#if PY_MAJOR_VERSION < 3
+  initeventhooks();
+#else
+  PyInit_eventhooks();
+#endif
+};
+
+void PyStart(void) {
+  if (!PY_INTERP_INIT) {
+    Py_Initialize();
+    PyInitHooks();
+    atexit(PyStop);
+    PY_INTERP_INIT = true;
+  };
+  PY_INTERP_COUNT++;
+};
+
+void PyStop(void) {
+  PY_INTERP_COUNT--;
+
+  // PY_INTERP_COUNT should only be negative when called atexit()
+  if (PY_INTERP_INIT && PY_INTERP_COUNT < 0) {
+    Py_Finalize();
+  };
+};
+
+void EventLoop(void) { CyclusEventLoopHook(); };
+}  // namespace cyclus
+#else   // else CYCLUS_WITH_PYTHON
+namespace cyclus {
+int PY_INTERP_COUNT = 0;
+bool PY_INTERP_INIT = false;
+
+void PyInitHooks(void) {};
+
+void PyStart(void) {};
+
+void PyStop(void) {};
+
+void EventLoop(void) {};
+} // namespace cyclus
+#endif  // ends CYCLUS_WITH_PYTHON

--- a/src/pyhooks.h
+++ b/src/pyhooks.h
@@ -1,46 +1,28 @@
 #ifndef CYCLUS_SRC_PYHOOKS_H_
 #define CYCLUS_SRC_PYHOOKS_H_
 
-#ifdef CYCLUS_WITH_PYTHON
-#include "Python.h"
-
-extern "C" {
-#include "eventhooks.h"
-}
-
 namespace cyclus {
-  /// Convience function for initializing Python hooks
-  inline void PyInitHooks(void) {
-  #if PY_MAJOR_VERSION < 3
-    initeventhooks();
-  #else
-    PyInit_eventhooks();
-  #endif
-  };
+/// Because of NumPy #7595, we can only initialize & finalize the Python
+/// interpreter once. This variable keeps a count of how many times we have
+/// initialized so that we can know when to really stop the interpreter.
+/// When Python binding are not installed, this will always remain zero.
+extern int PY_INTERP_COUNT;
 
-  /// Initialize Python functionality, this is a no-op if Python was not
-  /// installed along with Cyclus.
-  inline void PyStart(void) {
-    Py_Initialize();
-    PyInitHooks();
-  };
+/// Whether or not the Python interpreter has been initilized.
+extern bool PY_INTERP_INIT;
 
-  /// Closes the current Python session. This is a no-op if Python was
-  /// not installed with Cyclus.
-  inline void PyStop(void) { Py_Finalize(); };
+/// Convience function for initializing Python hooks
+void PyInitHooks(void);
 
-  // Add some simple shims that attach C++ to Python C hooks
-  inline void EventLoop(void) { CyclusEventLoopHook(); };
+/// Initialize Python functionality, this is a no-op if Python was not
+/// installed along with Cyclus.
+void PyStart(void);
+
+/// Closes the current Python session. This is a no-op if Python was
+/// not installed with Cyclus.
+void PyStop(void);
+
+// Add some simple shims that attach C++ to Python C hooks
+void EventLoop(void);
 }
-#else   // else CYCLUS_WITH_PYTHON
-namespace cyclus {
-  /// Initialize Python functionality, this is a no-op if Python was not
-  /// installed along with Cyclus.
-  inline void PyStart(void) {};
-
-  /// Closes the current Python session. This is a no-op if Python was
-  /// not installed with Cyclus.
-  inline void PyStop(void) {};
-}
-#endif  // ends CYCLUS_WITH_PYTHON
 #endif  // ends CYCLUS_SRC_PYHOOKS_H_


### PR DESCRIPTION
This fixes the segfault that is in the test suite that was caused by numpy. It also cleans up the pyhooks header so downstream packages don't have to have the same compile-time value of `CYCLUS_WITH_PYTHON` that cyclus had. 