### PR TITLE
Fix for Hdf5Back::Schema

### DIFF
--- a/src/hdf5_back.cc.in
+++ b/src/hdf5_back.cc.in
@@ -393,14 +393,26 @@ void Hdf5Back::CreateTable(Datum* d) {
   for(int i = 0; i < nvals; ++i) {
     shape = shapes[i];
     hsize_t nshape = shape.size();
-    attr_space = H5Screate_simple(1, &nshape, &nshape);
+    // if no shape is present, we set a primitive size of 1.
+    if(shape.size() == 0) {
+      nshape = 1;
+    }
+    hid_t shape_space = H5Screate_simple(1, &nshape, &nshape);
+    std::vector<int> shape_vector;
+    for(int j = 0; j < shape.size(); ++j) {
+      shape_vector.push_back(shape[j]);
+    }
+    // default shape value is -1, which denotes primitives 
+    if(shape.size() == 0) {
+      shape_vector.push_back(-1);
+    }
     std::stringstream col_name;
     col_name << "shape" << i;
     hid_t shape_attr = H5Acreate2(tb_set, col_name.str().c_str(), H5T_NATIVE_INT, 
-                                  attr_space, H5P_DEFAULT, H5P_DEFAULT);
-    H5Awrite(shape_attr, H5T_NATIVE_INT, &shape);
+                                  shape_space, H5P_DEFAULT, H5P_DEFAULT);
+    H5Awrite(shape_attr, H5T_NATIVE_INT, &shape_vector[0]);
     H5Aclose(shape_attr);
-    H5Sclose(attr_space);
+    H5Sclose(shape_space);
   }
   H5Dclose(tb_set);
 
@@ -443,26 +455,29 @@ std::list<ColumnInfo> Hdf5Back::Schema(std::string table) {
   hid_t tb_set = H5Dopen2(file_, table.c_str(), H5P_DEFAULT);
   hid_t tb_type = H5Dget_type(tb_set);
   int i;
-  char * colname;
   hsize_t ncols = H5Tget_nmembers(tb_type);
   LoadTableTypes(table, tb_set, ncols);
   DbTypes* dbtypes = schemas_[table];
+  char * colname;
     
   for (i = 0; i < ncols; ++i) {
     colname = H5Tget_member_name(tb_type, i);
     std::stringstream attr_name;
     attr_name << "shape" << i;
     hid_t attr_id = H5Aopen_by_name(tb_set, ".", attr_name.str().c_str(), H5P_DEFAULT, H5P_DEFAULT);
-    hid_t attr_type = H5Aget_type(attr_id);
     hid_t attr_space = H5Aget_space(attr_id);
-    hsize_t nshape;
-    H5Sget_simple_extent_dims(attr_space, &nshape, NULL);
-    std::vector<int> shape(nshape);
-    H5Aread(attr_id, attr_type, &shape);
-    ColumnInfo info = ColumnInfo(table, colname, i, dbtypes[i], shape);
-    schema.push_back(info); 
+    int ndims = H5Sget_simple_extent_ndims(attr_space);
+    std::vector<int> shape(ndims);
+    H5Aread(attr_id, H5T_NATIVE_INT, &shape[0]);
+    std::string colname_str = std::string(colname);
+    ColumnInfo info = ColumnInfo(table, colname_str, i, dbtypes[i], shape);
+    schema.push_back(info);
     free(colname);
+    H5Sclose(attr_space);
+    H5Aclose(attr_id);
   }
+  H5Tclose(tb_type);
+  H5Dclose(tb_set);
   
   return schema;
 }
@@ -483,7 +498,12 @@ std::set<std::string> Hdf5Back::Tables() {
                                  NULL, 0, H5P_DEFAULT);
     H5Lget_name_by_idx(root, ".", H5_INDEX_NAME, H5_ITER_NATIVE, i,
                        name, namelen+1, H5P_DEFAULT);
-    rtn.insert(string(name, namelen));
+    std::string str_name = std::string(name, namelen);
+    if (str_name.size() >= 4 && str_name.substr(str_name.size()-4) != "Keys" && str_name.substr(str_name.size()-4) != "Vals") {
+        rtn.insert(str_name);
+    } else if (str_name.size() < 4) {
+        rtn.insert(str_name);
+    }
   }
   H5Gclose(root);
   return rtn;

--- a/src/sqlite_back.cc
+++ b/src/sqlite_back.cc
@@ -154,6 +154,7 @@ std::set<std::string> SqliteBack::Tables() {
   while (stmt->Step()) {
     rtn.insert(stmt->GetText(0, NULL));
   }
+  rtn.erase("FieldTypes");
   return rtn;
 }
 

--- a/tests/test_cycluslib.py
+++ b/tests/test_cycluslib.py
@@ -54,7 +54,8 @@ def test_schema(db, fname, backend):
         assert_equal(cols[i], ci.col)
         assert_equal(dbs[i], ci.dbtype)
         assert_equal(i, ci.index)
-        assert_equal(0, len(ci.shape))
+        assert_equal(1, len(ci.shape))
+        assert_equal(-1, ci.shape)
 
 if __name__ == "__main__":
     nose.runmodule()


### PR DESCRIPTION
This PR fixes a few Hdf5-related bugs that allow Schema to function properly. The main problem was reading and writing the shape attribute- this now works. 

@scopatz 