### PR TITLE
Added missing toolkit Position

### DIFF
--- a/src/cyclus.h
+++ b/src/cyclus.h
@@ -53,6 +53,7 @@ extern "C" {
 #include "toolkit/enrichment.h"
 #include "toolkit/infile_converters.h"
 #include "toolkit/mat_query.h"
+#include "toolkit/position.h"
 #include "toolkit/resource_buff.h"
 #include "toolkit/res_buf.h"
 #include "toolkit/res_manip.h"


### PR DESCRIPTION
This PR adds the missing toolkit/position.h file from Cyclus.

This fixes https://github.com/cyclus/cycamore/pull/472
