### PR TITLE
changes for hdf5 table merging

### DIFF
--- a/src/hdf5_back.cc.in
+++ b/src/hdf5_back.cc.in
@@ -80,7 +80,7 @@ void Hdf5Back::Notify(DatumList data) {
     std::string name = (*it)->title();
     if (schema_sizes_.count(name) == 0) {
       if (H5Lexists(file_, name.c_str(), H5P_DEFAULT)) {
-        LoadTableTypes(name, (*it)->vals().size());
+        LoadTableTypes(name, (*it)->vals().size(), *it);
       } else {
         // Datum* d = *it;
         // CreateTable(d);
@@ -271,10 +271,15 @@ QueryResult Hdf5Back::GetTableInfo(std::string title, hid_t dset, hid_t dt) {
   return qr;
 }
 
-void Hdf5Back::LoadTableTypes(std::string title, hsize_t ncols) {
+void Hdf5Back::LoadTableTypes(std::string title, hsize_t ncols, Datum *d) {
   if (schemas_.count(title) > 0)
     return;
+    
   hid_t dset = H5Dopen2(file_, title.c_str(), H5P_DEFAULT);
+  if(dset < 0) {
+    CreateTable(d);
+    return;
+  }
   LoadTableTypes(title, dset, ncols);
   H5Dclose(dset);
 }

--- a/src/hdf5_back.h.in
+++ b/src/hdf5_back.h.in
@@ -104,7 +104,7 @@ class Hdf5Back : public FullBackend {
 
   /// Reads a table's column types into schemas_ if they aren't already there
   /// \{
-  void LoadTableTypes(std::string title, hsize_t ncols);
+  void LoadTableTypes(std::string title, hsize_t ncols, Datum *d);
   void LoadTableTypes(std::string title, hid_t dset, hsize_t ncols);
   /// \}
 


### PR DESCRIPTION
LoadTableTypes now calls CreateTable when an unrecognized table is being added. This is required for merging two Hdf5 output files together if the same tables are not present in both.