### PR TITLE
Python Extension Module RPATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,7 +272,12 @@ IF(NOT CYCLUS_DOC_ONLY)
     # Use new Python library finder
     find_package(PythonInterp)
     find_package(PythonLibs)
+    execute_process(COMMAND "${PYTHON_EXECUTABLE}" -c
+                            "import site; print(site.getsitepackages(['${CMAKE_INSTALL_PREFIX}'])[0])"
+                    OUTPUT_VARIABLE PYTHON_SITE_PACKAGES
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
     message("-- PYTHON_EXECUTABLE: ${PYTHON_EXECUTABLE}")
+    message("-- PYTHON_SITE_PACKAGES: ${PYTHON_SITE_PACKAGES}")
 
     # Include the CMake script UseCython.cmake.  This defines add_cython_module().
     # Instruction for use can be found at the top of cmake/UseCython.cmake.

--- a/cyclus/CMakeLists.txt
+++ b/cyclus/CMakeLists.txt
@@ -37,5 +37,9 @@ foreach(file ${CYCLUS_CYTHON_FILES})
     set_target_properties(${targ} PROPERTIES LINKER_LANGUAGE CXX
                                              OUTPUT_NAME ${name}
                                              LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+    # the following install is needed so that CMake sets the correct RPATH for the
+    # python extension modules, even though they are installed (with the wrong RPATH)
+    # by setup.py, along with the pure python files.
+    install(TARGETS ${targ} LIBRARY DESTINATION "${PYTHON_SITE_PACKAGES}/cyclus")
 endforeach()
 


### PR DESCRIPTION
This fixes an issue where Python extension modules were not actually getting the `CMAKE_INSTALL_RPATH` set.  With this, building off of conda locally never requires you to set the `LD_LIBRARY_PATH`