### PR TITLE
Added position toolkit inclusion statement

### DIFF
--- a/src/cyclus.h
+++ b/src/cyclus.h
@@ -53,6 +53,7 @@ extern "C" {
 #include "toolkit/enrichment.h"
 #include "toolkit/infile_converters.h"
 #include "toolkit/mat_query.h"
+#include "toolkit/position.h"
 #include "toolkit/resource_buff.h"
 #include "toolkit/res_buf.h"
 #include "toolkit/res_manip.h"


### PR DESCRIPTION
This adds position header file into cyclus.h that has been missing this whole time.