### PR TITLE
Python Simulation Input Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,6 @@ share/cyclus_nuc_data.h5
 src/pyne_decay.h
 src/pyne_decay.cc
 src/hdf5_back.cc
-src/eventhooks.cc
-src/eventhooks.h
 share/dbtypes.json
 tests/db.h5
 cyclus/cpp_typesystem.pxd
@@ -44,3 +42,7 @@ tests/libcyclus-test.sqlite
 # generated cython ignores
 *.cc.gen
 *.cc.h
+src/eventhooks.cc
+src/eventhooks.h
+src/pyinfile.cc
+src/pyinfile.h

--- a/cli/cyclus.cc
+++ b/cli/cyclus.cc
@@ -263,6 +263,10 @@ int ParseCliArgs(ArgInfo* ai, int argc, char* argv[]) {
       ("nuc-data", "print the path to cyclus_nuc_data.h5")
       ("json-to-xml", po::value<std::string>(), "*.json input file")
       ("xml-to-json", po::value<std::string>(), "*.xml input file")
+      ("json-to-py", po::value<std::string>(), "*.json input file")
+      ("py-to-json", po::value<std::string>(), "*.py input file")
+      ("py-to-xml", po::value<std::string>(), "*.py input file")
+      ("xml-to-py", po::value<std::string>(), "*.xml input file")
       ;
 
   po::variables_map vm;
@@ -415,6 +419,46 @@ int EarlyExitArgs(const ArgInfo& ai) {
       std::stringstream input;
       LoadRawStringstreamFromFile(input, infile);
       std::cout << cyclus::toolkit::XmlToJson(input.str());
+    } catch (cyclus::IOError err) {
+      std::cout << err.what() << "\n";
+    }
+    return 0;
+  } else if (ai.vm.count("json-to-py")) {
+    std::string infile(ai.vm["json-to-py"].as<std::string>());
+    try {
+      std::stringstream input;
+      LoadRawStringstreamFromFile(input, infile);
+      std::cout << cyclus::toolkit::JsonToPy(input.str());
+    } catch (cyclus::IOError err) {
+      std::cout << err.what() << "\n";
+    }
+    return 0;
+  } else if (ai.vm.count("py-to-json")) {
+    std::string infile(ai.vm["py-to-json"].as<std::string>());
+    try {
+      std::stringstream input;
+      LoadRawStringstreamFromFile(input, infile);
+      std::cout << cyclus::toolkit::PyToJson(input.str());
+    } catch (cyclus::IOError err) {
+      std::cout << err.what() << "\n";
+    }
+    return 0;
+  } else if (ai.vm.count("py-to-xml")) {
+    std::string infile(ai.vm["py-to-xml"].as<std::string>());
+    try {
+      std::stringstream input;
+      LoadRawStringstreamFromFile(input, infile);
+      std::cout << cyclus::toolkit::PyToXml(input.str());
+    } catch (cyclus::IOError err) {
+      std::cout << err.what() << "\n";
+    }
+    return 0;
+  } else if (ai.vm.count("xml-to-py")) {
+    std::string infile(ai.vm["xml-to-py"].as<std::string>());
+    try {
+      std::stringstream input;
+      LoadRawStringstreamFromFile(input, infile);
+      std::cout << cyclus::toolkit::XmlToPy(input.str());
     } catch (cyclus::IOError err) {
       std::cout << err.what() << "\n";
     }

--- a/cyclus/cpp_cyclus.pxd
+++ b/cyclus/cpp_cyclus.pxd
@@ -223,6 +223,12 @@ cdef extern from "pyhooks.h" namespace "cyclus":
     cdef void PyInitHooks() except +
 
 
+cdef extern from "pyhooks.h" namespace "cyclus::toolkit":
+
+    cdef std_string PyToJson(std_string) except +
+    cdef std_string JsonToPy(std_string) except +
+
+
 cdef extern from "xml_file_loader.h" namespace "cyclus":
 
     cdef void LoadStringstreamFromFile(stringstream&, std_string)
@@ -327,4 +333,6 @@ cdef extern from "toolkit/infile_converters.h" namespace "cyclus::toolkit":
 
     cdef std_string JsonToXml(std_string) except +
     cdef std_string XmlToJson(std_string) except +
+    cdef std_string PyToXml(std_string) except +
+    cdef std_string XmlToPy(std_string) except +
 

--- a/cyclus/lib.pyx
+++ b/cyclus/lib.pyx
@@ -1206,3 +1206,35 @@ def xml_to_json(s):
     cdef std_string cpp_rtn = cpp_cyclus.XmlToJson(cpp_s)
     rtn = std_string_to_py(cpp_rtn)
     return rtn
+
+
+def json_to_py(s):
+    """Converts a JSON string into an equivalent Python string"""
+    cdef std_string cpp_s = str_py_to_cpp(s)
+    cdef std_string cpp_rtn = cpp_cyclus.JsonToPy(cpp_s)
+    rtn = std_string_to_py(cpp_rtn)
+    return rtn
+
+
+def py_to_json(s):
+    """Converts a Python string into an equivalent JSON string"""
+    cdef std_string cpp_s = str_py_to_cpp(s)
+    cdef std_string cpp_rtn = cpp_cyclus.PyToJson(cpp_s)
+    rtn = std_string_to_py(cpp_rtn)
+    return rtn
+
+
+def py_to_xml(s):
+    """Converts a Python string into an equivalent XML string"""
+    cdef std_string cpp_s = str_py_to_cpp(s)
+    cdef std_string cpp_rtn = cpp_cyclus.PyToXml(cpp_s)
+    rtn = std_string_to_py(cpp_rtn)
+    return rtn
+
+
+def xml_to_py(s):
+    """Converts an XML string into an equivalent Python string"""
+    cdef std_string cpp_s = str_py_to_cpp(s)
+    cdef std_string cpp_rtn = cpp_cyclus.XmlToPy(cpp_s)
+    rtn = std_string_to_py(cpp_rtn)
+    return rtn

--- a/cyclus/main.py
+++ b/cyclus/main.py
@@ -8,8 +8,9 @@ from cyclus.jsoncpp import CustomWriter
 from cyclus.lib import (DynamicModule, Env, version, load_string_from_file,
     Recorder, Timer, Context, set_warn_limit, discover_specs, XMLParser,
     discover_specs_in_cyclus_path, discover_metadata_in_cyclus_path, Logger,
-    set_warn_limit, set_warn_as_error, xml_to_json, json_to_xml,
-    Hdf5Back, SqliteBack, InfileTree, SimInit, XMLFileLoader, XMLFlatLoader)
+    set_warn_limit, set_warn_as_error, xml_to_json, json_to_xml, py_to_json,
+    json_to_py, xml_to_py, py_to_xml, Hdf5Back, SqliteBack, InfileTree, SimInit,
+    XMLFileLoader, XMLFlatLoader)
 from cyclus.simstate import (get_schema_path, SimState,
     ensure_close_dynamic_modules)
 
@@ -251,26 +252,51 @@ class NucData(ZeroArgAction):
         print(s)
 
 
-class JsonToXml(Action):
+class InfileConverterAction(Action):
+
+    def __call__(self, parser, ns, values, option_string=None):
+        setattr(ns, self.name, values)
+        with open(values, 'r') as f:
+            s = f.read()
+        t = self.converter(s)
+        print(t.rstrip())
+
+
+class JsonToXml(InfileConverterAction):
     """converts JSON to XML"""
-
-    def __call__(self, parser, ns, values, option_string=None):
-        ns.json_to_xml = values
-        with open(ns.json_to_xml, 'r') as f:
-            s = f.read()
-        t = json_to_xml(s)
-        print(t.rstrip())
+    name = 'json_to_xml'
+    converter = json_to_xml
 
 
-class XmlToJson(Action):
+class XmlToJson(InfileConverterAction):
     """converts XML to JSON"""
+    name = 'xml_to_json'
+    converter = xml_to_json
 
-    def __call__(self, parser, ns, values, option_string=None):
-        ns.xml_to_json = values
-        with open(ns.xml_to_json, 'r') as f:
-            s = f.read()
-        t = xml_to_json(s)
-        print(t.rstrip())
+
+class JsonToPy(InfileConverterAction):
+    """converts JSON to Python"""
+    name = 'json_to_py'
+    converter = json_to_py
+
+
+class PyToJson(InfileConverterAction):
+    """converts Python to JSON"""
+    name = 'py_to_json'
+    converter = py_to_json
+
+
+class PyToXml(InfileConverterAction):
+    """converts Python to XML"""
+    name = 'py_to_xml'
+    converter = py_to_xml
+
+
+class XmlToPy(InfileConverterAction):
+    """converts XML to Python"""
+    name = 'xml_to_py'
+    converter = xml_to_py
+
 
 
 def make_parser():
@@ -339,6 +365,18 @@ def make_parser():
                    help='*.json input file')
     p.add_argument('--xml-to-json', action=XmlToJson,
                    dest='xml_to_json', default=None,
+                   help='*.xml input file')
+    p.add_argument('--json-to-py', action=JsonToPy,
+                   dest='json_to_py', default=None,
+                   help='*.json input file')
+    p.add_argument('--py-to-json', action=PyToJson,
+                   dest='py_to_json', default=None,
+                   help='*.py input file')
+    p.add_argument('--py-to-xml', action=PyToXml,
+                   dest='py_to_xml', default=None,
+                   help='*.py input file')
+    p.add_argument('--xml-to-py', action=XmlToPy,
+                   dest='xml_to_py', default=None,
                    help='*.xml input file')
     p.add_argument('input_file', nargs='?',
                    help='path to input file')

--- a/src/cyclus.h
+++ b/src/cyclus.h
@@ -24,6 +24,7 @@
 #include "material.h"
 #include "mock_sim.h"
 #include "agent.h"
+#include "pyhooks.h"
 #include "pyne.h"
 #include "pyne_decay.h"
 #include "query_backend.h"

--- a/src/pyhooks.cc
+++ b/src/pyhooks.cc
@@ -7,6 +7,7 @@
 
 extern "C" {
 #include "eventhooks.h"
+#include "pyinfile.h"
 }
 
 namespace cyclus {
@@ -16,8 +17,10 @@ bool PY_INTERP_INIT = false;
 void PyInitHooks(void) {
 #if PY_MAJOR_VERSION < 3
   initeventhooks();
+  initpyinfile();
 #else
   PyInit_eventhooks();
+  PyInit_pyinfile();
 #endif
 };
 
@@ -41,6 +44,12 @@ void PyStop(void) {
 };
 
 void EventLoop(void) { CyclusEventLoopHook(); };
+
+namespace toolkit {
+std::string PyToJson(std::string infile) { return CyclusPyToJson(infile); };
+
+std::string JsonToPy(std::string infile) { return CyclusJsonToPy(infile); };
+}  // namespace toolkit
 }  // namespace cyclus
 #else   // else CYCLUS_WITH_PYTHON
 namespace cyclus {
@@ -54,5 +63,19 @@ void PyStart(void) {};
 void PyStop(void) {};
 
 void EventLoop(void) {};
+
+namespace toolkit {
+std::string PyToJson(std::string infile) {
+  throw cyclus::ValidationError("Cannot convert from Python input files since "
+                                "Cyclus was not built with Python bindings.");
+  return "";
+};
+
+std::string JsonToPy(std::string infile) {
+  throw cyclus::ValidationError("Cannot convert to Python input files since "
+                                "Cyclus was not built with Python bindings.");
+  return "";
+};
+} // namespace toolkit
 } // namespace cyclus
 #endif  // ends CYCLUS_WITH_PYTHON

--- a/src/pyhooks.h
+++ b/src/pyhooks.h
@@ -17,11 +17,12 @@ extern bool PY_INTERP_INIT;
 void PyInitHooks(void);
 
 /// Initialize Python functionality, this is a no-op if Python was not
-/// installed along with Cyclus.
+/// installed along with Cyclus. This may be called many times and safely
+/// initializes the Python interpreter only once.
 void PyStart(void);
 
 /// Closes the current Python session. This is a no-op if Python was
-/// not installed with Cyclus.
+/// not installed with Cyclus. This may safely be called many times.
 void PyStop(void);
 
 // Add some simple shims that attach C++ to Python C hooks

--- a/src/pyhooks.h
+++ b/src/pyhooks.h
@@ -1,6 +1,8 @@
 #ifndef CYCLUS_SRC_PYHOOKS_H_
 #define CYCLUS_SRC_PYHOOKS_H_
 
+#include <string>
+
 namespace cyclus {
 /// Because of NumPy #7595, we can only initialize & finalize the Python
 /// interpreter once. This variable keeps a count of how many times we have
@@ -24,5 +26,13 @@ void PyStop(void);
 
 // Add some simple shims that attach C++ to Python C hooks
 void EventLoop(void);
-}
+
+namespace toolkit {
+/// Convert Python simulation string to JSON
+std::string PyToJson(std::string);
+
+/// Convert JSON string to Python simulation string
+std::string JsonToPy(std::string);
+}  // ends namespace toolkit
+}  // ends namespace cyclus
 #endif  // ends CYCLUS_SRC_PYHOOKS_H_

--- a/src/pyinfile.pxd
+++ b/src/pyinfile.pxd
@@ -1,0 +1,8 @@
+"""Header for Cyclus Python Input Files."""
+from libcpp.string cimport string as std_string
+
+cdef std_string str_py_to_cpp(object x)
+cdef object std_string_to_py(std_string x)
+
+cdef public std_string py_to_json "CyclusPyToJson" (std_string)
+cdef public std_string json_to_py "CyclusJsonToPy" (std_string)

--- a/src/pyinfile.pyx
+++ b/src/pyinfile.pyx
@@ -1,0 +1,57 @@
+"""Cyclus Python input file tools."""
+from __future__ import print_function, unicode_literals
+from libcpp.string cimport string as std_string
+
+
+cdef object std_string_to_py(std_string x):
+    pyx = x
+    pyx = pyx.decode()
+    return pyx
+
+
+cdef std_string str_py_to_cpp(object x):
+    cdef std_string s
+    x = x.encode()
+    s = std_string(<const char*> x)
+    return s
+
+
+cdef public std_string py_to_json "CyclusPyToJson" (std_string cpp_infile):
+    """Converts a Python file to JSON"""
+    infile = std_string_to_py(cpp_infile)
+    if not infile.endswith('\n'):
+        infile += '\n'
+    cpdef dict ctx = {}
+    exec(infile, ctx, ctx)
+    names = ('simulation', 'SIMULATION', 'Simulation')
+    for name in names:
+        if name in ctx:
+            sim = ctx[name]
+            break
+    else:
+        raise RuntimeError('simulation not found in python file.')
+    if callable(sim):
+        sim = sim()
+    from collections import Mapping
+    if isinstance(sim, str):
+        pass  # assume in JSON format
+    elif isinstance(sim, bytes):
+        sim = sim.decode()  # assume in JSON format, get into str
+    elif isinstance(sim, Mapping):
+        import json
+        sim = json.dumps(sim, sort_keys=True)
+    else:
+        raise RuntimeError('top-level simulation object does not have proper type.')
+    cdef std_string cpp_rtn = str_py_to_cpp(sim)
+    return cpp_rtn
+
+
+cdef public std_string json_to_py "CyclusJsonToPy" (std_string cpp_infile):
+    """Converts a JSON file to Python"""
+    infile = std_string_to_py(cpp_infile)
+    import json
+    sim = json.loads(infile)
+    from pprint import pformat
+    s = 'SIMULATION = ' + pformat(sim, indent=4) + '\n'
+    cdef std_string cpp_rtn = str_py_to_cpp(s)
+    return cpp_rtn

--- a/src/pyinfile.pyx
+++ b/src/pyinfile.pyx
@@ -39,7 +39,7 @@ cdef public std_string py_to_json "CyclusPyToJson" (std_string cpp_infile):
         sim = sim.decode()  # assume in JSON format, get into str
     elif isinstance(sim, Mapping):
         import json
-        sim = json.dumps(sim, sort_keys=True)
+        sim = json.dumps(sim, sort_keys=True, indent=1)
     else:
         raise RuntimeError('top-level simulation object does not have proper type.')
     cdef std_string cpp_rtn = str_py_to_cpp(sim)

--- a/src/pyinfile.pyx
+++ b/src/pyinfile.pyx
@@ -2,6 +2,11 @@
 from __future__ import print_function, unicode_literals
 from libcpp.string cimport string as std_string
 
+try:
+    from pprintpp import pformat
+except ImportError:
+    from pprint import pformat
+
 
 cdef object std_string_to_py(std_string x):
     pyx = x
@@ -51,7 +56,6 @@ cdef public std_string json_to_py "CyclusJsonToPy" (std_string cpp_infile):
     infile = std_string_to_py(cpp_infile)
     import json
     sim = json.loads(infile)
-    from pprint import pformat
-    s = 'SIMULATION = ' + pformat(sim, indent=4) + '\n'
+    s = 'SIMULATION = ' + pformat(sim, indent=1) + '\n'
     cdef std_string cpp_rtn = str_py_to_cpp(s)
     return cpp_rtn

--- a/src/toolkit/infile_converters.cc
+++ b/src/toolkit/infile_converters.cc
@@ -6,6 +6,7 @@
 #include "error.h"
 #include "infile_converters.h"
 #include "infile_tree.h"
+#include "pyhooks.h"
 #include "pyne.h"
 
 namespace cyclus {
@@ -158,6 +159,14 @@ std::string XmlToJson(std::string s) {
   Json::CustomWriter writer = Json::CustomWriter("{", "}", "[", "]", ": ",
                                                  ", ", " ", 80);
   return writer.write(jroot);
+}
+
+std::string PyToXml(std::string s) {
+  return JsonToXml(PyToJson(s));
+}
+
+std::string XmlToPy(std::string s) {
+  return JsonToPy(XmlToJson(s));
 }
 
 }  // namespace toolkit

--- a/src/toolkit/infile_converters.h
+++ b/src/toolkit/infile_converters.h
@@ -14,6 +14,13 @@ std::string XmlToJson(std::string s);
 
 // PyToJson declared in pyhooks.h
 // JsonToPy declared in pyhooks.h
+
+/// Converts a Python string into an equivalent XML string
+std::string PyToXml(std::string s);
+
+/// Converts an XML string into an equivalent JSON string
+std::string XmlToPy(std::string s);
+
 }  // namespace toolkit
 }  // namespace cyclus
 

--- a/src/toolkit/infile_converters.h
+++ b/src/toolkit/infile_converters.h
@@ -12,6 +12,8 @@ std::string JsonToXml(std::string s);
 /// Converts an XML string into an equivalent JSON string
 std::string XmlToJson(std::string s);
 
+// PyToJson declared in pyhooks.h
+// JsonToPy declared in pyhooks.h
 }  // namespace toolkit
 }  // namespace cyclus
 

--- a/src/xml_file_loader.cc
+++ b/src/xml_file_loader.cc
@@ -43,6 +43,9 @@ void LoadStringstreamFromFile(std::stringstream& stream, std::string file) {
   if (inext == ".json") {
     std::string inxml = cyclus::toolkit::JsonToXml(stream.str());
     stream.str(inxml);
+  } else if (inext == ".py") {
+    std::string inxml = cyclus::toolkit::PyToXml(stream.str());
+    stream.str(inxml);
   }
 }
 

--- a/tests/toolkit/infile_converters_tests.cc
+++ b/tests/toolkit/infile_converters_tests.cc
@@ -80,3 +80,31 @@ TEST(InfileConverters, JsonXmlRoundTrip) {
   EXPECT_STREQ(j1.c_str(), j2.c_str());
   EXPECT_STREQ(x1.c_str(), x2.c_str());
 }
+
+TEST(InfileConverters, JsonPyRoundTrip) {
+  using std::string;
+  cyclus::PyStart();
+  string inp = cyclus::toolkit::XmlToJson(MakeInput());
+  string p1 = cyclus::toolkit::JsonToPy(inp);
+  string j1 = cyclus::toolkit::PyToJson(p1);
+  string p2 = cyclus::toolkit::JsonToPy(j1);
+  string j2 = cyclus::toolkit::PyToJson(p2);
+  cyclus::PyStop();
+
+  EXPECT_STREQ(j1.c_str(), j2.c_str());
+  EXPECT_STREQ(p1.c_str(), p2.c_str());
+}
+
+TEST(InfileConverters, PyXmlRoundTrip) {
+  using std::string;
+  cyclus::PyStart();
+  string inp = MakeInput();
+  string p1 = cyclus::toolkit::XmlToPy(inp);
+  string x1 = cyclus::toolkit::PyToXml(p1);
+  string p2 = cyclus::toolkit::XmlToPy(x1);
+  string x2 = cyclus::toolkit::PyToXml(p2);
+  cyclus::PyStop();
+
+  EXPECT_STREQ(p1.c_str(), p2.c_str());
+  EXPECT_STREQ(x1.c_str(), x2.c_str());
+}


### PR DESCRIPTION
This adds the ability to use Python files as input files to Cyclus.  This PR builds off of the server PR and is probably long overdue.