### PR TITLE
Triggering Cycamore/Cymetric -- switching to CircleCI 2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,0 @@
-./docker/cyclus-ci/Dockerfile

--- a/README.rst
+++ b/README.rst
@@ -7,20 +7,20 @@ information on the entire "ecosystem" please refer to the `Cyclus website
 <http://fuelcycle.org>`_.
 
 
-================    ==================    ==================
-Cyclus Projects Status
------------------------------------------------------------- 
-   **Cyclus**         **Cycamore**           **Cymetric** 
-================    ==================    ==================
-|cyclus_status|     |cycamore_status|     |cymetric_status|
-================    ==================    ==================
-
-
-
-.. |cyclus_status| image:: https://circleci.com/gh/cyclus/cyclus/tree/develop.png?&amp;circle-token= 35d82ba8661d4f32e0f084b9d8a2388fa62c0262
-.. |cycamore_status| image:: https://circleci.com/gh/cyclus/cycamore/tree/develop.png?&amp;circle-token= 333211090d5d5a15110eed1adbe079a6f3a4a704
-.. |cymetric_status| image:: https://circleci.com/gh/cyclus/cymetric/tree/develop.png?&amp;circle-token= 72639b59387f077973af98e7ce72996eac18b96c
-
+.. ================    ==================    ==================
+.. Cyclus Projects Status
+.. ------------------------------------------------------------ 
+..    **Cyclus**         **Cycamore**           **Cymetric** 
+.. ================    ==================    ==================
+.. |cyclus_status|     |cycamore_status|     |cymetric_status|
+.. ================    ==================    ==================
+.. 
+.. 
+.. 
+.. .. |cyclus_status| image:: https://circleci.com/gh/cyclus/cyclus/tree/develop.png?&amp;circle-token= 35d82ba8661d4f32e0f084b9d8a2388fa62c0262
+.. .. |cycamore_status| image:: https://circleci.com/gh/cyclus/cycamore/tree/develop.png?&amp;circle-token= 333211090d5d5a15110eed1adbe079a6f3a4a704
+.. .. |cymetric_status| image:: https://circleci.com/gh/cyclus/cymetric/tree/develop.png?&amp;circle-token= 72639b59387f077973af98e7ce72996eac18b96c
+.. 
 
 
 ###########

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,6 @@ Cyclus Projects Status
 **Branch**              **Cyclus**         **Cycamore**           **Cymetric** 
 ================    =================    ===================    ===================
 master              |cyclus_master|       |cycamore_master|      |cymetric_master|
-================    =================    ===================    ===================
 develop             |cyclus_develop|      |cycamore_develop|     |cymetric_develop|
 ================    =================    ===================    ===================
 

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ information on the entire "ecosystem" please refer to the `Cyclus website
 ================    ================    ==================    ==================
 Cyclus Projects Status
 -------------------------------------------------------------------------------- 
-**Branch**   **Cyclus**         **Cycamore**           **Cymetric** 
+**Branch**              **Cyclus**         **Cycamore**           **Cymetric** 
 ================    ================    ==================    ==================
 master              |cyclusi_master|    |cycamore_master|     |cymetric_master|
 ================    ================    ==================    ==================

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ information on the entire "ecosystem" please refer to the `Cyclus website
 
 ================    ================    ==================    ==================
 Cyclus Projects Status
------------------------------------------------------------- 
+-------------------------------------------------------------------------------- 
 **Branch**   **Cyclus**         **Cycamore**           **Cymetric** 
 ================    ================    ==================    ==================
 master              |cyclusi_master|    |cycamore_master|     |cymetric_master|

--- a/README.rst
+++ b/README.rst
@@ -7,15 +7,15 @@ information on the entire "ecosystem" please refer to the `Cyclus website
 <http://fuelcycle.org>`_.
 
 
-================    ================    ==================    ==================
+================    =================    ===================    ===================
 Cyclus Projects Status
 -------------------------------------------------------------------------------- 
 **Branch**              **Cyclus**         **Cycamore**           **Cymetric** 
-================    ================    ==================    ==================
-master              |cyclusi_master|    |cycamore_master|     |cymetric_master|
-================    ================    ==================    ==================
-develop             |cyclus_develop|    |cycamore_develop|    |cymetric_develop|
-================    ================    ==================    ==================
+================    =================    ===================    ===================
+master              |cyclus_master|       |cycamore_master|      |cymetric_master|
+================    =================    ===================    ===================
+develop             |cyclus_develop|      |cycamore_develop|     |cymetric_develop|
+================    =================    ===================    ===================
 
 
 .. |cyclus_develop| image:: https://circleci.com/gh/cyclus/cyclus/tree/develop.png?&amp;circle-token= 35d82ba8661d4f32e0f084b9d8a2388fa62c0262

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ information on the entire "ecosystem" please refer to the `Cyclus website
 
 ================    =================    ===================    ===================
 Cyclus Projects Status
--------------------------------------------------------------------------------- 
+----------------------------------------------------------------------------------- 
 **Branch**              **Cyclus**         **Cycamore**           **Cymetric** 
 ================    =================    ===================    ===================
 master              |cyclus_master|       |cycamore_master|      |cymetric_master|

--- a/README.rst
+++ b/README.rst
@@ -7,20 +7,24 @@ information on the entire "ecosystem" please refer to the `Cyclus website
 <http://fuelcycle.org>`_.
 
 
-.. ================    ==================    ==================
-.. Cyclus Projects Status
-.. ------------------------------------------------------------ 
-..    **Cyclus**         **Cycamore**           **Cymetric** 
-.. ================    ==================    ==================
-.. |cyclus_status|     |cycamore_status|     |cymetric_status|
-.. ================    ==================    ==================
-.. 
-.. 
-.. 
-.. .. |cyclus_status| image:: https://circleci.com/gh/cyclus/cyclus/tree/develop.png?&amp;circle-token= 35d82ba8661d4f32e0f084b9d8a2388fa62c0262
-.. .. |cycamore_status| image:: https://circleci.com/gh/cyclus/cycamore/tree/develop.png?&amp;circle-token= 333211090d5d5a15110eed1adbe079a6f3a4a704
-.. .. |cymetric_status| image:: https://circleci.com/gh/cyclus/cymetric/tree/develop.png?&amp;circle-token= 72639b59387f077973af98e7ce72996eac18b96c
-.. 
+================    ================    ==================    ==================
+Cyclus Projects Status
+------------------------------------------------------------ 
+**Branch**   **Cyclus**         **Cycamore**           **Cymetric** 
+================    ================    ==================    ==================
+master              |cyclusi_master|    |cycamore_master|     |cymetric_master|
+================    ================    ==================    ==================
+develop             |cyclus_develop|    |cycamore_develop|    |cymetric_develop|
+================    ================    ==================    ==================
+
+
+.. |cyclus_develop| image:: https://circleci.com/gh/cyclus/cyclus/tree/develop.png?&amp;circle-token= 35d82ba8661d4f32e0f084b9d8a2388fa62c0262
+.. |cycamore_develop| image:: https://circleci.com/gh/cyclus/cycamore/tree/develop.png?&amp;circle-token= 333211090d5d5a15110eed1adbe079a6f3a4a704
+.. |cymetric_develop| image:: https://circleci.com/gh/cyclus/cymetric/tree/develop.png?&amp;circle-token= 72639b59387f077973af98e7ce72996eac18b96c
+.. |cyclus_master| image:: https://circleci.com/gh/cyclus/cyclus/tree/master.png?&amp;circle-token= 35d82ba8661d4f32e0f084b9d8a2388fa62c0262
+.. |cycamore_master| image:: https://circleci.com/gh/cyclus/cycamore/tree/master.png?&amp;circle-token= 333211090d5d5a15110eed1adbe079a6f3a4a704
+.. |cymetric_master| image:: https://circleci.com/gh/cyclus/cymetric/tree/master.png?&amp;circle-token= 72639b59387f077973af98e7ce72996eac18b96c
+
 
 
 ###########

--- a/circle.yml
+++ b/circle.yml
@@ -86,9 +86,10 @@ jobs:
                   curl -o ./bin/circleci https://raw.githubusercontent.com/rockymadden/circleci-cli/master/src/circleci 
                   chmod 755 ./bin/circleci
 
-                  curl --user ${CYCAMORE_CIRCLE_TOKEN}: \
+                  build_num=` curl --user ${CYCAMORE_CIRCLE_TOKEN}: \
                   --data build_parameters[CIRCLE_JOB]=empty_test \
-                  https://circleci.com/api/v1.1/project/github/cyclus/cycamore/tree/ci-test
+                  https://circleci.com/api/v1.1/project/github/cyclus/cycamore/tree/ci-test |grep build_num | cut -d"\'"" -f3 |cut -d"," -f1`
+                  echo ${build_num}
                   job_name=`./bin/circleci await cyclus/cycamore |grep outcome |cut -d"\"" -f4`
                   if [[ "$job_name" == "success" ]] ; then
                     exit 0;

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,7 @@
 version: 2
 
 jobs:
+    # Build Cyclus
     build:
         docker:
             - image: cyclus/cyclus-deps
@@ -21,7 +22,9 @@ jobs:
                 paths:
                   - /root
 
-    deploy_latest:
+
+    # Update docker container
+    deploy_latest: # Cyclus/dev -> Cyclus:latest
         docker:
             - image: circleci/ruby:2.4-node
         working_directory: ~/cyclus
@@ -43,7 +46,7 @@ jobs:
                 command: docker push cyclus/cyclus:latest # push to docker depot
 
     deploy_stable:
-        docker:
+        docker: # Cyclus/master -> Cyclus:stable
             - image: circleci/ruby:2.4-node
         working_directory: ~/cyclus
         steps:
@@ -62,6 +65,8 @@ jobs:
                   docker tag cyclus/cyclus:latest cyclus/cyclus:stable # creation
                   docker push cyclus/cyclus:stable # push to docker depot
 
+
+    # Debian package generation (on master update)
     deb_generation:
         docker:
             - image: circleci/ruby:2.4-node
@@ -75,7 +80,9 @@ jobs:
                   docker/deb-ci/build_upload_deb.sh 14
                   docker/deb-ci/build_upload_deb.sh 16
     
-    empty_test:
+
+    # External Triggers
+    cycamore_master: ## Cycamore/master against Cyclus/dev
         machine: true
         steps:
             - run:
@@ -88,12 +95,10 @@ jobs:
                   chmod 755 ./bin/circleci
 
                   build_num=`curl --user ${CYCAMORE_CIRCLE_TOKEN}: \
-                  --data build_parameters[CIRCLE_JOB]=empty_test \
-                  https://circleci.com/api/v1.1/project/github/cyclus/cycamore/tree/ci-test | \
+                  --data build_parameters[CIRCLE_JOB]=cyclus_dev_cycamore_master \
+                  https://circleci.com/api/v1.1/project/github/cyclus/cycamore/tree/develop | \
                   grep build_num | cut -d":" -f2 |cut -d"," -f1 | tail -n 2 | head -n 1`
                   build_num="$(echo -e "${build_num}" | tr -d '[:space:]')"
-                  echo "Build_num: ${build_num}"
-                  echo "./bin/circleci await cyclus/cycamore ${build_num#0} |grep \"outcome\" |cut -d"\"" -f4"
                   ./bin/circleci init --token $CYCAMORE_CIRCLE_TOKEN
                   job_name=`./bin/circleci await cyclus/cycamore ${build_num} |grep \"outcome\" |cut -d"\"" -f4`
                   if [[ "$job_name" == "success" ]] ; then
@@ -102,12 +107,12 @@ jobs:
                     exit 1;
                   fi
 
-
-    test_cycamore:
+    cycamore_dev: ## Cycamore/dev against Cyclus/dev
         machine: true
         steps:
             - run:
                 name: Cycamore/Cymetric 
+                no_output_timeout: "20m"
                 command: |
                   # Install circleci 
                   mkdir ./bin
@@ -123,12 +128,12 @@ jobs:
                   else 
                     exit 1;
                   fi
-                no_output_timeout: "20m"
-    test_cymetric:
+    cymetric_dev: ## Cymetric/dev against Cyclus/dev + Cyacamore/dev
         machine: true
         steps:
             - run:
                 name: Cycamore/Cymetric tests
+                no_output_timeout: "20m"
                 command: |
                   # Install dependencies
                   mkdir ./bin
@@ -144,8 +149,8 @@ jobs:
                   else 
                     exit 1;
                   fi
-                no_output_timeout: "20m"
 
+    # Test Jobs
     unit_test:
         docker:
             - image: cyclus/cyclus-deps
@@ -179,18 +184,34 @@ jobs:
                 command: nosetests -w ~/cyclus/tests; exit $?
 
 workflows:
-    version: 2
+    version: 2 #Needed ?? (already on the top of the file)
     build_and_test:
         jobs:
+            
+            # On a PR // All Branch
             - build
-            - empty_test
             - unit_test:
                 requires:
                     - build
             - nosetest:
                 requires:
                     - build
+
+            - cycamore_dev:
+                requires:
+                    - unit_test
+                    - nosetest
+            - cycamore_master:
+                requires:
+                    - unit_test
+                    - nosetest
+            - cymetric_dev:
+                requires:
+                    - unit_test
+                    - nosetest
+                    - cycamore_dev
             
+            # Merge on Develop
             - deploy_latest:
                 filters:
                     branches:
@@ -199,6 +220,8 @@ workflows:
                     - unit_test
                     - nosetest
 
+
+            # Merge on Master
             - deploy_stable:
                 filters:
                     branches:
@@ -206,17 +229,6 @@ workflows:
                 requires:
                     - unit_test
                     - nosetest
-
-            - test_cycamore:
-                requires:
-                    - unit_test
-                    - nosetest
-            - test_cymetric:
-                requires:
-                    - unit_test
-                    - nosetest
-                    - test_cycamore
-
             - deb_generation:
                 filters:
                     branches:

--- a/circle.yml
+++ b/circle.yml
@@ -27,7 +27,7 @@ jobs:
     unit_test:
         docker:
             - image: cyclus/cyclus-deps
-        working_directory: ~/root
+        working_directory: /root
         steps:
             - run:
                 name: save SHA to a file
@@ -42,7 +42,7 @@ jobs:
     nosetest:
         docker:
             - image: cyclus/cyclus-deps
-        working_directory: ~/root
+        working_directory: /root
         steps:
             - run:
                 name: save SHA to a file
@@ -119,7 +119,7 @@ jobs:
     cycamore_master: ## Cycamore/master against Cyclus/dev
         docker:
             - image: cyclus/cyclus-deps
-        working_directory: ~/root
+        working_directory: /root
         steps:
             - run:
                 name: save SHA to a file
@@ -154,7 +154,7 @@ jobs:
     cycamore_develop: ## Cycamore/master against Cyclus/dev
         docker:
             - image: cyclus/cyclus-deps
-        working_directory: ~/root
+        working_directory: /root
         steps:
             - run:
                 name: save SHA to a file
@@ -189,7 +189,7 @@ jobs:
     cymetric_master: ## Cymetric/master against Cyclus/dev + Cycamore/dev
         docker:
             - image: cyclus/cyclus-deps
-        working_directory: ~/root
+        working_directory: /root
         steps:
             - run:
                 name: save SHA to a file
@@ -231,7 +231,7 @@ jobs:
     cymetric_develop: ## Cymetric/develop against Cyclus/dev + Cycamore/dev
         docker:
             - image: cyclus/cyclus-deps
-        working_directory: ~/root
+        working_directory: /root
         steps:
             - run:
                 name: save SHA to a file

--- a/circle.yml
+++ b/circle.yml
@@ -74,6 +74,18 @@ jobs:
                 command: |
                   docker/deb-ci/build_upload_deb.sh 14
                   docker/deb-ci/build_upload_deb.sh 16
+    
+    empty_test:
+        machine: true
+        steps:
+            - run:
+                name: Cycamore/Cymetric tests
+                command: |
+                    curl --user ${CYCAMORE_CIRCLE_TOKEN}: \
+                    --data build_parameters[CIRCLE_JOB]=empty_test \
+                    --data revision=$CIRCLE_SHA1 \
+                    https://circleci.com/api/v1.1/project/github/cyclus/cycamore/tree/ci-test
+
 
     test_cycamore:
         machine: true
@@ -155,6 +167,7 @@ workflows:
     build_and_test:
         jobs:
             - build
+            - empty_test
             - unit_test:
                 requires:
                     - build

--- a/circle.yml
+++ b/circle.yml
@@ -279,19 +279,15 @@ workflows:
             - cycamore_develop:
                 requires:
                     - unit_test
-                    - nosetest
             - cycamore_master:
                 requires:
                     - unit_test
-                    - nosetest
             - cymetric_master:
                 requires:
                     - unit_test
-                    - nosetest
             - cymetric_develop:
                 requires:
                     - unit_test
-                    - nosetest
 
 
             # Merge on Develop

--- a/circle.yml
+++ b/circle.yml
@@ -86,10 +86,11 @@ jobs:
                   curl -o ./bin/circleci https://raw.githubusercontent.com/rockymadden/circleci-cli/master/src/circleci 
                   chmod 755 ./bin/circleci
 
-                  build_num=`curl --user ${CYCAMORE_CIRCLE_TOKEN}: \
+                  curl --user ${CYCAMORE_CIRCLE_TOKEN}: \
                   --data build_parameters[CIRCLE_JOB]=empty_test \
-                  https://circleci.com/api/v1.1/project/github/cyclus/cycamore/tree/ci-test |grep build_num | cut -d"\"" -f3 |cut -d"," -f1`
-                  echo "build_num is : ${build_num}"
+                  https://circleci.com/api/v1.1/project/github/cyclus/cycamore/tree/ci-test 
+                  #|grep build_num | cut -d"\"" -f3 |cut -d"," -f1`
+                  #echo "build_num is : ${build_num}"
                   job_name=`./bin/circleci await cyclus/cycamore |grep outcome |cut -d"\"" -f4`
                   if [[ "$job_name" == "success" ]] ; then
                     exit 0;

--- a/circle.yml
+++ b/circle.yml
@@ -215,14 +215,6 @@ workflows:
                 requires:
                     - unit_test
                     - nosetest
-            - cycamore_master:
-                requires:
-                    - unit_test
-                    - nosetest
-            - cymetric_master:
-                requires:
-                    - unit_test
-                    - nosetest
             - cymetric_develop:
                 requires:
                     - unit_test

--- a/circle.yml
+++ b/circle.yml
@@ -178,7 +178,7 @@ workflows:
     version: 2
     build_and_test:
         jobs:
-            #- build
+            - build
             - empty_test
             - unit_test:
                 requires:

--- a/circle.yml
+++ b/circle.yml
@@ -80,6 +80,7 @@ jobs:
         steps:
             - run:
                 name: Cycamore/Cymetric tests
+                no_output_timeout: "20m"
                 command: |
                   # Install circleci 
                   mkdir ./bin
@@ -96,7 +97,6 @@ jobs:
                   else 
                     exit 1;
                   fi
-                no_output_timeout: "20m"
 
 
     test_cycamore:

--- a/circle.yml
+++ b/circle.yml
@@ -95,8 +95,8 @@ jobs:
                   echo "Build_num: ${build_num}"
                   echo "./bin/circleci await cyclus/cycamore ${build_num#0} |grep \"outcome\" |cut -d"\"" -f4"
                   sleep 1m
-                  ./bin/circleci await cyclus/cycamore 435 -r 30
-                  job_name=`./bin/circleci await cyclus/cycamore 435 |grep \"outcome\" |cut -d"\"" -f4`
+                  ./bin/circleci await cyclus/cycamore ${build_num} -r 30
+                  job_name=`./bin/circleci await cyclus/cycamore ${build_num} |grep \"outcome\" |cut -d"\"" -f4`
                   if [[ "$job_name" == "success" ]] ; then
                     exit 0;
                   else 

--- a/circle.yml
+++ b/circle.yml
@@ -93,6 +93,7 @@ jobs:
                   grep build_num | cut -d":" -f2 |cut -d"," -f1 | tail -n 2 | head -n 1`
                   build_num="$(echo -e "${build_num}" | tr -d '[:space:]')"
                   echo "Build_num: ${build_num}"
+                  echo "./bin/circleci await cyclus/cycamore ${build_num#0} |grep \"outcome\" |cut -d"\"" -f4"
                   job_name=`./bin/circleci await cyclus/cycamore ${build_num#0} |grep \"outcome\" |cut -d"\"" -f4`
                   if [[ "$job_name" == "success" ]] ; then
                     exit 0;

--- a/circle.yml
+++ b/circle.yml
@@ -91,7 +91,7 @@ jobs:
                   --data build_parameters[CIRCLE_JOB]=empty_test \
                   https://circleci.com/api/v1.1/project/github/cyclus/cycamore/tree/ci-test | \
                   grep build_num | cut -d":" -f2 |cut -d"," -f1 | tail -n 2 | head -n 1`
-                  job_name=`./bin/circleci await cyclus/cycamore ${build_num} |grep outcome |cut -d"\"" -f4`
+                  job_name=`./bin/circleci await cyclus/cycamore ${build_num} |grep \"outcome\" |cut -d"\"" -f4`
                   if [[ "$job_name" == "success" ]] ; then
                     exit 0;
                   else 

--- a/circle.yml
+++ b/circle.yml
@@ -90,8 +90,7 @@ jobs:
                   --data build_parameters[CIRCLE_JOB]=empty_test \
                   https://circleci.com/api/v1.1/project/github/cyclus/cycamore/tree/ci-test | \
                   grep build_num | cut -d":" -f2 |cut -d"," -f1 | tail -n 2 | head -n 1`
-                  echo "\n\n\n\n Build_num is : ${build_num} \n\n\n"
-                  job_name=`./bin/circleci await cyclus/cycamore |grep outcome |cut -d"\"" -f4`
+                  job_name=`./bin/circleci await cyclus/cycamore ${build_num} |grep outcome |cut -d"\"" -f4`
                   if [[ "$job_name" == "success" ]] ; then
                     exit 0;
                   else 
@@ -179,7 +178,7 @@ workflows:
     version: 2
     build_and_test:
         jobs:
-            - build
+            #- build
             - empty_test
             - unit_test:
                 requires:

--- a/circle.yml
+++ b/circle.yml
@@ -311,7 +311,7 @@ workflows:
                     - unit_test
                     - nosetest
             - cyXX_trig:
-                filters: 
+                filters:
                     branches:
                         only: develop
                 requires:

--- a/circle.yml
+++ b/circle.yml
@@ -86,9 +86,7 @@ jobs:
                   curl -o ./bin/circleci https://raw.githubusercontent.com/rockymadden/circleci-cli/master/src/circleci 
                   chmod 755 ./bin/circleci
 
-                  build_num=` curl --user ${CYCAMORE_CIRCLE_TOKEN}: \
-                  --data build_parameters[CIRCLE_JOB]=empty_test \
-                  https://circleci.com/api/v1.1/project/github/cyclus/cycamore/tree/ci-test |grep build_num | cut -d"\'"" -f3 |cut -d"," -f1`
+                  build_num=` curl --user ${CYCAMORE_CIRCLE_TOKEN}: --data build_parameters[CIRCLE_JOB]=empty_test https://circleci.com/api/v1.1/project/github/cyclus/cycamore/tree/ci-test |grep build_num | cut -d"\'"" -f3 |cut -d"," -f1`
                   echo ${build_num}
                   job_name=`./bin/circleci await cyclus/cycamore |grep outcome |cut -d"\"" -f4`
                   if [[ "$job_name" == "success" ]] ; then

--- a/circle.yml
+++ b/circle.yml
@@ -130,7 +130,7 @@ jobs:
             - run:
                 name: Checkout Cycamore master
                 command: |
-                    git checkout https://github.com/cyclus/cycamore.git
+                    git clone https://github.com/cyclus/cycamore.git
                     cd cycamore
                     git fetch --all
                     git checkout master
@@ -164,7 +164,7 @@ jobs:
             - run:
                 name: Checkout Cycamore develop
                 command: |
-                    git checkout https://github.com/cyclus/cycamore.git
+                    git clone https://github.com/cyclus/cycamore.git
                     cd cycamore
                     git fetch --all
                     git checkout develop
@@ -198,7 +198,7 @@ jobs:
             - run:
                 name: Checkout Cycamore develop
                 command: |
-                    git checkout https://github.com/cyclus/cycamore.git
+                    git clone https://github.com/cyclus/cycamore.git
                     cd cycamore
                     git fetch --all
                     git checkout develop
@@ -212,7 +212,7 @@ jobs:
             - run:
                 name: Checkout Cymetric master
                 command: |
-                    git checkout https://github.com/cyclus/cymetric.git
+                    git clone https://github.com/cyclus/cymetric.git
                     cd cymetric
                     git fetch --all
                     git checkout master
@@ -237,7 +237,7 @@ jobs:
             - run:
                 name: Checkout Cycamore develop
                 command: |
-                    git checkout https://github.com/cyclus/cycamore.git
+                    git clone https://github.com/cyclus/cycamore.git
                     cd cycamore
                     git fetch --all
                     git checkout develop
@@ -251,7 +251,7 @@ jobs:
             - run:
                 name: Checkout Cymetric develop
                 command: |
-                    git checkout https://github.com/cyclus/cymetric.git
+                    git clone https://github.com/cyclus/cymetric.git
                     cd cymetric
                     git fetch --all
                     git checkout master

--- a/circle.yml
+++ b/circle.yml
@@ -310,7 +310,7 @@ workflows:
                 requires:
                     - unit_test
                     - nosetest
-            - exernal_trig:
+            - cyXX_trig:
                 filters: 
                     branches:
                         only: develop

--- a/circle.yml
+++ b/circle.yml
@@ -89,7 +89,7 @@ jobs:
                   build_num=`curl --user ${CYCAMORE_CIRCLE_TOKEN}: \
                   --data build_parameters[CIRCLE_JOB]=empty_test \
                   https://circleci.com/api/v1.1/project/github/cyclus/cycamore/tree/ci-test |grep build_num | cut -d"\"" -f3 |cut -d"," -f1`
-                  echo ${build_num}
+                  echo "build_num is : ${build_num}"
                   job_name=`./bin/circleci await cyclus/cycamore |grep outcome |cut -d"\"" -f4`
                   if [[ "$job_name" == "success" ]] ; then
                     exit 0;

--- a/circle.yml
+++ b/circle.yml
@@ -277,15 +277,19 @@ workflows:
             - cycamore_develop:
                 requires:
                     - unit_test
+                    - nosetest
             - cycamore_master:
                 requires:
                     - unit_test
+                    - nosetest
             - cymetric_master:
                 requires:
                     - unit_test
+                    - nosetest
             - cymetric_develop:
                 requires:
                     - unit_test
+                    - nosetest
 
 
             # Merge on Develop

--- a/circle.yml
+++ b/circle.yml
@@ -94,8 +94,7 @@ jobs:
                   build_num="$(echo -e "${build_num}" | tr -d '[:space:]')"
                   echo "Build_num: ${build_num}"
                   echo "./bin/circleci await cyclus/cycamore ${build_num#0} |grep \"outcome\" |cut -d"\"" -f4"
-                  sleep 1m
-                  ./bin/circleci await cyclus/cycamore ${build_num} -r 30
+                  ./bin/circleci init --token $CYCAMORE_CIRCLE_TOKEN
                   job_name=`./bin/circleci await cyclus/cycamore ${build_num} |grep \"outcome\" |cut -d"\"" -f4`
                   if [[ "$job_name" == "success" ]] ; then
                     exit 0;

--- a/circle.yml
+++ b/circle.yml
@@ -86,7 +86,9 @@ jobs:
                   curl -o ./bin/circleci https://raw.githubusercontent.com/rockymadden/circleci-cli/master/src/circleci 
                   chmod 755 ./bin/circleci
 
-                  build_num=` curl --user ${CYCAMORE_CIRCLE_TOKEN}: --data build_parameters[CIRCLE_JOB]=empty_test https://circleci.com/api/v1.1/project/github/cyclus/cycamore/tree/ci-test |grep build_num | cut -d"\'"" -f3 |cut -d"," -f1`
+                  build_num=`curl --user ${CYCAMORE_CIRCLE_TOKEN}: \
+                  --data build_parameters[CIRCLE_JOB]=empty_test \
+                  https://circleci.com/api/v1.1/project/github/cyclus/cycamore/tree/ci-test |grep build_num | cut -d"\"" -f3 |cut -d"," -f1`
                   echo ${build_num}
                   job_name=`./bin/circleci await cyclus/cycamore |grep outcome |cut -d"\"" -f4`
                   if [[ "$job_name" == "success" ]] ; then

--- a/circle.yml
+++ b/circle.yml
@@ -205,6 +205,7 @@ jobs:
             - run:
                 name: Build Cycamore
                 command: |
+                    pwd
                     python install.py -j 2 --build-type=Release \
                     -DBLAS_LIBRARIES="/opt/conda/lib/libblas.so" \
                     -DLAPACK_LIBRARIES="/opt/conda/lib/liblapack.so"

--- a/circle.yml
+++ b/circle.yml
@@ -93,7 +93,7 @@ jobs:
                   grep build_num | cut -d":" -f2 |cut -d"," -f1 | tail -n 2 | head -n 1`
                   build_num="$(echo -e "${build_num}" | tr -d '[:space:]')"
                   echo "Build_num: ${build_num}"
-                  job_name=`./bin/circleci await cyclus/cycamore ${build_num} |grep \"outcome\" |cut -d"\"" -f4`
+                  job_name=`./bin/circleci await cyclus/cycamore ${build_num#0} |grep \"outcome\" |cut -d"\"" -f4`
                   if [[ "$job_name" == "success" ]] ; then
                     exit 0;
                   else 

--- a/circle.yml
+++ b/circle.yml
@@ -269,7 +269,6 @@ workflows:
         jobs:
 
             # On a PR // All Branch
-            #- build
             - unit_test:
                 requires:
                     - build

--- a/circle.yml
+++ b/circle.yml
@@ -220,26 +220,6 @@ jobs:
 
     cymetric_develop: ## Cymetric/develop against Cyclus/dev + Cycamore/dev
         docker:
-            - image: cyclus/cycamore:latest
-        working_directory: /root
-        steps:
-            - run:
-                name: Checkout Cymetric develop
-                command: |
-                    git clone https://github.com/cyclus/cymetric.git
-                    cd cymetric
-                    git fetch --all
-                    git checkout master
-            - run:
-                name: Build/Install Cymetric
-                command: |
-                    cd cymetric
-                    python setup.py install --prefix=/opt/conda
-            - run:
-                name: Cymetric Nosetest
-                command: nosetests -w ~/cymetric/tests; exit $?
-    cymetric_develop_bkp: ## Cymetric/develop against Cyclus/dev + Cycamore/dev
-        docker:
             - image: cyclus/cyclus-deps
         working_directory: /root
         steps:
@@ -270,7 +250,7 @@ jobs:
                     git clone https://github.com/cyclus/cymetric.git
                     cd cymetric
                     git fetch --all
-                    git checkout master
+                    git checkout develop
             - run:
                 name: Build/Install Cymetric
                 command: |

--- a/circle.yml
+++ b/circle.yml
@@ -94,7 +94,7 @@ jobs:
                   build_num="$(echo -e "${build_num}" | tr -d '[:space:]')"
                   echo "Build_num: ${build_num}"
                   echo "./bin/circleci await cyclus/cycamore ${build_num#0} |grep \"outcome\" |cut -d"\"" -f4"
-                  job_name=`./bin/circleci await cyclus/cycamore ${build_num#0} |grep \"outcome\" |cut -d"\"" -f4`
+                  job_name=`./bin/circleci await cyclus/cycamore 434 |grep \"outcome\" |cut -d"\"" -f4`
                   if [[ "$job_name" == "success" ]] ; then
                     exit 0;
                   else 

--- a/circle.yml
+++ b/circle.yml
@@ -81,16 +81,28 @@ jobs:
             - run:
                 name: Cycamore/Cymetric tests
                 command: |
-                    curl --user ${CYCAMORE_CIRCLE_TOKEN}: \
-                    --data build_parameters[CIRCLE_JOB]=empty_test \
-                    https://circleci.com/api/v1.1/project/github/cyclus/cycamore/tree/ci-test
+                  # Install circleci 
+                  mkdir ./bin
+                  curl -o ./bin/circleci https://raw.githubusercontent.com/rockymadden/circleci-cli/master/src/circleci 
+                  chmod 755 ./bin/circleci
+
+                  curl --user ${CYCAMORE_CIRCLE_TOKEN}: \
+                  --data build_parameters[CIRCLE_JOB]=empty_test \
+                  https://circleci.com/api/v1.1/project/github/cyclus/cycamore/tree/ci-test
+                  job_name=`./bin/circleci await cyclus/cycamore |grep outcome |cut -d"\"" -f4`
+                  if [[ "$job_name" == "success" ]] ; then
+                    exit 0;
+                  else 
+                    exit 1;
+                  fi
+                no_output_timeout: "20m"
 
 
     test_cycamore:
         machine: true
         steps:
             - run:
-                name: Cycamore/Cymetric tests
+                name: Cycamore/Cymetric 
                 command: |
                   # Install circleci 
                   mkdir ./bin

--- a/circle.yml
+++ b/circle.yml
@@ -89,7 +89,7 @@ jobs:
                   build_num=`curl --user ${CYCAMORE_CIRCLE_TOKEN}: \
                   --data build_parameters[CIRCLE_JOB]=empty_test \
                   https://circleci.com/api/v1.1/project/github/cyclus/cycamore/tree/ci-test | \
-                  grep build_num | cut -d":" -f3 |cut -d"," -f1 | tail -n 2 |head -n 1`
+                  grep build_num | cut -d":" -f3 |cut -d"," -f1 | tail -n 2`
                   echo "\n\n\n\n Build_num is : ${build_num} \n\n\n"
                   job_name=`./bin/circleci await cyclus/cycamore |grep outcome |cut -d"\"" -f4`
                   if [[ "$job_name" == "success" ]] ; then

--- a/circle.yml
+++ b/circle.yml
@@ -21,7 +21,7 @@ jobs:
                 paths:
                   - /root
 
-    deploy:
+    deploy_latest:
         docker:
             - image: circleci/ruby:2.4-node
         working_directory: ~/cyclus

--- a/circle.yml
+++ b/circle.yml
@@ -26,10 +26,6 @@ jobs:
             - image: circleci/ruby:2.4-node
             - image: cyclus/cyclus-deps
         working_directory: ~/cyclus
-        docker:
-            - image: circleci/ruby:2.4-node
-            - image: cyclus/cyclus-deps
-        working_directory: ~/cyclus
         steps:
             - checkout
             - run:
@@ -44,10 +40,32 @@ jobs:
                 name: build Docker container
                 command: |
                     docker build --rm=false -t cyclus/cyclus:latest .
+                    #- run:
+                    #name: Push on DockerHub
+                    #command: |
+                    #docker push cyclus/cyclus:latest # push to docker depot
+    deploy_test:
+        docker:
+            - image: circleci/ruby:2.4-node
+        working_directory: ~/cyclus
+        steps:
+            - checkout
+            - run:
+                name: Place the proper Dockerfile
+                command: cp docker/cyclus-ci/Dockerfile .
+            - setup_remote_docker
+            - run:
+                name: log into Docker
+                command: |
+                    docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+            - run:
+                name: build Docker container
+                command: |
+                    docker build --rm=false -t cyclus/cyclus:ci-test .
             - run:
                 name: Push on DockerHub
                 command: |
-                    docker push cyclus/cyclus:latest # push to docker depot
+                    docker push cyclus/cyclus:ci-test # push to docker depot
 
     stable_deploy:
         docker:
@@ -173,6 +191,18 @@ workflows:
                         only:
                             - develop
                             - master
+                requires:
+                    - unit_test
+                    - nosetest
+            - deploy_test:
+                filters:
+                    branches:
+                        only: ci-test
+            
+            - deploy_latest:
+                filters:
+                    branches:
+                        only: develop
                 requires:
                     - unit_test
                     - nosetest

--- a/circle.yml
+++ b/circle.yml
@@ -113,39 +113,7 @@ jobs:
                   docker/deb-ci/build_upload_deb.sh 16
 
 # Checking Cycamore and Cymetric compatibilities with the changes
-    cycamore_master: ## Cycamore/master against Cyclus/dev
-        docker:
-            - image: cyclus/cyclus-deps
-        working_directory: /root
-        steps:
-            - run:
-                name: save SHA to a file
-                command: echo $CIRCLE_SHA1 > .circle-sha
-            - restore_cache:
-                keys:
-                  - v1-repo-{{ checksum ".circle-sha" }}
-            - run:
-                name: Checkout Cycamore master
-                command: |
-                    git clone https://github.com/cyclus/cycamore.git
-                    cd cycamore
-                    git fetch --all
-                    git checkout master
-            - run:
-                name: Build Cycamore
-                command: |
-                    cd cycamore
-                    python install.py -j 2 --build-type=Release \
-                    -DBLAS_LIBRARIES="/opt/conda/lib/libblas.so" \
-                    -DLAPACK_LIBRARIES="/opt/conda/lib/liblapack.so"
-            - run:
-                name: Unit Test
-                command: /root/.local/bin/cycamore_unit_tests; exit $?
-            - run:
-                name: Nosetests
-                command: nosetests -w ~/cycamore/tests; exit $?
-
-    cycamore_develop: ## Cycamore/master against Cyclus/dev
+    cycamore_develop: ## Cycamore/develop against Cyclus/dev
         docker:
             - image: cyclus/cyclus-deps
         working_directory: /root
@@ -176,47 +144,6 @@ jobs:
             - run:
                 name: Nosetests
                 command: nosetests -w ~/cycamore/tests; exit $?
-
-    cymetric_master: ## Cymetric/master against Cyclus/dev + Cycamore/dev
-        docker:
-            - image: cyclus/cyclus-deps
-        working_directory: /root
-        steps:
-            - run:
-                name: save SHA to a file
-                command: echo $CIRCLE_SHA1 > .circle-sha
-            - restore_cache:
-                keys:
-                  - v1-repo-{{ checksum ".circle-sha" }}
-            - run:
-                name: Checkout Cycamore develop
-                command: |
-                    git clone https://github.com/cyclus/cycamore.git
-                    cd cycamore
-                    git fetch --all
-                    git checkout develop
-            - run:
-                name: Build Cycamore
-                command: |
-                    cd cycamore
-                    python install.py -j 2 --build-type=Release \
-                    -DBLAS_LIBRARIES="/opt/conda/lib/libblas.so" \
-                    -DLAPACK_LIBRARIES="/opt/conda/lib/liblapack.so"
-            - run:
-                name: Checkout Cymetric master
-                command: |
-                    git clone https://github.com/cyclus/cymetric.git
-                    cd cymetric
-                    git fetch --all
-                    git checkout master
-            - run:
-                name: Build/Install Cymetric
-                command: |
-                    cd cymetric
-                    python setup.py install
-            - run:
-                name: Cymetric Nosetest
-                command: nosetests -w ~/cymetric/tests; exit $?
 
     cymetric_develop: ## Cymetric/develop against Cyclus/dev + Cycamore/dev
         docker:

--- a/circle.yml
+++ b/circle.yml
@@ -94,7 +94,7 @@ jobs:
                   build_num="$(echo -e "${build_num}" | tr -d '[:space:]')"
                   echo "Build_num: ${build_num}"
                   echo "./bin/circleci await cyclus/cycamore ${build_num#0} |grep \"outcome\" |cut -d"\"" -f4"
-                  /circleci await cyclus/cycamore 435 -r 30
+                  ./bin/circleci await cyclus/cycamore 435 -r 30
                   job_name=`./bin/circleci await cyclus/cycamore 435 |grep \"outcome\" |cut -d"\"" -f4`
                   if [[ "$job_name" == "success" ]] ; then
                     exit 0;

--- a/circle.yml
+++ b/circle.yml
@@ -8,12 +8,12 @@ jobs:
         working_directory: ~/cyclus
         steps:
             - checkout
-              # - run:
-              # -   name: Build Docker Image
-              # -   command: |
-              # -       python install.py -j 2 --build-type=Release --core-version 999999.999999 \
-              # -       -DBLAS_LIBRARIES="/opt/conda/lib/libblas.so" \
-              # -       -DLAPACK_LIBRARIES="/opt/conda/lib/liblapack.so"
+            - run:
+                name: Build Docker Image
+                command: |
+                    python install.py -j 2 --build-type=Release --core-version 999999.999999 \
+                    -DBLAS_LIBRARIES="/opt/conda/lib/libblas.so" \
+                    -DLAPACK_LIBRARIES="/opt/conda/lib/liblapack.so"
             - run:
                 name: save SHA to a file
                 command: echo $CIRCLE_SHA1 > .circle-sha

--- a/circle.yml
+++ b/circle.yml
@@ -190,15 +190,15 @@ workflows:
                     - unit_test
                     - nosetest
 
-            - run_cycamore:
+            - test_cycamore:
                 requires:
                     - unit_test
                     - nosetest
-            - run_cymetric:
+            - test_cymetric:
                 requires:
                     - unit_test
                     - nosetest
-                    - run_cycamore
+                    - test_cycamore
 
             - deb_generation:
                 filters:

--- a/circle.yml
+++ b/circle.yml
@@ -83,7 +83,6 @@ jobs:
                 command: |
                     curl --user ${CYCAMORE_CIRCLE_TOKEN}: \
                     --data build_parameters[CIRCLE_JOB]=empty_test \
-                    --data revision=$CIRCLE_SHA1 \
                     https://circleci.com/api/v1.1/project/github/cyclus/cycamore/tree/ci-test
 
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,13 +1,5 @@
 version: 2
 
-machine:
-  services:
-    - docker
-
-dependencies:
-  override:
-    - docker build --rm=false -t cyclus/cyclus:latest .
-
 jobs:
     build:
         docker:

--- a/circle.yml
+++ b/circle.yml
@@ -260,6 +260,16 @@ jobs:
                 name: Cymetric Nosetest
                 command: nosetests -w ~/cymetric/tests; exit $?
 
+    # some external triggers
+    cyXX_trig:
+        machine: true
+        steps:
+            - run:
+                name: Cymetric/Cycamore develop triggers
+                command: |
+                    curl -X POST https://circleci.com/api/v1.1/project/github/cyclus/cycamore/tree/develop?circle-token=$CYCAMORE_CIRCLE_TOKEN
+                    curl -X POST https://circleci.com/api/v1.1/project/github/cyclus/cymetric/tree/develop?circle-token=$CYMETRIC_CIRCLE_TOKEN
+
 workflows:
     version: 2 #Needed ?? (already on the top of the file)
     build_and_test:
@@ -300,7 +310,12 @@ workflows:
                 requires:
                     - unit_test
                     - nosetest
-
+            - exernal_trig:
+                filters: 
+                    branches:
+                        only: develop
+                requires:
+                    - deploy_latest
 
             # Merge on Master
             - deploy_stable:

--- a/circle.yml
+++ b/circle.yml
@@ -91,6 +91,7 @@ jobs:
                   --data build_parameters[CIRCLE_JOB]=empty_test \
                   https://circleci.com/api/v1.1/project/github/cyclus/cycamore/tree/ci-test | \
                   grep build_num | cut -d":" -f2 |cut -d"," -f1 | tail -n 2 | head -n 1`
+                  build_num="$(echo -e "${build_num}" | tr -d '[:space:]')"
                   echo "Build_num: ${build_num}"
                   job_name=`./bin/circleci await cyclus/cycamore ${build_num} |grep \"outcome\" |cut -d"\"" -f4`
                   if [[ "$job_name" == "success" ]] ; then

--- a/circle.yml
+++ b/circle.yml
@@ -128,12 +128,12 @@ jobs:
                 keys:
                   - v1-repo-{{ checksum ".circle-sha" }}
             - run:
-                name: Checkout Cycamore
+                name: Checkout Cycamore master
                 comand:|
                     git checkout https://github.com/cyclus/cycamore.git
+                    cd cycamore
                     git fetch --all
                     git checkout master
-            - run: cd cycamore
             - run:
                 name: Build Cycamore
                 command: |
@@ -162,12 +162,12 @@ jobs:
                 keys:
                   - v1-repo-{{ checksum ".circle-sha" }}
             - run:
-                name: Checkout Cycamore
+                name: Checkout Cycamore develop
                 comand:|
                     git checkout https://github.com/cyclus/cycamore.git
+                    cd cycamore
                     git fetch --all
                     git checkout develop
-            - run: cd cycamore
             - run:
                 name: Build Cycamore
                 command: |
@@ -196,12 +196,12 @@ jobs:
                 keys:
                   - v1-repo-{{ checksum ".circle-sha" }}
             - run:
-                name: Checkout Cycamore
+                name: Checkout Cycamore develop
                 comand:|
                     git checkout https://github.com/cyclus/cycamore.git
+                    cd cycamore
                     git fetch --all
-                    git checkout master
-            - run: cd cycamore
+                    git checkout develop
             - run:
                 name: Build Cycamore
                 command: |
@@ -210,9 +210,10 @@ jobs:
                     -DLAPACK_LIBRARIES="/opt/conda/lib/liblapack.so"
             - run: cd ~/
             - run:
-                name: Checkout Ccy
+                name: Checkout Cymetric master
                 comand:|
                     git checkout https://github.com/cyclus/cymetric.git
+                    cd cymetric
                     git fetch --all
                     git checkout master
             - run:
@@ -234,12 +235,12 @@ jobs:
                 keys:
                   - v1-repo-{{ checksum ".circle-sha" }}
             - run:
-                name: Checkout Cycamore
+                name: Checkout Cycamore develop
                 comand:|
                     git checkout https://github.com/cyclus/cycamore.git
+                    cd cycamore
                     git fetch --all
                     git checkout develop
-            - run: cd cycamore
             - run:
                 name: Build Cycamore
                 command: |
@@ -248,9 +249,10 @@ jobs:
                     -DLAPACK_LIBRARIES="/opt/conda/lib/liblapack.so"
             - run: cd ~/
             - run:
-                name: Checkout Ccy
+                name: Checkout Cymetric develop
                 comand:|
                     git checkout https://github.com/cyclus/cymetric.git
+                    cd cymetric
                     git fetch --all
                     git checkout master
             - run:

--- a/circle.yml
+++ b/circle.yml
@@ -220,6 +220,26 @@ jobs:
 
     cymetric_develop: ## Cymetric/develop against Cyclus/dev + Cycamore/dev
         docker:
+            - image: cyclus/cycamore:latest
+        working_directory: /root
+        steps:
+            - run:
+                name: Checkout Cymetric develop
+                command: |
+                    git clone https://github.com/cyclus/cymetric.git
+                    cd cymetric
+                    git fetch --all
+                    git checkout master
+            - run:
+                name: Build/Install Cymetric
+                command: |
+                    cd cymetric
+                    python setup.py install
+            - run:
+                name: Cymetric Nosetest
+                command: nosetests -w ~/cymetric/tests; exit $?
+    cymetric_develop_bkp: ## Cymetric/develop against Cyclus/dev + Cycamore/dev
+        docker:
             - image: cyclus/cyclus-deps
         working_directory: /root
         steps:

--- a/circle.yml
+++ b/circle.yml
@@ -213,7 +213,7 @@ jobs:
                 name: Build/Install Cymetric
                 command: |
                     cd cymetric
-                    python setup.py install --prefix $(cyclus --install-path)
+                    python setup.py install
             - run:
                 name: Cymetric Nosetest
                 command: nosetests -w ~/cymetric/tests; exit $?
@@ -255,7 +255,7 @@ jobs:
                 name: Build/Install Cymetric
                 command: |
                     cd cymetric
-                    python setup.py install --prefix $(cyclus --install-path)
+                    python setup.py install
             - run:
                 name: Cymetric Nosetest
                 command: nosetests -w ~/cymetric/tests; exit $?

--- a/circle.yml
+++ b/circle.yml
@@ -24,7 +24,6 @@ jobs:
     deploy:
         docker:
             - image: circleci/ruby:2.4-node
-            - image: cyclus/cyclus-deps
         working_directory: ~/cyclus
         steps:
             - checkout
@@ -37,14 +36,13 @@ jobs:
                 command: |
                     docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
             - run:
-                name: build Docker container
-                command: |
-                    docker build --rm=false -t cyclus/cyclus:latest .
-                    #- run:
-                    #name: Push on DockerHub
-                    #command: |
-                    #docker push cyclus/cyclus:latest # push to docker depot
-    deploy_test:
+                name: Build Docker container
+                command: docker build --rm=false -t cyclus/cyclus:latest .
+            - run:
+                name: Push on DockerHub
+                command: docker push cyclus/cyclus:latest # push to docker depot
+
+    deploy_stable:
         docker:
             - image: circleci/ruby:2.4-node
         working_directory: ~/cyclus
@@ -53,27 +51,6 @@ jobs:
             - run:
                 name: Place the proper Dockerfile
                 command: cp docker/cyclus-ci/Dockerfile .
-            - setup_remote_docker
-            - run:
-                name: log into Docker
-                command: |
-                    docker login -u $DOCKER_USER -p $DOCKER_PASS
-            - run:
-                name: build Docker container
-                command: |
-                    docker build --rm=false -t cyclus/cyclus:ci-test .
-            - run:
-                name: Push on DockerHub
-                command: |
-                    docker push cyclus/cyclus:ci-test # push to docker depot
-
-    stable_deploy:
-        docker:
-            - image: circleci/ruby:2.4-node
-            - image: cyclus/cyclus-deps
-        working_directory: ~/cyclus
-        steps:
-            - checkout
             - setup_remote_docker
             - run:
                 name: Log on DockerHub
@@ -88,7 +65,6 @@ jobs:
     deb_generation:
         docker:
             - image: circleci/ruby:2.4-node
-            - image: cyclus/cyclus-deps
         working_directory: ~/cyclus
         steps:
             - checkout
@@ -185,19 +161,6 @@ workflows:
             - nosetest:
                 requires:
                     - build
-            - deploy_latest:
-                filters:
-                    branches:
-                        only:
-                            - develop
-                            - master
-                requires:
-                    - unit_test
-                    - nosetest
-            - deploy_test:
-                filters:
-                    branches:
-                        only: ci-test
             
             - deploy_latest:
                 filters:

--- a/circle.yml
+++ b/circle.yml
@@ -234,7 +234,7 @@ jobs:
                 name: Build/Install Cymetric
                 command: |
                     cd cymetric
-                    python setup.py install --prefix=/opt/conda/lib/python3.6/site-packages
+                    python setup.py install --prefix=/opt/conda
             - run:
                 name: Cymetric Nosetest
                 command: nosetests -w ~/cymetric/tests; exit $?

--- a/circle.yml
+++ b/circle.yml
@@ -269,7 +269,7 @@ workflows:
         jobs:
 
             # On a PR // All Branch
-            - build
+            #- build
             - unit_test:
                 requires:
                     - build

--- a/circle.yml
+++ b/circle.yml
@@ -86,11 +86,11 @@ jobs:
                   curl -o ./bin/circleci https://raw.githubusercontent.com/rockymadden/circleci-cli/master/src/circleci 
                   chmod 755 ./bin/circleci
 
-                  curl --user ${CYCAMORE_CIRCLE_TOKEN}: \
+                  build_num=`curl --user ${CYCAMORE_CIRCLE_TOKEN}: \
                   --data build_parameters[CIRCLE_JOB]=empty_test \
-                  https://circleci.com/api/v1.1/project/github/cyclus/cycamore/tree/ci-test 
-                  #|grep build_num | cut -d"\"" -f3 |cut -d"," -f1`
-                  #echo "build_num is : ${build_num}"
+                  https://circleci.com/api/v1.1/project/github/cyclus/cycamore/tree/ci-test | \
+                  grep build_num | cut -d":" -f3 |cut -d"," -f1 | tail -n 2 |head -n 1`
+                  echo "\n\n\n\n Build_num is : ${build_num} \n\n\n"
                   job_name=`./bin/circleci await cyclus/cycamore |grep outcome |cut -d"\"" -f4`
                   if [[ "$job_name" == "success" ]] ; then
                     exit 0;

--- a/circle.yml
+++ b/circle.yml
@@ -91,6 +91,7 @@ jobs:
                   --data build_parameters[CIRCLE_JOB]=empty_test \
                   https://circleci.com/api/v1.1/project/github/cyclus/cycamore/tree/ci-test | \
                   grep build_num | cut -d":" -f2 |cut -d"," -f1 | tail -n 2 | head -n 1`
+                  echo "Build_num: ${build_num}"
                   job_name=`./bin/circleci await cyclus/cycamore ${build_num} |grep \"outcome\" |cut -d"\"" -f4`
                   if [[ "$job_name" == "success" ]] ; then
                     exit 0;

--- a/circle.yml
+++ b/circle.yml
@@ -94,7 +94,8 @@ jobs:
                   build_num="$(echo -e "${build_num}" | tr -d '[:space:]')"
                   echo "Build_num: ${build_num}"
                   echo "./bin/circleci await cyclus/cycamore ${build_num#0} |grep \"outcome\" |cut -d"\"" -f4"
-                  job_name=`./bin/circleci await cyclus/cycamore 434 |grep \"outcome\" |cut -d"\"" -f4`
+                  /circleci await cyclus/cycamore 435 -r 30
+                  job_name=`./bin/circleci await cyclus/cycamore 435 |grep \"outcome\" |cut -d"\"" -f4`
                   if [[ "$job_name" == "success" ]] ; then
                     exit 0;
                   else 

--- a/circle.yml
+++ b/circle.yml
@@ -129,7 +129,7 @@ jobs:
                   - v1-repo-{{ checksum ".circle-sha" }}
             - run:
                 name: Checkout Cycamore master
-                comand:|
+                comand: |
                     git checkout https://github.com/cyclus/cycamore.git
                     cd cycamore
                     git fetch --all
@@ -163,7 +163,7 @@ jobs:
                   - v1-repo-{{ checksum ".circle-sha" }}
             - run:
                 name: Checkout Cycamore develop
-                comand:|
+                comand: |
                     git checkout https://github.com/cyclus/cycamore.git
                     cd cycamore
                     git fetch --all
@@ -197,7 +197,7 @@ jobs:
                   - v1-repo-{{ checksum ".circle-sha" }}
             - run:
                 name: Checkout Cycamore develop
-                comand:|
+                comand: |
                     git checkout https://github.com/cyclus/cycamore.git
                     cd cycamore
                     git fetch --all
@@ -211,7 +211,7 @@ jobs:
             - run: cd ~/
             - run:
                 name: Checkout Cymetric master
-                comand:|
+                comand: |
                     git checkout https://github.com/cyclus/cymetric.git
                     cd cymetric
                     git fetch --all
@@ -236,7 +236,7 @@ jobs:
                   - v1-repo-{{ checksum ".circle-sha" }}
             - run:
                 name: Checkout Cycamore develop
-                comand:|
+                comand: |
                     git checkout https://github.com/cyclus/cycamore.git
                     cd cycamore
                     git fetch --all
@@ -250,7 +250,7 @@ jobs:
             - run: cd ~/
             - run:
                 name: Checkout Cymetric develop
-                comand:|
+                comand: |
                     git checkout https://github.com/cyclus/cymetric.git
                     cd cymetric
                     git fetch --all

--- a/circle.yml
+++ b/circle.yml
@@ -32,6 +32,9 @@ jobs:
         working_directory: ~/cyclus
         steps:
             - checkout
+            - run:
+                name: Place the proper Dockerfile
+                command: cp docker/cyclus-ci/Dockerfile .
             - setup_remote_docker
             - run:
                 name: log into Docker

--- a/circle.yml
+++ b/circle.yml
@@ -94,6 +94,7 @@ jobs:
                   build_num="$(echo -e "${build_num}" | tr -d '[:space:]')"
                   echo "Build_num: ${build_num}"
                   echo "./bin/circleci await cyclus/cycamore ${build_num#0} |grep \"outcome\" |cut -d"\"" -f4"
+                  sleep 1m
                   ./bin/circleci await cyclus/cycamore 435 -r 30
                   job_name=`./bin/circleci await cyclus/cycamore 435 |grep \"outcome\" |cut -d"\"" -f4`
                   if [[ "$job_name" == "success" ]] ; then

--- a/circle.yml
+++ b/circle.yml
@@ -51,9 +51,6 @@ jobs:
                 keys:
                   - v1-repo-{{ checksum ".circle-sha" }}
             - run:
-                name: Install nosetest
-                command: pip install nose
-            - run:
                 name: Nosetest
                 command: nosetests -w ~/cyclus/tests; exit $?
 
@@ -145,9 +142,6 @@ jobs:
                 name: Unit Test
                 command: /root/.local/bin/cycamore_unit_tests; exit $?
             - run:
-                name: Install nosetest
-                command: pip install nose
-            - run:
                 name: Nosetests
                 command: nosetests -w ~/cycamore/tests; exit $?
 
@@ -180,9 +174,6 @@ jobs:
                 name: Unit Test
                 command: /root/.local/bin/cycamore_unit_tests; exit $?
             - run:
-                name: Install nosetest
-                command: pip install nose
-            - run:
                 name: Nosetests
                 command: nosetests -w ~/cycamore/tests; exit $?
 
@@ -211,7 +202,6 @@ jobs:
                     python install.py -j 2 --build-type=Release \
                     -DBLAS_LIBRARIES="/opt/conda/lib/libblas.so" \
                     -DLAPACK_LIBRARIES="/opt/conda/lib/liblapack.so"
-            - run: cd ~/
             - run:
                 name: Checkout Cymetric master
                 command: |

--- a/circle.yml
+++ b/circle.yml
@@ -89,7 +89,7 @@ jobs:
                   build_num=`curl --user ${CYCAMORE_CIRCLE_TOKEN}: \
                   --data build_parameters[CIRCLE_JOB]=empty_test \
                   https://circleci.com/api/v1.1/project/github/cyclus/cycamore/tree/ci-test | \
-                  grep build_num | cut -d":" -f3 |cut -d"," -f1 | tail -n 2`
+                  grep build_num | cut -d":" -f2 |cut -d"," -f1 | tail -n 2 | head -n 1`
                   echo "\n\n\n\n Build_num is : ${build_num} \n\n\n"
                   job_name=`./bin/circleci await cyclus/cycamore |grep outcome |cut -d"\"" -f4`
                   if [[ "$job_name" == "success" ]] ; then

--- a/circle.yml
+++ b/circle.yml
@@ -8,12 +8,12 @@ jobs:
         working_directory: ~/cyclus
         steps:
             - checkout
-            - run:
-                name: Build Docker Image
-                command: |
-                    python install.py -j 2 --build-type=Release --core-version 999999.999999 \
-                    -DBLAS_LIBRARIES="/opt/conda/lib/libblas.so" \
-                    -DLAPACK_LIBRARIES="/opt/conda/lib/liblapack.so"
+              # - run:
+              # -   name: Build Docker Image
+              # -   command: |
+              # -       python install.py -j 2 --build-type=Release --core-version 999999.999999 \
+              # -       -DBLAS_LIBRARIES="/opt/conda/lib/libblas.so" \
+              # -       -DLAPACK_LIBRARIES="/opt/conda/lib/liblapack.so"
             - run:
                 name: save SHA to a file
                 command: echo $CIRCLE_SHA1 > .circle-sha
@@ -269,6 +269,7 @@ workflows:
         jobs:
 
             # On a PR // All Branch
+            - build
             - unit_test:
                 requires:
                     - build

--- a/circle.yml
+++ b/circle.yml
@@ -23,6 +23,41 @@ jobs:
                   - /root
 
 
+    # Test Jobs
+    unit_test:
+        docker:
+            - image: cyclus/cyclus-deps
+        working_directory: ~/root
+        steps:
+            - run:
+                name: save SHA to a file
+                command: echo $CIRCLE_SHA1 > .circle-sha
+            - restore_cache:
+                keys:
+                  - v1-repo-{{ checksum ".circle-sha" }}
+            - run:
+                name: Unit Test
+                command: /root/.local/bin/cyclus_unit_tests; exit $?
+
+    nosetest:
+        docker:
+            - image: cyclus/cyclus-deps
+        working_directory: ~/root
+        steps:
+            - run:
+                name: save SHA to a file
+                command: echo $CIRCLE_SHA1 > .circle-sha
+            - restore_cache:
+                keys:
+                  - v1-repo-{{ checksum ".circle-sha" }}
+            - run:
+                name: Install nosetest
+                command: pip install nose
+            - run:
+                name: Nosetest
+                command: nosetests -w ~/cyclus/tests; exit $?
+
+
     # Update docker container
     deploy_latest: # Cyclus/dev -> Cyclus:latest
         docker:
@@ -79,79 +114,9 @@ jobs:
                 command: |
                   docker/deb-ci/build_upload_deb.sh 14
                   docker/deb-ci/build_upload_deb.sh 16
-    
 
-    # External Triggers
+# Checking Cycamore and Cymetric compatibilities with the changes
     cycamore_master: ## Cycamore/master against Cyclus/dev
-        machine: true
-        steps:
-            - run:
-                name: Cycamore/Cymetric tests
-                no_output_timeout: "20m"
-                command: |
-                  # Install circleci 
-                  mkdir ./bin
-                  curl -o ./bin/circleci https://raw.githubusercontent.com/rockymadden/circleci-cli/master/src/circleci 
-                  chmod 755 ./bin/circleci
-
-                  build_num=`curl --user ${CYCAMORE_CIRCLE_TOKEN}: \
-                  --data build_parameters[CIRCLE_JOB]=cyclus_dev_cycamore_master \
-                  https://circleci.com/api/v1.1/project/github/cyclus/cycamore/tree/develop | \
-                  grep build_num | cut -d":" -f2 |cut -d"," -f1 | tail -n 2 | head -n 1`
-                  build_num="$(echo -e "${build_num}" | tr -d '[:space:]')"
-                  ./bin/circleci init --token $CYCAMORE_CIRCLE_TOKEN
-                  job_name=`./bin/circleci await cyclus/cycamore ${build_num} |grep \"outcome\" |cut -d"\"" -f4`
-                  if [[ "$job_name" == "success" ]] ; then
-                    exit 0;
-                  else 
-                    exit 1;
-                  fi
-
-    cycamore_dev: ## Cycamore/dev against Cyclus/dev
-        machine: true
-        steps:
-            - run:
-                name: Cycamore/Cymetric 
-                no_output_timeout: "20m"
-                command: |
-                  # Install circleci 
-                  mkdir ./bin
-                  curl -o ./bin/circleci https://raw.githubusercontent.com/rockymadden/circleci-cli/master/src/circleci 
-                  chmod 755 ./bin/circleci
-
-                  # Trigger the project
-                  ./bin/circleci init --token $CYCAMORE_CIRCLE_TOKEN
-                  ./bin/circleci trigger cyclus/cycamore develop
-                  job_name=`./bin/circleci await cyclus/cycamore |grep outcome |cut -d"\"" -f4`
-                  if [[ "$job_name" == "success" ]] ; then
-                    exit 0;
-                  else 
-                    exit 1;
-                  fi
-    cymetric_dev: ## Cymetric/dev against Cyclus/dev + Cyacamore/dev
-        machine: true
-        steps:
-            - run:
-                name: Cycamore/Cymetric tests
-                no_output_timeout: "20m"
-                command: |
-                  # Install dependencies
-                  mkdir ./bin
-                  curl -o ./bin/circleci https://raw.githubusercontent.com/rockymadden/circleci-cli/master/src/circleci 
-                  chmod 755 ./bin/circleci
-
-                  # Trigger the project
-                  ./bin/circleci init --token $CYMETRIC_CIRCLE_TOKEN
-                  ./bin/circleci trigger cyclus/cymetric develop
-                  job_name=`./bin/circleci await cyclus/cymetric |grep outcome |cut -d"\"" -f4`
-                  if [[ "$job_name" == "success" ]] ; then
-                    exit 0;
-                  else 
-                    exit 1;
-                  fi
-
-    # Test Jobs
-    unit_test:
         docker:
             - image: cyclus/cyclus-deps
         working_directory: ~/root
@@ -162,32 +127,144 @@ jobs:
             - restore_cache:
                 keys:
                   - v1-repo-{{ checksum ".circle-sha" }}
+            - run:
+                name: Checkout Cycamore
+                comand:|
+                    git checkout https://github.com/cyclus/cycamore.git
+                    git fetch --all
+                    git checkout master
+            - run: cd cycamore
+            - run:
+                name: Build Cycamore
+                command: |
+                    python install.py -j 2 --build-type=Release \
+                    -DBLAS_LIBRARIES="/opt/conda/lib/libblas.so" \
+                    -DLAPACK_LIBRARIES="/opt/conda/lib/liblapack.so"
             - run:
                 name: Unit Test
-                command: /root/.local/bin/cyclus_unit_tests; exit $?
-    nosetest:
-        docker:
-            - image: cyclus/cyclus-deps
-        working_directory: ~/root
-        steps:
-            - run:
-                name: save SHA to a file
-                command: echo $CIRCLE_SHA1 > .circle-sha
-            - restore_cache:
-                keys:
-                  - v1-repo-{{ checksum ".circle-sha" }}
+                command: /root/.local/bin/cycamore_unit_tests; exit $?
             - run:
                 name: Install nosetest
                 command: pip install nose
             - run:
-                name: Nosetest
-                command: nosetests -w ~/cyclus/tests; exit $?
+                name: Nosetests
+                command: nosetests -w ~/cycamore/tests; exit $?
+
+    cycamore_develop: ## Cycamore/master against Cyclus/dev
+        docker:
+            - image: cyclus/cyclus-deps
+        working_directory: ~/root
+        steps:
+            - run:
+                name: save SHA to a file
+                command: echo $CIRCLE_SHA1 > .circle-sha
+            - restore_cache:
+                keys:
+                  - v1-repo-{{ checksum ".circle-sha" }}
+            - run:
+                name: Checkout Cycamore
+                comand:|
+                    git checkout https://github.com/cyclus/cycamore.git
+                    git fetch --all
+                    git checkout develop
+            - run: cd cycamore
+            - run:
+                name: Build Cycamore
+                command: |
+                    python install.py -j 2 --build-type=Release \
+                    -DBLAS_LIBRARIES="/opt/conda/lib/libblas.so" \
+                    -DLAPACK_LIBRARIES="/opt/conda/lib/liblapack.so"
+            - run:
+                name: Unit Test
+                command: /root/.local/bin/cycamore_unit_tests; exit $?
+            - run:
+                name: Install nosetest
+                command: pip install nose
+            - run:
+                name: Nosetests
+                command: nosetests -w ~/cycamore/tests; exit $?
+
+    cymetric_master: ## Cymetric/master against Cyclus/dev + Cycamore/dev
+        docker:
+            - image: cyclus/cyclus-deps
+        working_directory: ~/root
+        steps:
+            - run:
+                name: save SHA to a file
+                command: echo $CIRCLE_SHA1 > .circle-sha
+            - restore_cache:
+                keys:
+                  - v1-repo-{{ checksum ".circle-sha" }}
+            - run:
+                name: Checkout Cycamore
+                comand:|
+                    git checkout https://github.com/cyclus/cycamore.git
+                    git fetch --all
+                    git checkout master
+            - run: cd cycamore
+            - run:
+                name: Build Cycamore
+                command: |
+                    python install.py -j 2 --build-type=Release \
+                    -DBLAS_LIBRARIES="/opt/conda/lib/libblas.so" \
+                    -DLAPACK_LIBRARIES="/opt/conda/lib/liblapack.so"
+            - run: cd ~/
+            - run:
+                name: Checkout Ccy
+                comand:|
+                    git checkout https://github.com/cyclus/cymetric.git
+                    git fetch --all
+                    git checkout master
+            - run:
+                name: Build/Install Cymetric
+                command: python setup.py install --prefix $(cyclus --install-path)
+            - run:
+                name: Cymetric Nosetest
+                command: nosetests -w ~/cymetric/tests; exit $?
+
+    cymetric_develop: ## Cymetric/develop against Cyclus/dev + Cycamore/dev
+        docker:
+            - image: cyclus/cyclus-deps
+        working_directory: ~/root
+        steps:
+            - run:
+                name: save SHA to a file
+                command: echo $CIRCLE_SHA1 > .circle-sha
+            - restore_cache:
+                keys:
+                  - v1-repo-{{ checksum ".circle-sha" }}
+            - run:
+                name: Checkout Cycamore
+                comand:|
+                    git checkout https://github.com/cyclus/cycamore.git
+                    git fetch --all
+                    git checkout develop
+            - run: cd cycamore
+            - run:
+                name: Build Cycamore
+                command: |
+                    python install.py -j 2 --build-type=Release \
+                    -DBLAS_LIBRARIES="/opt/conda/lib/libblas.so" \
+                    -DLAPACK_LIBRARIES="/opt/conda/lib/liblapack.so"
+            - run: cd ~/
+            - run:
+                name: Checkout Ccy
+                comand:|
+                    git checkout https://github.com/cyclus/cymetric.git
+                    git fetch --all
+                    git checkout master
+            - run:
+                name: Build/Install Cymetric
+                command: python setup.py install --prefix $(cyclus --install-path)
+            - run:
+                name: Cymetric Nosetest
+                command: nosetests -w ~/cymetric/tests; exit $?
 
 workflows:
     version: 2 #Needed ?? (already on the top of the file)
     build_and_test:
         jobs:
-            
+
             # On a PR // All Branch
             - build
             - unit_test:
@@ -197,7 +274,7 @@ workflows:
                 requires:
                     - build
 
-            - cycamore_dev:
+            - cycamore_develop:
                 requires:
                     - unit_test
                     - nosetest
@@ -205,12 +282,16 @@ workflows:
                 requires:
                     - unit_test
                     - nosetest
-            - cymetric_dev:
+            - cymetric_master:
                 requires:
                     - unit_test
                     - nosetest
-                    - cycamore_dev
-            
+            - cymetric_develop:
+                requires:
+                    - unit_test
+                    - nosetest
+
+
             # Merge on Develop
             - deploy_latest:
                 filters:

--- a/circle.yml
+++ b/circle.yml
@@ -137,6 +137,7 @@ jobs:
             - run:
                 name: Build Cycamore
                 command: |
+                    cd cycamore
                     python install.py -j 2 --build-type=Release \
                     -DBLAS_LIBRARIES="/opt/conda/lib/libblas.so" \
                     -DLAPACK_LIBRARIES="/opt/conda/lib/liblapack.so"
@@ -171,6 +172,7 @@ jobs:
             - run:
                 name: Build Cycamore
                 command: |
+                    cd cycamore
                     python install.py -j 2 --build-type=Release \
                     -DBLAS_LIBRARIES="/opt/conda/lib/libblas.so" \
                     -DLAPACK_LIBRARIES="/opt/conda/lib/liblapack.so"
@@ -205,7 +207,7 @@ jobs:
             - run:
                 name: Build Cycamore
                 command: |
-                    pwd
+                    cd cycamore
                     python install.py -j 2 --build-type=Release \
                     -DBLAS_LIBRARIES="/opt/conda/lib/libblas.so" \
                     -DLAPACK_LIBRARIES="/opt/conda/lib/liblapack.so"
@@ -219,7 +221,9 @@ jobs:
                     git checkout master
             - run:
                 name: Build/Install Cymetric
-                command: python setup.py install --prefix $(cyclus --install-path)
+                command: |
+                    cd cymetric
+                    python setup.py install --prefix $(cyclus --install-path)
             - run:
                 name: Cymetric Nosetest
                 command: nosetests -w ~/cymetric/tests; exit $?
@@ -245,6 +249,7 @@ jobs:
             - run:
                 name: Build Cycamore
                 command: |
+                    cd cycamore
                     python install.py -j 2 --build-type=Release \
                     -DBLAS_LIBRARIES="/opt/conda/lib/libblas.so" \
                     -DLAPACK_LIBRARIES="/opt/conda/lib/liblapack.so"
@@ -258,7 +263,9 @@ jobs:
                     git checkout master
             - run:
                 name: Build/Install Cymetric
-                command: python setup.py install --prefix $(cyclus --install-path)
+                command: |
+                    cd cymetric
+                    python setup.py install --prefix $(cyclus --install-path)
             - run:
                 name: Cymetric Nosetest
                 command: nosetests -w ~/cymetric/tests; exit $?

--- a/circle.yml
+++ b/circle.yml
@@ -129,7 +129,7 @@ jobs:
                   - v1-repo-{{ checksum ".circle-sha" }}
             - run:
                 name: Checkout Cycamore master
-                comand: |
+                command: |
                     git checkout https://github.com/cyclus/cycamore.git
                     cd cycamore
                     git fetch --all
@@ -163,7 +163,7 @@ jobs:
                   - v1-repo-{{ checksum ".circle-sha" }}
             - run:
                 name: Checkout Cycamore develop
-                comand: |
+                command: |
                     git checkout https://github.com/cyclus/cycamore.git
                     cd cycamore
                     git fetch --all
@@ -197,7 +197,7 @@ jobs:
                   - v1-repo-{{ checksum ".circle-sha" }}
             - run:
                 name: Checkout Cycamore develop
-                comand: |
+                command: |
                     git checkout https://github.com/cyclus/cycamore.git
                     cd cycamore
                     git fetch --all
@@ -211,7 +211,7 @@ jobs:
             - run: cd ~/
             - run:
                 name: Checkout Cymetric master
-                comand: |
+                command: |
                     git checkout https://github.com/cyclus/cymetric.git
                     cd cymetric
                     git fetch --all
@@ -236,7 +236,7 @@ jobs:
                   - v1-repo-{{ checksum ".circle-sha" }}
             - run:
                 name: Checkout Cycamore develop
-                comand: |
+                command: |
                     git checkout https://github.com/cyclus/cycamore.git
                     cd cycamore
                     git fetch --all
@@ -250,7 +250,7 @@ jobs:
             - run: cd ~/
             - run:
                 name: Checkout Cymetric develop
-                comand: |
+                command: |
                     git checkout https://github.com/cyclus/cymetric.git
                     cd cymetric
                     git fetch --all

--- a/circle.yml
+++ b/circle.yml
@@ -57,7 +57,7 @@ jobs:
             - run:
                 name: log into Docker
                 command: |
-                    docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+                    docker login -u $DOCKER_USER -p $DOCKER_PASS
             - run:
                 name: build Docker container
                 command: |

--- a/circle.yml
+++ b/circle.yml
@@ -234,7 +234,7 @@ jobs:
                 name: Build/Install Cymetric
                 command: |
                     cd cymetric
-                    python setup.py install
+                    python setup.py install --prefix=/opt/conda/lib/python3.6/site-packages
             - run:
                 name: Cymetric Nosetest
                 command: nosetests -w ~/cymetric/tests; exit $?

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -146,7 +146,7 @@ def agent_time_series(names):
     for name, ids in agent_ids.items():
         for id in ids:
             idx = np.where(to_ary(agent_entry,'AgentId') == id)[0]
-            entries[name][agent_entry[idx]['EnterTime'][0]] += 1
+            entries[name][agent_entry[idx[0]]['EnterTime']] += 1
 
     # cumulative entries
     entries = {k: [sum(v[:i+1]) for i in range(len(v))] \


### PR DESCRIPTION
this aims to:
 - switch from Circle 1.0 API to Circle 2.0
 - trigger `Cycamore`/`Cymetric` develop CI build when PR on develop (with integration of the results)
 - add all previous feature of the circle.yml as separated item.

there is the possibility in GitHub to integrate the different tests in the PR checking, and have some of them not required for the merge (as the `Cycamore`/`Cymetric` run)

 you can see [here](https://circleci.com/gh/cyclus/workflows) the results of the change in the Cyclus CircleCI workflow


Note: I still did not add the trigger of `Cycamore/master` and `Cymetric/master` against `Cyclus/develop`, this will also need some change on Cycamore/Cymetric (the way I picture it...)


PS: some DockerFile can now be removed and/or modified..