### PR TITLE
python2.7 fix

### DIFF
--- a/cli/cycpp.py
+++ b/cli/cycpp.py
@@ -834,13 +834,13 @@ class StateAccumulator(object):
             current_shape = ann_dict['shape']
         new_shape = []
         # Flatten list dimensions
-        if isinstance(type_canon, str):
+        if isinstance(type_canon, STRING_TYPES):
             result = [type_canon]
         else:
             result = list(type_canon)
             i = 0
             while i < len(result):
-                if isinstance(result[i], str):
+                if isinstance(result[i], STRING_TYPES):
                     i += 1
                 else:
                     temp = result[i][1:]

--- a/cyclus/gentypesystem.py
+++ b/cyclus/gentypesystem.py
@@ -23,9 +23,11 @@ from pprint import pprint, pformat
 if sys.version_info[0] > 2:
     from urllib.request import urlopen
     str_types = (str, bytes)
+    unicode_types = (str,)
 else:
     from urllib2 import urlopen
     str_types = (str, unicode)
+    unicode_types = (str, unicode)
 
 import jinja2
 
@@ -2459,9 +2461,9 @@ def typesystem_pyx(ts, ns):
         annotations=ANNOTATIONS,
         nonuser_annotations=nonuser_annotations,
         uniquestrtypes = [t for t in ts.uniquetypes
-                          if isinstance(ts.norms[t], str)],
+                          if isinstance(ts.norms[t], unicode_types)],
         uniquetuptypes = sorted([(ts.norms[t], t) for t in ts.uniquetypes
-                                 if not isinstance(ts.norms[t], str)], reverse=True,
+                                 if not isinstance(ts.norms[t], unicode_types)], reverse=True,
                                 key=lambda x: (x[0][0], x[1])),
         groupby=itertools.groupby,
         firstfirst=lambda x: x[0][0],


### PR DESCRIPTION
This fix ensures that Python 2.7's `unicode` type is treated the same as `str` while generating the typesystem. Previously, `unicode` was not handled, causing list comprehensions to produce empty lists, resulting in incorrect code generation.

@bam241 Please let me know if this solves #1356 