### PR TITLE
Hdf5 support for map_string_map_int_double type variations

### DIFF
--- a/src/hdf5_back_gen.py
+++ b/src/hdf5_back_gen.py
@@ -2097,9 +2097,10 @@ def pad_children(t, variable, fixed_var=None, depth=0, prefix=""):
                                                depth=depth+1, prefix=prefix
                                                               +prefixes[count]))
                 #attempt to resize container
-                body_nodes.append(ExprStmt(child=Raw(code=child_variable+".resize("+child_length+")")))
-                size = "(" + child_length + "-" + child_pad_count + ")" + "*" + item_size
-                body_nodes.append(memset("&"+child_variable, str(0), size))
+                if child_node.canon[0] == 'VECTOR':
+                    body_nodes.append(ExprStmt(child=Raw(code=child_variable+".resize("+child_length+")")))
+                    size = "(" + child_length + "-" + child_pad_count + ")" + "*" + item_size
+                    body_nodes.append(memset("&"+child_variable, str(0), size))
                 keywords[child_keyword] = child_variable
             #PAIRS, etc.
             else:
@@ -2765,9 +2766,6 @@ def setup():
             CANON_TO_NODE[canon] = Type(cpp=cpp, db=db, canon=canon)
             DB_TO_VL[db] = row[8]
 
-def init_dicts():
-    global NOT_VL
-    
     fixed_length_types = []
     for n in CANON_TYPES:
         if no_vl(CANON_TO_NODE[n]) and n not in fixed_length_types:
@@ -2828,6 +2826,7 @@ def main():
     setup()
         
     # Dispatch to requested generation function
+    #print(MAIN_DISPATCH)
     function = MAIN_DISPATCH[gen_instruction]
     print(function())
 

--- a/src/query_backend.h
+++ b/src/query_backend.h
@@ -179,7 +179,7 @@ enum DbTypes {
   VL_MAP_VL_STRING_VL_VECTOR_DOUBLE,  // ["std::map<std::string, std::vector<double>>", 3, ["HDF5", "SQLite"], ["VL_MAP", "VL_STRING", ["VL_VECTOR", "DOUBLE"]], true]
 
   // map<string,  map<int,  double> >
-  MAP_STRING_MAP_INT_DOUBLE,  // ["std::map<std::string, std::map<int, double>>", 3, ["SQLite"], ["MAP", "STRING", ["MAP", "INT", "DOUBLE"]], false]
+  MAP_STRING_MAP_INT_DOUBLE,  // ["std::map<std::string, std::map<int, double>>", 3, ["HDF5", "SQLite"], ["MAP", "STRING", ["MAP", "INT", "DOUBLE"]], false]
   MAP_STRING_VL_MAP_INT_DOUBLE,  // ["std::map<std::string, std::map<int, double>>", 3, ["SQLite"], ["MAP", "STRING", ["VL_MAP", "INT", "DOUBLE"]], false]
   VL_MAP_STRING_MAP_INT_DOUBLE,  // ["std::map<std::string, std::map<int, double>>", 3, ["SQLite"], ["VL_MAP", "STRING", ["MAP", "INT", "DOUBLE"]], true]
   MAP_VL_STRING_MAP_INT_DOUBLE,  // ["std::map<std::string, std::map<int, double>>", 3, ["SQLite"], ["MAP", "VL_STRING", ["MAP", "INT", "DOUBLE"]], false]

--- a/src/query_backend.h
+++ b/src/query_backend.h
@@ -169,14 +169,14 @@ enum DbTypes {
   // append new types only:
 
   // map<string,  vector<double> >
-  MAP_STRING_VECTOR_DOUBLE,  // ["std::map<std::string, std::vector<double>>", 3, ["SQLite"], ["MAP", "STRING", ["VECTOR", "DOUBLE"]], false]
-  MAP_STRING_VL_VECTOR_DOUBLE,  // ["std::map<std::string, std::vector<double>>", 3, ["SQLite"], ["MAP", "STRING", ["VL_VECTOR", "DOUBLE"]], false]
-  VL_MAP_STRING_VECTOR_DOUBLE,  // ["std::map<std::string, std::vector<double>>", 3, ["SQLite"], ["VL_MAP", "STRING", ["VECTOR", "DOUBLE"]], true]
-  MAP_VL_STRING_VECTOR_DOUBLE,  // ["std::map<std::string, std::vector<double>>", 3, ["SQLite"], ["MAP", "VL_STRING", ["VECTOR", "DOUBLE"]], false]
-  MAP_VL_STRING_VL_VECTOR_DOUBLE,  // ["std::map<std::string, std::vector<double>>", 3, ["SQLite"], ["MAP", "VL_STRING", ["VL_VECTOR", "DOUBLE"]], false]
-  VL_MAP_STRING_VL_VECTOR_DOUBLE,  // ["std::map<std::string, std::vector<double>>", 3, ["SQLite"], ["VL_MAP", "STRING", ["VL_VECTOR", "DOUBLE"]], true]
-  VL_MAP_VL_STRING_VECTOR_DOUBLE,  // ["std::map<std::string, std::vector<double>>", 3, ["SQLite"], ["VL_MAP", "VL_STRING", ["VECTOR", "DOUBLE"]], true]
-  VL_MAP_VL_STRING_VL_VECTOR_DOUBLE,  // ["std::map<std::string, std::vector<double>>", 3, ["SQLite"], ["VL_MAP", "VL_STRING", ["VL_VECTOR", "DOUBLE"]], true]
+  MAP_STRING_VECTOR_DOUBLE,  // ["std::map<std::string, std::vector<double>>", 3, ["HDF5", "SQLite"], ["MAP", "STRING", ["VECTOR", "DOUBLE"]], false]
+  MAP_STRING_VL_VECTOR_DOUBLE,  // ["std::map<std::string, std::vector<double>>", 3, ["HDF5", "SQLite"], ["MAP", "STRING", ["VL_VECTOR", "DOUBLE"]], false]
+  VL_MAP_STRING_VECTOR_DOUBLE,  // ["std::map<std::string, std::vector<double>>", 3, ["HDF5", "SQLite"], ["VL_MAP", "STRING", ["VECTOR", "DOUBLE"]], true]
+  MAP_VL_STRING_VECTOR_DOUBLE,  // ["std::map<std::string, std::vector<double>>", 3, ["HDF5", "SQLite"], ["MAP", "VL_STRING", ["VECTOR", "DOUBLE"]], false]
+  MAP_VL_STRING_VL_VECTOR_DOUBLE,  // ["std::map<std::string, std::vector<double>>", 3, ["HDF5", "SQLite"], ["MAP", "VL_STRING", ["VL_VECTOR", "DOUBLE"]], false]
+  VL_MAP_STRING_VL_VECTOR_DOUBLE,  // ["std::map<std::string, std::vector<double>>", 3, ["HDF5", "SQLite"], ["VL_MAP", "STRING", ["VL_VECTOR", "DOUBLE"]], true]
+  VL_MAP_VL_STRING_VECTOR_DOUBLE,  // ["std::map<std::string, std::vector<double>>", 3, ["HDF5", "SQLite"], ["VL_MAP", "VL_STRING", ["VECTOR", "DOUBLE"]], true]
+  VL_MAP_VL_STRING_VL_VECTOR_DOUBLE,  // ["std::map<std::string, std::vector<double>>", 3, ["HDF5", "SQLite"], ["VL_MAP", "VL_STRING", ["VL_VECTOR", "DOUBLE"]], true]
 
   // map<string,  map<int,  double> >
   MAP_STRING_MAP_INT_DOUBLE,  // ["std::map<std::string, std::map<int, double>>", 3, ["SQLite"], ["MAP", "STRING", ["MAP", "INT", "DOUBLE"]], false]
@@ -884,6 +884,14 @@ class Sha1 {
       hash_.process_bytes(&(it->first.first), sizeof(int));
       hash_.process_bytes(it->first.second.c_str(), it->first.second.size());
       hash_.process_bytes(&(it->second), sizeof(double));
+    }
+  }
+  
+  inline void Update(const std::map<std::string, std::vector<double>>& x) {
+    std::map<std::string, std::vector<double>>::const_iterator it = x.begin();
+    for (; it != x.end(); ++it) {
+      hash_.process_bytes(it->first.c_str(), it->first.size());
+      Update(it->second);
     }
   }
   /// \}

--- a/src/query_backend.h
+++ b/src/query_backend.h
@@ -180,13 +180,13 @@ enum DbTypes {
 
   // map<string,  map<int,  double> >
   MAP_STRING_MAP_INT_DOUBLE,  // ["std::map<std::string, std::map<int, double>>", 3, ["HDF5", "SQLite"], ["MAP", "STRING", ["MAP", "INT", "DOUBLE"]], false]
-  MAP_STRING_VL_MAP_INT_DOUBLE,  // ["std::map<std::string, std::map<int, double>>", 3, ["SQLite"], ["MAP", "STRING", ["VL_MAP", "INT", "DOUBLE"]], false]
-  VL_MAP_STRING_MAP_INT_DOUBLE,  // ["std::map<std::string, std::map<int, double>>", 3, ["SQLite"], ["VL_MAP", "STRING", ["MAP", "INT", "DOUBLE"]], true]
-  MAP_VL_STRING_MAP_INT_DOUBLE,  // ["std::map<std::string, std::map<int, double>>", 3, ["SQLite"], ["MAP", "VL_STRING", ["MAP", "INT", "DOUBLE"]], false]
-  MAP_VL_STRING_VL_MAP_INT_DOUBLE,  // ["std::map<std::string, std::map<int, double>>", 3, ["SQLite"], ["MAP", "VL_STRING", ["VL_MAP", "INT", "DOUBLE"]], false]
-  VL_MAP_STRING_VL_MAP_INT_DOUBLE,  // ["std::map<std::string, std::map<int, double>>", 3, ["SQLite"], ["VL_MAP", "STRING", ["VL_MAP", "INT", "DOUBLE"]], true]
-  VL_MAP_VL_STRING_MAP_INT_DOUBLE,  // ["std::map<std::string, std::map<int, double>>", 3, ["SQLite"], ["VL_MAP", "VL_STRING", ["MAP", "INT", "DOUBLE"]], true]
-  VL_MAP_VL_STRING_VL_MAP_INT_DOUBLE,  // ["std::map<std::string, std::map<int, double>>", 3, ["SQLite"], ["VL_MAP", "VL_STRING", ["VL_MAP", "INT", "DOUBLE"]], true]
+  MAP_STRING_VL_MAP_INT_DOUBLE,  // ["std::map<std::string, std::map<int, double>>", 3, ["HDF5", "SQLite"], ["MAP", "STRING", ["VL_MAP", "INT", "DOUBLE"]], false]
+  VL_MAP_STRING_MAP_INT_DOUBLE,  // ["std::map<std::string, std::map<int, double>>", 3, ["HDF5", "SQLite"], ["VL_MAP", "STRING", ["MAP", "INT", "DOUBLE"]], true]
+  MAP_VL_STRING_MAP_INT_DOUBLE,  // ["std::map<std::string, std::map<int, double>>", 3, ["HDF5", "SQLite"], ["MAP", "VL_STRING", ["MAP", "INT", "DOUBLE"]], false]
+  MAP_VL_STRING_VL_MAP_INT_DOUBLE,  // ["std::map<std::string, std::map<int, double>>", 3, ["HDF5", "SQLite"], ["MAP", "VL_STRING", ["VL_MAP", "INT", "DOUBLE"]], false]
+  VL_MAP_STRING_VL_MAP_INT_DOUBLE,  // ["std::map<std::string, std::map<int, double>>", 3, ["HDF5", "SQLite"], ["VL_MAP", "STRING", ["VL_MAP", "INT", "DOUBLE"]], true]
+  VL_MAP_VL_STRING_MAP_INT_DOUBLE,  // ["std::map<std::string, std::map<int, double>>", 3, ["HDF5", "SQLite"], ["VL_MAP", "VL_STRING", ["MAP", "INT", "DOUBLE"]], true]
+  VL_MAP_VL_STRING_VL_MAP_INT_DOUBLE,  // ["std::map<std::string, std::map<int, double>>", 3, ["HDF5", "SQLite"], ["VL_MAP", "VL_STRING", ["VL_MAP", "INT", "DOUBLE"]], true]
 
   // map<string,  pair<double,  map<int,  double> > >
   MAP_STRING_PAIR_DOUBLE_MAP_INT_DOUBLE,  // ["std::map<std::string, std::pair<double, std::map<int, double>>>", 4, ["SQLite"], ["MAP", "STRING", ["PAIR", "DOUBLE", ["MAP", "INT", "DOUBLE"]]], false]
@@ -889,6 +889,14 @@ class Sha1 {
   
   inline void Update(const std::map<std::string, std::vector<double>>& x) {
     std::map<std::string, std::vector<double>>::const_iterator it = x.begin();
+    for (; it != x.end(); ++it) {
+      hash_.process_bytes(it->first.c_str(), it->first.size());
+      Update(it->second);
+    }
+  }
+  
+  inline void Update(const std::map<std::string, std::map<int, double>>& x) {
+    std::map<std::string, std::map<int, double>>::const_iterator it = x.begin();
     for (; it != x.end(); ++it) {
       hash_.process_bytes(it->first.c_str(), it->first.size());
       Update(it->second);

--- a/tests/hdf5_back_gen_tests.py
+++ b/tests/hdf5_back_gen_tests.py
@@ -14,10 +14,11 @@ import cyclus.typesystem as ts
 
 cycdir = os.path.dirname(os.path.dirname(__file__))
 sys.path.insert(0, os.path.join(cycdir, 'src'))
-from hdf5_back_gen import resolve_unicode, convert_canonical, init_dicts, ORIGIN_DICT
+import hdf5_back_gen
+#from hdf5_back_gen import resolve_unicode, convert_canonical, setup, ORIGIN_DICT
 
 #Call to hdf5_back_gen function 
-init_dicts()
+hdf5_back_gen.setup()
 
 is_primitive = lambda canon: isinstance(canon, str)
 
@@ -29,7 +30,7 @@ CANON_TO_VL = {}
 def setup():
     with open(os.path.join(os.path.dirname(__file__), '..', 'share', 
                        'dbtypes.json')) as f:
-        RAW_TABLE = resolve_unicode(json.load(f))
+        RAW_TABLE = hdf5_back_gen.resolve_unicode(json.load(f))
     
     VERSION = ""
     TABLE_START = 0
@@ -48,7 +49,7 @@ def setup():
         if row[6] == 1 and row[4] == "HDF5" and row[5] == VERSION:        
             db = row[1]
             is_vl = row[8]
-            canon = convert_canonical(row[7])
+            canon = hdf5_back_gen.convert_canonical(row[7])
             if canon not in CANON_TYPES:
                 CANON_TYPES.append(canon)
             CANON_TO_DB[canon] = db
@@ -98,7 +99,7 @@ def generate_meta(canon, depth=0):
     meta_shape = []
     my_shape = None
     my_type = None
-    origin = ORIGIN_DICT[canon]
+    origin = hdf5_back_gen.ORIGIN_DICT[canon]
     if is_primitive(canon):
         if CANON_TO_VL[canon]:
             my_shape = -1
@@ -185,7 +186,7 @@ def populate(meta):
     my_type = current_type[TYPE_FUNCTION]
     canon = current_type[TYPE_CANON]
     data = my_type()
-    origin = ORIGIN_DICT[canon]
+    origin = hdf5_back_gen.ORIGIN_DICT[canon]
     if is_primitive(canon):
         if origin == 'STRING' or origin == 'BLOB':
             if my_shape > 0:

--- a/tests/hdf5_back_gen_tests.py
+++ b/tests/hdf5_back_gen_tests.py
@@ -76,7 +76,7 @@ TYPE_SHAPE = 0
 TYPE_FUNCTION = 1
 TYPE_CANON = 2
 CONTAINER_MIN = 4
-CONTAINER_MAX = 10
+CONTAINER_MAX = 8
 def generate_meta(canon, depth=0):
     """Produces metadata about a type to be created.
     
@@ -257,15 +257,17 @@ def generate_and_test():
         rec.register_backend(back)
         data_meta = generate_meta(i)
         shape = get_shape(data_meta)
+        print("shape: ", shape)
         data = []
         for j in range(ROW_NUM):
             data.append(populate(data_meta))
-            d = rec.new_datum("test0")
-            d.add_val("col0", data[j], shape=shape, type=ts.IDS[CANON_TO_DB[i]])
-            d.record()
-            rec.flush()
         exp = pd.DataFrame({'col0': data}, columns=['col0'])
         print("expected: \n", exp)
+        for j in data:
+            d = rec.new_datum("test0")
+            d.add_val("col0", j, shape=shape, type=ts.IDS[CANON_TO_DB[i]])
+            d.record()
+            rec.flush()
         obs = back.query("test0")
         print("observed: \n", obs)
         yield assert_frame_equal, exp, obs


### PR DESCRIPTION
Added all variants of `MAP_STRING_MAP_INT_DOUBLE`, and fixed a couple `gentypesystem.py` bugs. Plus a few PEP8 changes to `hdf5_back_gen.py`

@scopatz 