### PR TITLE
Hdf5 backend support for all current SQLite types

### DIFF
--- a/src/hdf5_back_gen.py
+++ b/src/hdf5_back_gen.py
@@ -1454,7 +1454,7 @@ def get_item_type(t, shape_array=None, vl_flag=False, prefix="", depth=0):
             # 3. Create compound type using total item size.
             compound = hdf5_create_compound(list(child_dict.values()))
             
-            item_var = get_variable("item_type", prefix="", depth=depth+1)
+            item_var = get_variable("item_type", prefix=prefix+'compound', depth=depth+1)
             node.nodes.append(ExprStmt(child=Decl(type=Type(cpp="hid_t"),
                                                   name=Raw(code=item_var))))
             
@@ -1472,6 +1472,7 @@ def get_item_type(t, shape_array=None, vl_flag=False, prefix="", depth=0):
                 node.nodes.append(VL_ADD_BLOCK(ORIGIN_TO_VL[ORIGIN_DICT[t.canon]], item_var))
             else:
                 node.nodes.append(VL_ADD_BLOCK(t, item_var))
+            opened_stack.append(type_var)
         
         elif container_type in variable_length_types and not DB_TO_VL[t.db]:
             array_node = ExprStmt(child=Assign(target=Var(name=type_var),
@@ -2808,7 +2809,7 @@ def setup():
     VARIATION_DICT['BLOB'] = []
     VARIATION_DICT['STRING'] = [CANON_TO_NODE['VL_STRING']]
         
-    for i in VARIATION_DICT.keys():
+    for i in VARIATION_DICT:
         ORIGIN_DICT[i] = i
         if VARIATION_DICT[i] != []:
             for j in VARIATION_DICT[i]:

--- a/src/query_backend.h
+++ b/src/query_backend.h
@@ -263,22 +263,22 @@ enum DbTypes {
   VL_MAP_VL_STRING_PAIR_VL_STRING_VL_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["HDF5", "SQLite"], ["VL_MAP", "VL_STRING", ["PAIR", "VL_STRING", ["VL_VECTOR", "DOUBLE"]]], true]
 
   // map<string,  map<string,  int> >
-  MAP_STRING_MAP_STRING_INT,  // ["std::map<std::string, std::map<std::string, int>>", 3, ["SQLite"], ["MAP", "STRING", ["MAP", "STRING", "INT"]], false]
-  MAP_STRING_MAP_VL_STRING_INT,  // ["std::map<std::string, std::map<std::string, int>>", 3, ["SQLite"], ["MAP", "STRING", ["MAP", "VL_STRING", "INT"]], false]
-  MAP_STRING_VL_MAP_STRING_INT,  // ["std::map<std::string, std::map<std::string, int>>", 3, ["SQLite"], ["MAP", "STRING", ["VL_MAP", "STRING", "INT"]], false]
-  MAP_STRING_VL_MAP_VL_STRING_INT,  // ["std::map<std::string, std::map<std::string, int>>", 3, ["SQLite"], ["MAP", "STRING", ["VL_MAP", "VL_STRING", "INT"]], false]
-  MAP_VL_STRING_MAP_STRING_INT,  // ["std::map<std::string, std::map<std::string, int>>", 3, ["SQLite"], ["MAP", "VL_STRING", ["MAP", "STRING", "INT"]], false]
-  MAP_VL_STRING_VL_MAP_STRING_INT,  // ["std::map<std::string, std::map<std::string, int>>", 3, ["SQLite"], ["MAP", "VL_STRING", ["VL_MAP", "STRING", "INT"]], false]
-  MAP_VL_STRING_MAP_VL_STRING_INT,  // ["std::map<std::string, std::map<std::string, int>>", 3, ["SQLite"], ["MAP", "VL_STRING", ["MAP", "VL_STRING", "INT"]], false]
-  MAP_VL_STRING_VL_MAP_VL_STRING_INT,  // ["std::map<std::string, std::map<std::string, int>>", 3, ["SQLite"], ["MAP", "VL_STRING", ["VL_MAP", "VL_STRING", "INT"]], false]
-  VL_MAP_STRING_MAP_STRING_INT,  // ["std::map<std::string, std::map<std::string, int>>", 3, ["SQLite"], ["VL_MAP", "STRING", ["MAP", "STRING", "INT"]], false]
-  VL_MAP_VL_STRING_MAP_STRING_INT,  // ["std::map<std::string, std::map<std::string, int>>", 3, ["SQLite"], ["VL_MAP", "VL_STRING", ["MAP", "STRING", "INT"]], false]
-  VL_MAP_STRING_VL_MAP_STRING_INT,  // ["std::map<std::string, std::map<std::string, int>>", 3, ["SQLite"], ["VL_MAP", "STRING", ["VL_MAP", "STRING", "INT"]], false]
-  VL_MAP_STRING_MAP_VL_STRING_INT,  // ["std::map<std::string, std::map<std::string, int>>", 3, ["SQLite"], ["VL_MAP", "STRING", ["MAP", "VL_STRING", "INT"]], false]
-  VL_MAP_STRING_VL_MAP_VL_STRING_INT,  // ["std::map<std::string, std::map<std::string, int>>", 3, ["SQLite"], ["VL_MAP", "STRING", ["VL_MAP", "VL_STRING", "INT"]], false]
-  VL_MAP_VL_STRING_MAP_VL_STRING_INT,  // ["std::map<std::string, std::map<std::string, int>>", 3, ["SQLite"], ["VL_MAP", "VL_STRING", ["MAP", "VL_STRING", "INT"]], false]
-  VL_MAP_VL_STRING_VL_MAP_STRING_INT,  // ["std::map<std::string, std::map<std::string, int>>", 3, ["SQLite"], ["VL_MAP", "VL_STRING", ["VL_MAP", "STRING", "INT"]], false]
-  VL_MAP_VL_STRING_VL_MAP_VL_STRING_INT,  // ["std::map<std::string, std::map<std::string, int>>", 3, ["SQLite"], ["VL_MAP", "VL_STRING", ["VL_MAP", "VL_STRING", "INT"]], false]
+  MAP_STRING_MAP_STRING_INT,  // ["std::map<std::string, std::map<std::string, int>>", 3, ["HDF5", "SQLite"], ["MAP", "STRING", ["MAP", "STRING", "INT"]], false]
+  MAP_STRING_MAP_VL_STRING_INT,  // ["std::map<std::string, std::map<std::string, int>>", 3, ["HDF5", "SQLite"], ["MAP", "STRING", ["MAP", "VL_STRING", "INT"]], false]
+  MAP_STRING_VL_MAP_STRING_INT,  // ["std::map<std::string, std::map<std::string, int>>", 3, ["HDF5", "SQLite"], ["MAP", "STRING", ["VL_MAP", "STRING", "INT"]], false]
+  MAP_STRING_VL_MAP_VL_STRING_INT,  // ["std::map<std::string, std::map<std::string, int>>", 3, ["HDF5", "SQLite"], ["MAP", "STRING", ["VL_MAP", "VL_STRING", "INT"]], false]
+  MAP_VL_STRING_MAP_STRING_INT,  // ["std::map<std::string, std::map<std::string, int>>", 3, ["HDF5", "SQLite"], ["MAP", "VL_STRING", ["MAP", "STRING", "INT"]], false]
+  MAP_VL_STRING_VL_MAP_STRING_INT,  // ["std::map<std::string, std::map<std::string, int>>", 3, ["HDF5", "SQLite"], ["MAP", "VL_STRING", ["VL_MAP", "STRING", "INT"]], false]
+  MAP_VL_STRING_MAP_VL_STRING_INT,  // ["std::map<std::string, std::map<std::string, int>>", 3, ["HDF5", "SQLite"], ["MAP", "VL_STRING", ["MAP", "VL_STRING", "INT"]], false]
+  MAP_VL_STRING_VL_MAP_VL_STRING_INT,  // ["std::map<std::string, std::map<std::string, int>>", 3, ["HDF5", "SQLite"], ["MAP", "VL_STRING", ["VL_MAP", "VL_STRING", "INT"]], false]
+  VL_MAP_STRING_MAP_STRING_INT,  // ["std::map<std::string, std::map<std::string, int>>", 3, ["HDF5", "SQLite"], ["VL_MAP", "STRING", ["MAP", "STRING", "INT"]], true]
+  VL_MAP_VL_STRING_MAP_STRING_INT,  // ["std::map<std::string, std::map<std::string, int>>", 3, ["HDF5", "SQLite"], ["VL_MAP", "VL_STRING", ["MAP", "STRING", "INT"]], true]
+  VL_MAP_STRING_VL_MAP_STRING_INT,  // ["std::map<std::string, std::map<std::string, int>>", 3, ["HDF5", "SQLite"], ["VL_MAP", "STRING", ["VL_MAP", "STRING", "INT"]], true]
+  VL_MAP_STRING_MAP_VL_STRING_INT,  // ["std::map<std::string, std::map<std::string, int>>", 3, ["HDF5", "SQLite"], ["VL_MAP", "STRING", ["MAP", "VL_STRING", "INT"]], true]
+  VL_MAP_STRING_VL_MAP_VL_STRING_INT,  // ["std::map<std::string, std::map<std::string, int>>", 3, ["HDF5", "SQLite"], ["VL_MAP", "STRING", ["VL_MAP", "VL_STRING", "INT"]], true]
+  VL_MAP_VL_STRING_MAP_VL_STRING_INT,  // ["std::map<std::string, std::map<std::string, int>>", 3, ["HDF5", "SQLite"], ["VL_MAP", "VL_STRING", ["MAP", "VL_STRING", "INT"]], true]
+  VL_MAP_VL_STRING_VL_MAP_STRING_INT,  // ["std::map<std::string, std::map<std::string, int>>", 3, ["HDF5", "SQLite"], ["VL_MAP", "VL_STRING", ["VL_MAP", "STRING", "INT"]], true]
+  VL_MAP_VL_STRING_VL_MAP_VL_STRING_INT,  // ["std::map<std::string, std::map<std::string, int>>", 3, ["HDF5", "SQLite"], ["VL_MAP", "VL_STRING", ["VL_MAP", "VL_STRING", "INT"]], true]
 
   // vector<pair<pair<double, double>, map<string, double>>>
   VECTOR_PAIR_PAIR_DOUBLE_DOUBLE_MAP_STRING_DOUBLE, // ["std::vector<std::pair<std::pair<double, double>, std::map<std::string, double> > >", 5, ["SQLite"], ["VECTOR", ["PAIR", ["PAIR", "DOUBLE", "DOUBLE"], ["MAP", "STRING", "DOUBLE"]]], false]
@@ -978,6 +978,14 @@ class Sha1 {
   
   inline void Update(const std::map<std::string, std::pair<std::string, std::vector<double>>>& x) {
     std::map<std::string, std::pair<std::string, std::vector<double>>>::const_iterator it = x.begin();
+    for(; it != x.end(); ++it) {
+      hash_.process_bytes(it->first.c_str(), it->first.size());
+      Update(it->second);
+    }
+  }
+  
+  inline void Update(const std::map<std::string, std::map<std::string, int>>& x) {
+    std::map<std::string, std::map<std::string, int>>::const_iterator it = x.begin();
     for(; it != x.end(); ++it) {
       hash_.process_bytes(it->first.c_str(), it->first.size());
       Update(it->second);

--- a/src/query_backend.h
+++ b/src/query_backend.h
@@ -241,11 +241,11 @@ enum DbTypes {
   VL_MAP_VL_STRING_VL_VECTOR_PAIR_INT_PAIR_VL_STRING_VL_STRING,  // ["std::map<std::string, std::vector<std::pair<int, std::pair<std::string, std::string>>>>", 7, ["HDF5", "SQLite"], ["VL_MAP", "VL_STRING", ["VL_VECTOR", ["PAIR", "INT", ["PAIR", "VL_STRING", "VL_STRING"]]]], true]
 
   // list< pair<int,  int>
-  LIST_PAIR_INT_INT,  // ["std::list<std::pair<int, int>>", 2, ["SQLite"], ["LIST", ["PAIR", "INT", "INT"]], false]
-  VL_LIST_PAIR_INT_INT,  // ["std::list<std::pair<int, int>>", 2, ["SQLite"], ["VL_LIST", ["PAIR", "INT", "INT"]], true]
+  LIST_PAIR_INT_INT,  // ["std::list<std::pair<int, int>>", 2, ["HDF5", "SQLite"], ["LIST", ["PAIR", "INT", "INT"]], false]
+  VL_LIST_PAIR_INT_INT,  // ["std::list<std::pair<int, int>>", 2, ["HDF5", "SQLite"], ["VL_LIST", ["PAIR", "INT", "INT"]], true]
 
   // map< string,  pair< string,  vector<double> > > >
-  MAP_STRING_PAIR_STRING_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["SQLite"], ["MAP", "STRING", ["PAIR", "STRING", ["VECTOR", "DOUBLE"]]], false]
+  MAP_STRING_PAIR_STRING_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["HDF5", "SQLite"], ["MAP", "STRING", ["PAIR", "STRING", ["VECTOR", "DOUBLE"]]], false]
   MAP_STRING_PAIR_STRING_VL_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["SQLite"], ["MAP", "STRING", ["PAIR", "STRING", ["VL_VECTOR", "DOUBLE"]]], false]
   MAP_STRING_PAIR_VL_STRING_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["SQLite"], ["MAP", "STRING", ["PAIR", "VL_STRING", ["VECTOR", "DOUBLE"]]], false]
   MAP_STRING_PAIR_VL_STRING_VL_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["SQLite"], ["MAP", "STRING", ["PAIR", "VL_STRING", ["VL_VECTOR", "DOUBLE"]]], false]
@@ -330,7 +330,12 @@ enum DbTypes {
   VL_VECTOR_PAIR_INT_PAIR_STRING_STRING, // ["std::vector<std::pair<int, std::pair<std::string, std::string>>>", 1, ["HDF5"], ["VL_VECTOR", ["PAIR", "INT", ["PAIR", "STRING", "STRING"]]], true]
   VL_VECTOR_PAIR_INT_PAIR_VL_STRING_STRING, // ["std::vector<std::pair<int, std::pair<std::string, std::string>>>", 1, ["HDF5"], ["VL_VECTOR", ["PAIR", "INT", ["PAIR", "VL_STRING", "STRING"]]], true]
   VL_VECTOR_PAIR_INT_PAIR_STRING_VL_STRING, // ["std::vector<std::pair<int, std::pair<std::string, std::string>>>", 1, ["HDF5"], ["VL_VECTOR", ["PAIR", "INT", ["PAIR", "STRING", "VL_STRING"]]], true]
-  VL_VECTOR_PAIR_INT_PAIR_VL_STRING_VL_STRING, // ["std::vector<std::pair<int, std::pair<std::string, std::string>>>", 1, ["HDF5"], ["VL_VECTOR", ["PAIR", "INT", ["PAIR", "VL_STRING", "VL_STRING"]]], true] 
+  VL_VECTOR_PAIR_INT_PAIR_VL_STRING_VL_STRING, // ["std::vector<std::pair<int, std::pair<std::string, std::string>>>", 1, ["HDF5"], ["VL_VECTOR", ["PAIR", "INT", ["PAIR", "VL_STRING", "VL_STRING"]]], true]
+  
+  PAIR_STRING_VECTOR_DOUBLE, // ["std::pair<std::string, std::vector<double>>", 1, ["HDF5"], ["PAIR", "STRING", ["VECTOR", "DOUBLE"]], false]
+  PAIR_VL_STRING_VECTOR_DOUBLE, // ["std::pair<std::string, std::vector<double>>", 1, [], ["PAIR", "VL_STRING", ["VECTOR", "DOUBLE"]], false]
+  PAIR_STRING_VL_VECTOR_DOUBLE, // ["std::pair<std::string, std::vector<double>>", 1, [], ["PAIR", "STRING", ["VL_VECTOR", "DOUBLE"]], false]
+  PAIR_VL_STRING_VL_VECTOR_DOUBLE, // ["std::pair<std::string, std::vector<double>>", 1, [], ["PAIR", "VL_STRING", ["VL_VECTOR", "DOUBLE"]], false]
   
   // append new types only:
 };
@@ -956,6 +961,13 @@ class Sha1 {
     for (; it != x.end(); ++it) {
       hash_.process_bytes(it->first.c_str(), it->first.size());
       Update(it->second);
+    }
+  }
+  
+  inline void Update(const std::list<std::pair<int, int>>& x){
+    std::list<std::pair<int, int>>::const_iterator it = x.begin();
+    for (; it != x.end(); ++it) {
+      Update(*it);
     }
   }
   

--- a/src/query_backend.h
+++ b/src/query_backend.h
@@ -246,21 +246,21 @@ enum DbTypes {
 
   // map< string,  pair< string,  vector<double> > > >
   MAP_STRING_PAIR_STRING_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["HDF5", "SQLite"], ["MAP", "STRING", ["PAIR", "STRING", ["VECTOR", "DOUBLE"]]], false]
-  MAP_STRING_PAIR_STRING_VL_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["SQLite"], ["MAP", "STRING", ["PAIR", "STRING", ["VL_VECTOR", "DOUBLE"]]], false]
-  MAP_STRING_PAIR_VL_STRING_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["SQLite"], ["MAP", "STRING", ["PAIR", "VL_STRING", ["VECTOR", "DOUBLE"]]], false]
-  MAP_STRING_PAIR_VL_STRING_VL_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["SQLite"], ["MAP", "STRING", ["PAIR", "VL_STRING", ["VL_VECTOR", "DOUBLE"]]], false]
-  MAP_VL_STRING_PAIR_STRING_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["SQLite"], ["MAP", "VL_STRING", ["PAIR", "STRING", ["VECTOR", "DOUBLE"]]], false]
-  MAP_VL_STRING_PAIR_VL_STRING_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["SQLite"], ["MAP", "VL_STRING", ["PAIR", "VL_STRING", ["VECTOR", "DOUBLE"]]], false]
-  MAP_VL_STRING_PAIR_STRING_VL_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["SQLite"], ["MAP", "VL_STRING", ["PAIR", "STRING", ["VL_VECTOR", "DOUBLE"]]], false]
-  MAP_VL_STRING_PAIR_VL_STRING_VL_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["SQLite"], ["MAP", "VL_STRING", ["PAIR", "VL_STRING", ["VL_VECTOR", "DOUBLE"]]], false]
-  VL_MAP_STRING_PAIR_STRING_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["SQLite"], ["VL_MAP", "STRING", ["PAIR", "STRING", ["VECTOR", "DOUBLE"]]], true]
-  VL_MAP_VL_STRING_PAIR_STRING_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["SQLite"], ["VL_MAP", "VL_STRING", ["PAIR", "STRING", ["VECTOR", "DOUBLE"]]], true]
-  VL_MAP_STRING_PAIR_VL_STRING_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["SQLite"], ["VL_MAP", "STRING", ["PAIR", "VL_STRING", ["VECTOR", "DOUBLE"]]], true]
-  VL_MAP_STRING_PAIR_STRING_VL_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["SQLite"], ["VL_MAP", "STRING", ["PAIR", "STRING", ["VL_VECTOR", "DOUBLE"]]], true]
-  VL_MAP_VL_STRING_PAIR_VL_STRING_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["SQLite"], ["VL_MAP", "VL_STRING", ["PAIR", "VL_STRING", ["VECTOR", "DOUBLE"]]], true]
-  VL_MAP_VL_STRING_PAIR_STRING_VL_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["SQLite"], ["VL_MAP", "VL_STRING", ["PAIR", "STRING", ["VL_VECTOR", "DOUBLE"]]], true]
-  VL_MAP_STRING_PAIR_VL_STRING_VL_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["SQLite"], ["VL_MAP", "STRING", ["PAIR", "VL_STRING", ["VL_VECTOR", "DOUBLE"]]], true]
-  VL_MAP_VL_STRING_PAIR_VL_STRING_VL_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["SQLite"], ["VL_MAP", "VL_STRING", ["PAIR", "VL_STRING", ["VL_VECTOR", "DOUBLE"]]], true]
+  MAP_STRING_PAIR_STRING_VL_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["HDF5", "SQLite"], ["MAP", "STRING", ["PAIR", "STRING", ["VL_VECTOR", "DOUBLE"]]], false]
+  MAP_STRING_PAIR_VL_STRING_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["HDF5", "SQLite"], ["MAP", "STRING", ["PAIR", "VL_STRING", ["VECTOR", "DOUBLE"]]], false]
+  MAP_STRING_PAIR_VL_STRING_VL_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["HDF5", "SQLite"], ["MAP", "STRING", ["PAIR", "VL_STRING", ["VL_VECTOR", "DOUBLE"]]], false]
+  MAP_VL_STRING_PAIR_STRING_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["HDF5", "SQLite"], ["MAP", "VL_STRING", ["PAIR", "STRING", ["VECTOR", "DOUBLE"]]], false]
+  MAP_VL_STRING_PAIR_VL_STRING_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["HDF5", "SQLite"], ["MAP", "VL_STRING", ["PAIR", "VL_STRING", ["VECTOR", "DOUBLE"]]], false]
+  MAP_VL_STRING_PAIR_STRING_VL_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["HDF5", "SQLite"], ["MAP", "VL_STRING", ["PAIR", "STRING", ["VL_VECTOR", "DOUBLE"]]], false]
+  MAP_VL_STRING_PAIR_VL_STRING_VL_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["HDF5", "SQLite"], ["MAP", "VL_STRING", ["PAIR", "VL_STRING", ["VL_VECTOR", "DOUBLE"]]], false]
+  VL_MAP_STRING_PAIR_STRING_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["HDF5", "SQLite"], ["VL_MAP", "STRING", ["PAIR", "STRING", ["VECTOR", "DOUBLE"]]], true]
+  VL_MAP_VL_STRING_PAIR_STRING_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["HDF5", "SQLite"], ["VL_MAP", "VL_STRING", ["PAIR", "STRING", ["VECTOR", "DOUBLE"]]], true]
+  VL_MAP_STRING_PAIR_VL_STRING_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["HDF5", "SQLite"], ["VL_MAP", "STRING", ["PAIR", "VL_STRING", ["VECTOR", "DOUBLE"]]], true]
+  VL_MAP_STRING_PAIR_STRING_VL_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["HDF5", "SQLite"], ["VL_MAP", "STRING", ["PAIR", "STRING", ["VL_VECTOR", "DOUBLE"]]], true]
+  VL_MAP_VL_STRING_PAIR_VL_STRING_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["HDF5", "SQLite"], ["VL_MAP", "VL_STRING", ["PAIR", "VL_STRING", ["VECTOR", "DOUBLE"]]], true]
+  VL_MAP_VL_STRING_PAIR_STRING_VL_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["HDF5", "SQLite"], ["VL_MAP", "VL_STRING", ["PAIR", "STRING", ["VL_VECTOR", "DOUBLE"]]], true]
+  VL_MAP_STRING_PAIR_VL_STRING_VL_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["HDF5", "SQLite"], ["VL_MAP", "STRING", ["PAIR", "VL_STRING", ["VL_VECTOR", "DOUBLE"]]], true]
+  VL_MAP_VL_STRING_PAIR_VL_STRING_VL_VECTOR_DOUBLE,  // ["std::map<std::string, std::pair<std::string, std::vector<double>>>", 5, ["HDF5", "SQLite"], ["VL_MAP", "VL_STRING", ["PAIR", "VL_STRING", ["VL_VECTOR", "DOUBLE"]]], true]
 
   // map<string,  map<string,  int> >
   MAP_STRING_MAP_STRING_INT,  // ["std::map<std::string, std::map<std::string, int>>", 3, ["SQLite"], ["MAP", "STRING", ["MAP", "STRING", "INT"]], false]
@@ -333,9 +333,9 @@ enum DbTypes {
   VL_VECTOR_PAIR_INT_PAIR_VL_STRING_VL_STRING, // ["std::vector<std::pair<int, std::pair<std::string, std::string>>>", 1, ["HDF5"], ["VL_VECTOR", ["PAIR", "INT", ["PAIR", "VL_STRING", "VL_STRING"]]], true]
   
   PAIR_STRING_VECTOR_DOUBLE, // ["std::pair<std::string, std::vector<double>>", 1, ["HDF5"], ["PAIR", "STRING", ["VECTOR", "DOUBLE"]], false]
-  PAIR_VL_STRING_VECTOR_DOUBLE, // ["std::pair<std::string, std::vector<double>>", 1, [], ["PAIR", "VL_STRING", ["VECTOR", "DOUBLE"]], false]
-  PAIR_STRING_VL_VECTOR_DOUBLE, // ["std::pair<std::string, std::vector<double>>", 1, [], ["PAIR", "STRING", ["VL_VECTOR", "DOUBLE"]], false]
-  PAIR_VL_STRING_VL_VECTOR_DOUBLE, // ["std::pair<std::string, std::vector<double>>", 1, [], ["PAIR", "VL_STRING", ["VL_VECTOR", "DOUBLE"]], false]
+  PAIR_VL_STRING_VECTOR_DOUBLE, // ["std::pair<std::string, std::vector<double>>", 1, ["HDF5"], ["PAIR", "VL_STRING", ["VECTOR", "DOUBLE"]], false]
+  PAIR_STRING_VL_VECTOR_DOUBLE, // ["std::pair<std::string, std::vector<double>>", 1, ["HDF5"], ["PAIR", "STRING", ["VL_VECTOR", "DOUBLE"]], false]
+  PAIR_VL_STRING_VL_VECTOR_DOUBLE, // ["std::pair<std::string, std::vector<double>>", 1, ["HDF5"], ["PAIR", "VL_STRING", ["VL_VECTOR", "DOUBLE"]], false]
   
   // append new types only:
 };
@@ -968,6 +968,19 @@ class Sha1 {
     std::list<std::pair<int, int>>::const_iterator it = x.begin();
     for (; it != x.end(); ++it) {
       Update(*it);
+    }
+  }
+  
+  inline void Update(const std::pair<std::string, std::vector<double>>& x) {
+    hash_.process_bytes(x.first.c_str(), x.first.size());
+    Update(x.second);
+  }
+  
+  inline void Update(const std::map<std::string, std::pair<std::string, std::vector<double>>>& x) {
+    std::map<std::string, std::pair<std::string, std::vector<double>>>::const_iterator it = x.begin();
+    for(; it != x.end(); ++it) {
+      hash_.process_bytes(it->first.c_str(), it->first.size());
+      Update(it->second);
     }
   }
   

--- a/src/query_backend.h
+++ b/src/query_backend.h
@@ -281,14 +281,14 @@ enum DbTypes {
   VL_MAP_VL_STRING_VL_MAP_VL_STRING_INT,  // ["std::map<std::string, std::map<std::string, int>>", 3, ["HDF5", "SQLite"], ["VL_MAP", "VL_STRING", ["VL_MAP", "VL_STRING", "INT"]], true]
 
   // vector<pair<pair<double, double>, map<string, double>>>
-  VECTOR_PAIR_PAIR_DOUBLE_DOUBLE_MAP_STRING_DOUBLE, // ["std::vector<std::pair<std::pair<double, double>, std::map<std::string, double> > >", 5, ["SQLite"], ["VECTOR", ["PAIR", ["PAIR", "DOUBLE", "DOUBLE"], ["MAP", "STRING", "DOUBLE"]]], false]
-  VECTOR_PAIR_PAIR_DOUBLE_DOUBLE_MAP_VL_STRING_DOUBLE, // ["std::vector<std::pair<std::pair<double, double>, std::map<std::string, double> > > ", 5, ["SQLite"], ["VECTOR", ["PAIR", ["PAIR", "DOUBLE", "DOUBLE"], ["MAP", "VL_STRING", "DOUBLE"]]], false]
-  VECTOR_PAIR_PAIR_DOUBLE_DOUBLE_VL_MAP_STRING_DOUBLE, // ["std::vector<std::pair<std::pair<double, double>, std::map<std::string, double> > > ", 5, ["SQLite"], ["VECTOR", ["PAIR", ["PAIR", "DOUBLE", "DOUBLE"], ["VL_MAP", "STRING", "DOUBLE"]]], false]
-  VECTOR_PAIR_PAIR_DOUBLE_DOUBLE_VL_MAP_VL_STRING_DOUBLE, // ["std::vector<std::pair<std::pair<double, double>, std::map<std::string, double> > > ", 5, ["SQLite"], ["VECTOR", ["PAIR", ["PAIR", "DOUBLE", "DOUBLE"], ["VL_MAP", "VL_STRING", "DOUBLE"]]], false]
-  VL_VECTOR_PAIR_PAIR_DOUBLE_DOUBLE_MAP_STRING_DOUBLE, // ["std::vector<std::pair<std::pair<double, double>, std::map<std::string, double> > >", 5, ["SQLite"], ["VL_VECTOR", ["PAIR", ["PAIR", "DOUBLE", "DOUBLE"], ["MAP", "STRING", "DOUBLE"]]], false]
-  VL_VECTOR_PAIR_PAIR_DOUBLE_DOUBLE_MAP_VL_STRING_DOUBLE, // ["std::vector<std::pair<std::pair<double, double>, std::map<std::string, double> > > ", 5, ["SQLite"], ["VL_VECTOR", ["PAIR", ["PAIR", "DOUBLE", "DOUBLE"], ["MAP", "VL_STRING", "DOUBLE"]]], false]
-  VL_VECTOR_PAIR_PAIR_DOUBLE_DOUBLE_VL_MAP_STRING_DOUBLE, // ["std::vector<std::pair<std::pair<double, double>, std::map<std::string, double> > > ", 5, ["SQLite"], ["VL_VECTOR", ["PAIR", ["PAIR", "DOUBLE", "DOUBLE"], ["VL_MAP", "STRING", "DOUBLE"]]], false]
-  VL_VECTOR_PAIR_PAIR_DOUBLE_DOUBLE_VL_MAP_VL_STRING_DOUBLE, // ["std::vector<std::pair<std::pair<double, double>, std::map<std::string, double> > >", 5, ["SQLite"], ["VL_VECTOR", ["PAIR", ["PAIR", "DOUBLE", "DOUBLE"], ["VL_MAP", "VL_STRING", "DOUBLE"]]], false]
+  VECTOR_PAIR_PAIR_DOUBLE_DOUBLE_MAP_STRING_DOUBLE, // ["std::vector<std::pair<std::pair<double, double>, std::map<std::string, double>>>", 5, ["HDF5", "SQLite"], ["VECTOR", ["PAIR", ["PAIR", "DOUBLE", "DOUBLE"], ["MAP", "STRING", "DOUBLE"]]], false]
+  VECTOR_PAIR_PAIR_DOUBLE_DOUBLE_MAP_VL_STRING_DOUBLE, // ["std::vector<std::pair<std::pair<double, double>, std::map<std::string, double>>>", 5, ["HDF5", "SQLite"], ["VECTOR", ["PAIR", ["PAIR", "DOUBLE", "DOUBLE"], ["MAP", "VL_STRING", "DOUBLE"]]], false]
+  VECTOR_PAIR_PAIR_DOUBLE_DOUBLE_VL_MAP_STRING_DOUBLE, // ["std::vector<std::pair<std::pair<double, double>, std::map<std::string, double>>>", 5, ["HDF5", "SQLite"], ["VECTOR", ["PAIR", ["PAIR", "DOUBLE", "DOUBLE"], ["VL_MAP", "STRING", "DOUBLE"]]], false]
+  VECTOR_PAIR_PAIR_DOUBLE_DOUBLE_VL_MAP_VL_STRING_DOUBLE, // ["std::vector<std::pair<std::pair<double, double>, std::map<std::string, double>>>", 5, ["HDF5", "SQLite"], ["VECTOR", ["PAIR", ["PAIR", "DOUBLE", "DOUBLE"], ["VL_MAP", "VL_STRING", "DOUBLE"]]], false]
+  VL_VECTOR_PAIR_PAIR_DOUBLE_DOUBLE_MAP_STRING_DOUBLE, // ["std::vector<std::pair<std::pair<double, double>, std::map<std::string, double>>>", 5, ["HDF5", "SQLite"], ["VL_VECTOR", ["PAIR", ["PAIR", "DOUBLE", "DOUBLE"], ["MAP", "STRING", "DOUBLE"]]], true]
+  VL_VECTOR_PAIR_PAIR_DOUBLE_DOUBLE_MAP_VL_STRING_DOUBLE, // ["std::vector<std::pair<std::pair<double, double>, std::map<std::string, double>>>", 5, ["HDF5", "SQLite"], ["VL_VECTOR", ["PAIR", ["PAIR", "DOUBLE", "DOUBLE"], ["MAP", "VL_STRING", "DOUBLE"]]], true]
+  VL_VECTOR_PAIR_PAIR_DOUBLE_DOUBLE_VL_MAP_STRING_DOUBLE, // ["std::vector<std::pair<std::pair<double, double>, std::map<std::string, double>>>", 5, ["HDF5", "SQLite"], ["VL_VECTOR", ["PAIR", ["PAIR", "DOUBLE", "DOUBLE"], ["VL_MAP", "STRING", "DOUBLE"]]], true]
+  VL_VECTOR_PAIR_PAIR_DOUBLE_DOUBLE_VL_MAP_VL_STRING_DOUBLE, // ["std::vector<std::pair<std::pair<double, double>, std::map<std::string, double>>>", 5, ["HDF5", "SQLite"], ["VL_VECTOR", ["PAIR", ["PAIR", "DOUBLE", "DOUBLE"], ["VL_MAP", "VL_STRING", "DOUBLE"]]], true]
 
   // pair<int, pair<string, string>>
   PAIR_INT_PAIR_STRING_STRING,  // ["std::pair<int, std::pair<std::string, std::string>>", 2, ["HDF5"], ["PAIR", "INT", ["PAIR", "STRING", "STRING"]], false]
@@ -297,13 +297,13 @@ enum DbTypes {
   PAIR_INT_PAIR_VL_STRING_VL_STRING,  // ["std::pair<int, std::pair<std::string, std::string>>", 2, ["HDF5"], ["PAIR", "INT", ["PAIR", "VL_STRING", "VL_STRING"]], false]
 
   // pair<double, double>
-  PAIR_DOUBLE_DOUBLE,  // ["std::pair<double, double>", 0, [], ["PAIR", "DOUBLE", "DOUBLE"], false]
+  PAIR_DOUBLE_DOUBLE,  // ["std::pair<double, double>", 0, ["HDF5"], ["PAIR", "DOUBLE", "DOUBLE"], false]
 
   // pair<pair<double, double>, map<string, double>>
-  PAIR_PAIR_DOUBLE_DOUBLE_MAP_STRING_DOUBLE,        // ["std::pair<std::pair<double, double>, std::map<std::string, double>>", 4, [], ["PAIR", ["PAIR", "DOUBLE", "DOUBLE"], ["MAP", "STRING", "DOUBLE"]], false]
-  PAIR_PAIR_DOUBLE_DOUBLE_MAP_VL_STRING_DOUBLE,     // ["std::pair<std::pair<double, double>, std::map<std::string, double>>", 4, [], ["PAIR", ["PAIR", "DOUBLE", "DOUBLE"], ["MAP", "VL_STRING", "DOUBLE"]], false]
-  PAIR_PAIR_DOUBLE_DOUBLE_VL_MAP_STRING_DOUBLE,     // ["std::pair<std::pair<double, double>, std::map<std::string, double>>", 4, [], ["PAIR", ["PAIR", "DOUBLE", "DOUBLE"], ["VL_MAP", "STRING", "DOUBLE"]], false]
-  PAIR_PAIR_DOUBLE_DOUBLE_VL_MAP_VL_STRING_DOUBLE,  // ["std::pair<std::pair<double, double>, std::map<std::string, double>>", 4, [], ["PAIR", ["PAIR", "DOUBLE", "DOUBLE"], ["VL_MAP", "VL_STRING", "DOUBLE"]], false]   
+  PAIR_PAIR_DOUBLE_DOUBLE_MAP_STRING_DOUBLE,        // ["std::pair<std::pair<double, double>, std::map<std::string, double>>", 4, ["HDF5"], ["PAIR", ["PAIR", "DOUBLE", "DOUBLE"], ["MAP", "STRING", "DOUBLE"]], false]
+  PAIR_PAIR_DOUBLE_DOUBLE_MAP_VL_STRING_DOUBLE,     // ["std::pair<std::pair<double, double>, std::map<std::string, double>>", 4, ["HDF5"], ["PAIR", ["PAIR", "DOUBLE", "DOUBLE"], ["MAP", "VL_STRING", "DOUBLE"]], false]
+  PAIR_PAIR_DOUBLE_DOUBLE_VL_MAP_STRING_DOUBLE,     // ["std::pair<std::pair<double, double>, std::map<std::string, double>>", 4, ["HDF5"], ["PAIR", ["PAIR", "DOUBLE", "DOUBLE"], ["VL_MAP", "STRING", "DOUBLE"]], false]
+  PAIR_PAIR_DOUBLE_DOUBLE_VL_MAP_VL_STRING_DOUBLE,  // ["std::pair<std::pair<double, double>, std::map<std::string, double>>", 4, ["HDF5"], ["PAIR", ["PAIR", "DOUBLE", "DOUBLE"], ["VL_MAP", "VL_STRING", "DOUBLE"]], false]   
 
   // Resource Tools
   MATERIAL,  // ["cyclus::Material", 0, [], "MATERIAL", fasle]
@@ -989,6 +989,23 @@ class Sha1 {
     for(; it != x.end(); ++it) {
       hash_.process_bytes(it->first.c_str(), it->first.size());
       Update(it->second);
+    }
+  }
+  
+  inline void Update(const std::pair<double, double>& x) {
+    hash_.process_bytes(&(x.first), sizeof(double));
+    hash_.process_bytes(&(x.second), sizeof(double));
+  }
+  
+  inline void Update(const std::pair<std::pair<double, double>, std::map<std::string, double>>& x) {
+    Update(x.first);
+    Update(x.second);
+  }
+  
+  inline void Update(const std::vector<std::pair<std::pair<double, double>, std::map<std::string, double>>>& x) {
+    std::vector<std::pair<std::pair<double, double>, std::map<std::string, double>>>::const_iterator it = x.begin();
+    for(; it != x.end(); ++it) {
+      Update(*it);
     }
   }
   


### PR DESCRIPTION
With the addition of these types: 
- LIST_PAIR_INT_INT
- MAP_STRING_PAIR_STRING_VECTOR_DOUBLE
- MAP_STRING_MAP_STRING_INT
- VECTOR_PAIR_PAIR_DOUBLE_DOUBLE_MAP_STRING_DOUBLE

(and their variations), the Hdf5 backend now supports all SQLite-supported datatypes.

Types in `query_backend.h` that are not supported yet:
- Cyclus resource types 
- (VL_)VECTOR_BOOL (requires specialization, in progress)
- (VL_)SET_BOOL (requires some restraints I haven't yet implemented)

@scopatz 