### PR TITLE
Make COIN Optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 build
 debug
 doxygen.conf
-suffix.h
+platform.h
 *.pdf
 *.pyc
 *.dvi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,10 @@ IF(NOT CYCLUS_DOC_ONLY)
     FIND_PACKAGE(COIN)
     MESSAGE("-- COIN Version: ${COIN_VERSION}")
     set(LIBS ${LIBS} ${COIN_LIBRARIES})
+    if(NOT COIN_FOUND)
+      # no COIN, so no MILPs
+      set(DEFAULT_ALLOW_MILPS false)
+    endif()
 
     #
     # Some optional libraries to link in, as availble. Required for conda.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,7 +213,7 @@ IF(NOT CYCLUS_DOC_ONLY)
     MESSAGE("--    Boost Serialization location: ${Boost_SERIALIZATION_LIBRARY}")
 
     # find coin and link to it
-    FIND_PACKAGE(COIN REQUIRED)
+    FIND_PACKAGE(COIN)
     MESSAGE("-- COIN Version: ${COIN_VERSION}")
     set(LIBS ${LIBS} ${COIN_LIBRARIES})
 
@@ -338,7 +338,8 @@ IF(NOT CYCLUS_DOC_ONLY)
     # include all the directories we just found
     # NOTE: for some reason, adding quotes around
     # ${Glibmm_INCLUDE_DIRS} breaks Ubuntu 12.04
-    INCLUDE_DIRECTORIES("${LIBXML2_INCLUDE_DIR}"
+    set(inc_dirs
+        "${LIBXML2_INCLUDE_DIR}"
         "${LibXML++_INCLUDE_DIR}"
         "${Glibmm_INCLUDE_DIRS}"
         "${LibXML++Config_INCLUDE_DIR}"
@@ -346,6 +347,10 @@ IF(NOT CYCLUS_DOC_ONLY)
         "${HDF5_INCLUDE_DIRS}"
         "${Boost_INCLUDE_DIR}"
         "${COIN_INCLUDE_DIRS}")
+    IF(NOT inc_dirs STREQUAL "")
+      INCLUDE_DIRECTORIES(inc_dirs)
+    ENDIF()
+
 
     if(Cython_FOUND)
         INCLUDE_DIRECTORIES("${PYTHON_INCLUDE_DIRS}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,7 @@ IF(NOT CYCLUS_DOC_ONLY)
         FIND_LIBRARY(LibXML++ REQUIRED ${DEPS_HINTS})
     ENDIF()
     SET(LIBS ${LIBS} ${LibXML++_LIBRARIES})
+    message("-- LibXML++ Include Dir: ${LibXML++_INCLUDE_DIR}")
 
     # find lapack and link to it
     FIND_PACKAGE(LAPACK REQUIRED)
@@ -352,8 +353,9 @@ IF(NOT CYCLUS_DOC_ONLY)
         "${Boost_INCLUDE_DIR}"
         "${COIN_INCLUDE_DIRS}")
     IF(NOT inc_dirs STREQUAL "")
-      INCLUDE_DIRECTORIES(inc_dirs)
+      INCLUDE_DIRECTORIES(${inc_dirs})
     ENDIF()
+    message("-- Include Directories: ${inc_dirs}")
 
 
     if(Cython_FOUND)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,12 @@
 #################################################################
 ############# special file configuration ########################
 #################################################################
-
-CONFIGURE_FILE(suffix.h.in "${CMAKE_CURRENT_SOURCE_DIR}/suffix.h" @ONLY)
+if(COIN_FOUND)
+  set(cyclus_has_coin 1)
+else()
+  set(cyclus_has_coin 0)
+endif()
+CONFIGURE_FILE(platform.h.in "${CMAKE_CURRENT_SOURCE_DIR}/platform.h" @ONLY)
 
 CONFIGURE_FILE(version.cc.in "${CMAKE_CURRENT_SOURCE_DIR}/version.cc" @ONLY)
 
@@ -160,6 +164,7 @@ SET(CYCLUS_CORE_INCLUDE_DIRS ${CYCLUS_CORE_INCLUDE_DIRS}
     PARENT_SCOPE
     )
 FILE(GLOB cc_files "${CMAKE_CURRENT_SOURCE_DIR}/[^_]*.cc")
+list(REMOVE_ITEM cc_files ${CMAKE_CURRENT_SOURCE_DIR}/prog_solver.cc)
 list(REMOVE_ITEM cc_files ${CMAKE_CURRENT_SOURCE_DIR}/coin_helpers.cc)
 
 SET(CYCLUS_CORE_SRC ${CYCLUS_CORE_SRC}
@@ -169,6 +174,7 @@ SET(CYCLUS_CORE_SRC ${CYCLUS_CORE_SRC}
 
 if(COIN_FOUND)
   SET(CYCLUS_CORE_SRC ${CYCLUS_CORE_SRC}
+      "${CMAKE_CURRENT_SOURCE_DIR}/prog_solver.cc"
       "${CMAKE_CURRENT_SOURCE_DIR}/coin_helpers.cc"
       "${CMAKE_CURRENT_SOURCE_DIR}/OsiCbcSolverInterface.cpp"
       )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -159,25 +159,33 @@ endif(Cython_FOUND)
 
 INCLUDE_DIRECTORIES("${CMAKE_CURRENT_SOURCE_DIR}")
 
+set(CYCLUS_COIN_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/prog_solver.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/coin_helpers.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/prog_translator.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/solver_factory.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/OsiCbcSolverInterface.cpp"
+    )
+
 SET(CYCLUS_CORE_INCLUDE_DIRS ${CYCLUS_CORE_INCLUDE_DIRS}
     "${CMAKE_CURRENT_SOURCE_DIR}"
     PARENT_SCOPE
     )
 FILE(GLOB cc_files "${CMAKE_CURRENT_SOURCE_DIR}/[^_]*.cc")
-list(REMOVE_ITEM cc_files ${CMAKE_CURRENT_SOURCE_DIR}/prog_solver.cc)
+foreach(ccfile ${CYCLUS_COIN_SRC})
+  list(REMOVE_ITEM cc_files ${ccfile})
+endforeach()
 list(REMOVE_ITEM cc_files ${CMAKE_CURRENT_SOURCE_DIR}/coin_helpers.cc)
+list(REMOVE_ITEM cc_files ${CMAKE_CURRENT_SOURCE_DIR}/prog_translator.cc)
 
 SET(CYCLUS_CORE_SRC ${CYCLUS_CORE_SRC}
     ${cc_files}
     "${CMAKE_CURRENT_SOURCE_DIR}/transmute.c"
     )
 
+# Add Cyclus source files that use COIN, if we have COIN
 if(COIN_FOUND)
-  SET(CYCLUS_CORE_SRC ${CYCLUS_CORE_SRC}
-      "${CMAKE_CURRENT_SOURCE_DIR}/prog_solver.cc"
-      "${CMAKE_CURRENT_SOURCE_DIR}/coin_helpers.cc"
-      "${CMAKE_CURRENT_SOURCE_DIR}/OsiCbcSolverInterface.cpp"
-      )
+  SET(CYCLUS_CORE_SRC ${CYCLUS_CORE_SRC} ${CYCLUS_COIN_SRC})
 endif()
 
 add_definitions(-DPYNE_DECAY_IS_DUMMY)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -160,12 +160,19 @@ SET(CYCLUS_CORE_INCLUDE_DIRS ${CYCLUS_CORE_INCLUDE_DIRS}
     PARENT_SCOPE
     )
 FILE(GLOB cc_files "${CMAKE_CURRENT_SOURCE_DIR}/[^_]*.cc")
+list(REMOVE_ITEM cc_files ${CMAKE_CURRENT_SOURCE_DIR}/coin_helpers.cc)
 
 SET(CYCLUS_CORE_SRC ${CYCLUS_CORE_SRC}
     ${cc_files}
-    "${CMAKE_CURRENT_SOURCE_DIR}/OsiCbcSolverInterface.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/transmute.c"
     )
+
+if(COIN_FOUND)
+  SET(CYCLUS_CORE_SRC ${CYCLUS_CORE_SRC}
+      "${CMAKE_CURRENT_SOURCE_DIR}/coin_helpers.cc"
+      "${CMAKE_CURRENT_SOURCE_DIR}/OsiCbcSolverInterface.cpp"
+      )
+endif()
 
 add_definitions(-DPYNE_DECAY_IS_DUMMY)
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")

--- a/src/cyclus.h
+++ b/src/cyclus.h
@@ -1,5 +1,7 @@
 #ifndef CYCLUS_SRC_CYCLUS_H_
 #define CYCLUS_SRC_CYCLUS_H_
+// platform needs to be before all other includes
+#include "platform.h"
 
 #include "bid.h"
 #include "bid_portfolio.h"
@@ -43,7 +45,9 @@ extern "C" {
 #include "version.h"
 
 #include "toolkit/builder.h"
+#if CYCLUS_HAS_COIN
 #include "toolkit/building_manager.h"
+#endif
 #include "toolkit/matl_buy_policy.h"
 #include "toolkit/matl_sell_policy.h"
 #include "toolkit/commodity.h"

--- a/src/discovery.cc
+++ b/src/discovery.cc
@@ -14,8 +14,8 @@
 #include "context.h"
 #include "dynamic_module.h"
 #include "env.h"
+#include "platform.h"
 #include "recorder.h"
-#include "suffix.h"
 #include "timer.h"
 
 namespace cyclus {

--- a/src/dynamic_module.cc
+++ b/src/dynamic_module.cc
@@ -7,8 +7,8 @@
 #include "context.h"
 #include "env.h"
 #include "agent.h"
+#include "platform.h"
 #include "pyhooks.h"
-#include "suffix.h"
 
 #include DYNAMICLOADLIB
 

--- a/src/env.cc.in
+++ b/src/env.cc.in
@@ -11,8 +11,8 @@
 #include "boost/filesystem.hpp"
 
 #include "logger.h"
+#include "platform.h"
 #include "pyhooks.h"
-#include "suffix.h"
 
 namespace fs = boost::filesystem;
 

--- a/src/platform.h.in
+++ b/src/platform.h.in
@@ -1,2 +1,3 @@
 #define SUFFIX "@suffix@"
 #define DYNAMICLOADLIB "@dynamicloadlib@"
+#define CYCLUS_HAS_COIN @cyclus_has_coin@

--- a/src/prog_solver.h
+++ b/src/prog_solver.h
@@ -1,5 +1,6 @@
 #ifndef CYCLUS_SRC_PROG_SOLVER_H_
 #define CYCLUS_SRC_PROG_SOLVER_H_
+#include "platform.h"
 #if CYCLUS_HAS_COIN
 
 #include <string>

--- a/src/prog_solver.h
+++ b/src/prog_solver.h
@@ -1,5 +1,6 @@
 #ifndef CYCLUS_SRC_PROG_SOLVER_H_
 #define CYCLUS_SRC_PROG_SOLVER_H_
+#if CYCLUS_HAS_COIN
 
 #include <string>
 
@@ -36,10 +37,10 @@ class ProgSolver: public ExchangeSolver {
  protected:
   /// @brief the ProgSolver solves an ExchangeGraph...
   virtual double SolveGraph();
-  
+
  private:
   void WriteMPS();
-  
+
   std::string solver_t_;
   double tmax_;
   bool verbose_, mps_;
@@ -47,5 +48,5 @@ class ProgSolver: public ExchangeSolver {
 };
 
 }  // namespace cyclus
-
+#endif  // CYCLUS_HAS_COIN
 #endif  // CYCLUS_SRC_PROG_SOLVER_H_

--- a/src/prog_translator.h
+++ b/src/prog_translator.h
@@ -1,6 +1,7 @@
 #ifndef CYCLUS_SRC_PROG_TRANSLATOR_H_
 #define CYCLUS_SRC_PROG_TRANSLATOR_H_
-#if CYLCUS_HAS_COIN
+#include "platform.h"
+#if CYCLUS_HAS_COIN
 
 #include <vector>
 

--- a/src/prog_translator.h
+++ b/src/prog_translator.h
@@ -1,5 +1,6 @@
 #ifndef CYCLUS_SRC_PROG_TRANSLATOR_H_
 #define CYCLUS_SRC_PROG_TRANSLATOR_H_
+#if CYLCUS_HAS_COIN
 
 #include <vector>
 
@@ -36,9 +37,9 @@ struct ProgTranslatorContext {
 class ProgTranslator {
  public:
   /// @brief This class is now deprecated.
-  struct Context { 
-    Context(); 
-    ~Context(); 
+  struct Context {
+    Context();
+    ~Context();
   };
 
   /// constructor
@@ -75,7 +76,7 @@ class ProgTranslator {
 
   /// @throws if preference is unsatisfactory (i.e., not greater than 0)
   void CheckPref(double pref);
-  
+
   /// perform all translation for a node group
   /// @param grp a pointer to the node group
   /// @param req a boolean flag, true if grp is a request group
@@ -91,4 +92,5 @@ class ProgTranslator {
 
 }  // namespace cyclus
 
+#endif  // CYLCUS_HAS_COIN
 #endif  // CYCLUS_SRC_PROG_TRANSLATOR_H_

--- a/src/solver_factory.h
+++ b/src/solver_factory.h
@@ -1,5 +1,6 @@
 #ifndef CYCLUS_SRC_SOLVER_FACTORY_H_
 #define CYCLUS_SRC_SOLVER_FACTORY_H_
+#if CYCLUS_HAS_COIN
 
 #include <string>
 
@@ -8,11 +9,11 @@
 class OsiSolverInterface;
 
 namespace cyclus {
- 
+
 /// this is taken exactly from driver4.cpp in the Cbc examples
 static int CbcCallBack(CbcModel * model, int from);
-  
-/// An event handler that records the time that a better solution is found  
+
+/// An event handler that records the time that a better solution is found
 class ObjValueHandler: public CbcEventHandler {
  public:
   ObjValueHandler(double obj, double time, bool found);
@@ -25,7 +26,7 @@ class ObjValueHandler: public CbcEventHandler {
   inline double time() const { return time_; }
   inline double obj() const { return obj_; }
   inline bool found() const { return found_; }
-    
+
  private:
   double obj_, time_;
   bool found_;
@@ -49,10 +50,10 @@ class SolverFactory {
   inline void solver_t(std::string t) { t_ = t; }
   inline const std::string solver_t() const { return t_; }
   inline std::string solver_t() { return t_; }
-  
+
   /// get the configured solver
   OsiSolverInterface* get();
-  
+
  private:
   std::string t_;
   double tmax_;
@@ -66,4 +67,5 @@ bool HasInt(OsiSolverInterface* si);
 
 }  // namespace cyclus
 
+#endif  // CYCLUS_HAS_COIN
 #endif  // CYCLUS_SRC_SOLVER_FACTORY_H_

--- a/src/solver_factory.h
+++ b/src/solver_factory.h
@@ -1,5 +1,6 @@
 #ifndef CYCLUS_SRC_SOLVER_FACTORY_H_
 #define CYCLUS_SRC_SOLVER_FACTORY_H_
+#include "platform.h"
 #if CYCLUS_HAS_COIN
 
 #include <string>

--- a/src/toolkit/CMakeLists.txt
+++ b/src/toolkit/CMakeLists.txt
@@ -8,7 +8,19 @@ SET(
   PARENT_SCOPE
   )
 
+set(CYCLUS_TOOLKIT_COIN_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/building_manager.cc"
+    )
+
 FILE(GLOB cc_files "${CMAKE_CURRENT_SOURCE_DIR}/*.cc")
+
+# Remove toolkit source files that rely on COIN if we don't have it
+if(NOT COIN_FOUND)
+  foreach(ccfile ${CYCLUS_TOOLKIT_COIN_SRC})
+    list(REMOVE_ITEM cc_files ${ccfile})
+  endforeach()
+endif()
+
 SET(CYCLUS_CORE_SRC ${CYCLUS_CORE_SRC} ${cc_files} PARENT_SCOPE)
 
 FILE(GLOB h_files "${CMAKE_CURRENT_SOURCE_DIR}/*.h")

--- a/src/unix_helper_functions.h
+++ b/src/unix_helper_functions.h
@@ -5,7 +5,7 @@
 #include <dlfcn.h>
 
 #include "error.h"
-#include "suffix.h"
+#include "platform.h"
 
 namespace cyclus {
 

--- a/src/version.cc.in
+++ b/src/version.cc.in
@@ -3,18 +3,24 @@
 
 #include "version.h"
 
+#if CYCLUS_HAS_COIN
 #include "CbcConfig.h"
 #include "ClpConfig.h"
+// required for coin-cbc v < 2.5
+#ifndef CBC_VERSION
+#define CBC_VERSION CBCVERSION
+#endif
+#else
+#define CBC_VERSION "-1"
+#define CLP_VERSION "-1"
+#endif
+
 #include "boost/version.hpp"
 #include "hdf5.h"
 #include "libxml/xmlversion.h"
 #include "libxml++config.h"
 #include "sqlite3.h"
 
-// required for coin-cbc v < 2.5
-#ifndef CBC_VERSION
-#define CBC_VERSION CBCVERSION
-#endif
 
 #define INNER(x) #x
 #define SVER(x,y,z) INNER(x.y.z)

--- a/src/version.cc.in
+++ b/src/version.cc.in
@@ -1,6 +1,7 @@
 #include <sstream>
 #include <cstring>
 
+#include "platform.h"
 #include "version.h"
 
 #if CYCLUS_HAS_COIN

--- a/src/windows_helper_functions.h
+++ b/src/windows_helper_functions.h
@@ -5,7 +5,7 @@
 #include <windows.h>
 
 #include "error.h"
-#include "suffix.h"
+#include "platform.h"
 
 namespace cyclus {
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -61,7 +61,20 @@ INSTALL(FILES GoogleTest/gtest/gtest.h
 
 INCLUDE_DIRECTORIES(${CYCLUS_CORE_INCLUDE_DIRS})
 
+set(CYCLUS_TEST_COIN_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/solver_factory_tests.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/prog_translator_tests.cc"
+    )
+
 FILE(GLOB cc_files "${CMAKE_CURRENT_SOURCE_DIR}/*.cc")
+
+# Remove test source files that rely on COIN if we don't have it
+if(NOT COIN_FOUND)
+  foreach(ccfile ${CYCLUS_TEST_COIN_SRC})
+    list(REMOVE_ITEM cc_files ${ccfile})
+  endforeach()
+endif()
+
 SET(CYCLUS_CORE_TEST_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}")
 
 FILE(GLOB header_files "${CMAKE_CURRENT_SOURCE_DIR}/*.h")

--- a/tests/agent_tests/agent_tests.h
+++ b/tests/agent_tests/agent_tests.h
@@ -4,7 +4,7 @@
 #include <gtest/gtest.h>
 
 #include "agent.h"
-#include "suffix.h"
+#include "platform.h"
 #include "test_context.h"
 
 #if GTEST_HAS_PARAM_TEST

--- a/tests/agent_tests/facility_tests.h
+++ b/tests/agent_tests/facility_tests.h
@@ -5,7 +5,7 @@
 
 #include "agent_tests.h"
 #include "facility.h"
-#include "suffix.h"
+#include "platform.h"
 #include "test_context.h"
 #include "test_agents/test_inst.h"
 

--- a/tests/agent_tests/institution_tests.h
+++ b/tests/agent_tests/institution_tests.h
@@ -5,7 +5,7 @@
 
 #include "agent_tests.h"
 #include "institution.h"
-#include "suffix.h"
+#include "platform.h"
 #include "test_context.h"
 #include "test_agents/test_facility.h"
 #include "test_agents/test_inst.h"

--- a/tests/agent_tests/region_tests.h
+++ b/tests/agent_tests/region_tests.h
@@ -6,7 +6,7 @@
 #include "agent_tests.h"
 #include "context.h"
 #include "region.h"
-#include "suffix.h"
+#include "platform.h"
 #include "test_context.h"
 
 #if GTEST_HAS_PARAM_TEST

--- a/tests/integ_tests.cc
+++ b/tests/integ_tests.cc
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include "cyclus.h"
+#include "platform.h"
 #include "pyhooks.h"
 #include "sim_init.h"
 #include "xml_file_loader.h"
@@ -69,12 +70,14 @@ TEST(IntegTests, RunAllInfiles) {
   infiles.push_back("inventory_compact_false.xml");
   infiles.push_back("inventory_false.xml");
   infiles.push_back("lotka_volterra_determ.xml");
-  infiles.push_back("minimal_cycle.xml");
-  infiles.push_back("null_sink.xml");
   infiles.push_back("predator.xml");
   infiles.push_back("prey.xml");
+#if CYCLUS_HAS_COIN
+  infiles.push_back("null_sink.xml");
   infiles.push_back("source_to_sink.xml");
+  infiles.push_back("minimal_cycle.xml");
   infiles.push_back("trivial_cycle.xml");
+#endif
 
   for (int i = 0; i < infiles.size(); i++) {
     {

--- a/tests/test_minimal_cycle.py
+++ b/tests/test_minimal_cycle.py
@@ -3,12 +3,14 @@
 import nose
 
 from nose.tools import assert_equal, assert_almost_equal, assert_true
+from nose.plugins.skip import SkipTest
+
 from numpy.testing import assert_array_equal
 import os
 import sqlite3
 import tables
 import numpy as np
-from tools import check_cmd
+from tools import check_cmd, cyclus_has_coin
 from helper import tables_exist, find_ids, exit_times, create_sim_input, \
     h5out, sqliteout, clean_outs, sha1array, to_ary, which_outfile
 
@@ -97,6 +99,9 @@ def test_minimal_cycle():
 
     This equation is used to test each transaction amount.
     """
+    if not cyclus_has_coin():
+        raise SkipTest("Cyclus does not have COIN")
+
     # A reference simulation input for minimal cycle with different commodities
     ref_input = os.path.join(INPUT, "minimal_cycle.xml")
     # Conversion factors for the simulations

--- a/tests/test_null_sink.py
+++ b/tests/test_null_sink.py
@@ -1,13 +1,18 @@
 #! /usr/bin/env python
 
-from nose.tools import assert_false, assert_true, assert_equal
 import os
-import tables
 import sqlite3
+
+from nose.tools import assert_false, assert_true, assert_equal
+from nose.plugins.skip import SkipTest
+
+
 import numpy as np
-from tools import check_cmd
+import tables
 from helper import tables_exist, find_ids, exit_times, \
     h5out, sqliteout, clean_outs, to_ary, which_outfile
+
+from tools import check_cmd, cyclus_has_coin
 
 
 INPUT = os.path.join(os.path.dirname(__file__), "input")
@@ -19,6 +24,8 @@ def check_null_sink(fname, given_spec):
     transaction records must not exist in order to pass this test.
     """
     clean_outs()
+    if not cyclus_has_coin():
+        raise SkipTest("Cyclus does not have COIN")
 
     # Cyclus simulation input for null sink testing
     sim_input = os.path.join(INPUT, fname)

--- a/tests/test_source_to_sink.py
+++ b/tests/test_source_to_sink.py
@@ -1,12 +1,14 @@
 #! /usr/bin/env python
 
 from nose.tools import assert_equal, assert_true
+from nose.plugins.skip import SkipTest
+
 from numpy.testing import assert_array_equal
 import os
 import sqlite3
 import tables
 import numpy as np
-from tools import check_cmd
+from tools import check_cmd, cyclus_has_coin
 from helper import tables_exist, find_ids, exit_times, \
     h5out, sqliteout, clean_outs, to_ary, which_outfile
 
@@ -17,6 +19,8 @@ def check_source_to_sink(fname, source_spec, sink_spec):
     were of equal quantities and only between sink and source facilities.
     """
     clean_outs()
+    if not cyclus_has_coin():
+        raise SkipTest("Cyclus does not have COIN")
 
     # Cyclus simulation input for Source and Sink
     sim_inputs = [os.path.join(INPUT, fname)]

--- a/tests/test_trivial_cycle.py
+++ b/tests/test_trivial_cycle.py
@@ -1,12 +1,13 @@
 #! /usr/bin/env python
 
 from nose.tools import assert_equal, assert_almost_equal, assert_true
+from nose.plugins.skip import SkipTest
 from numpy.testing import assert_array_equal
 import os
 import sqlite3
 import tables
 import numpy as np
-from tools import check_cmd
+from tools import check_cmd, cyclus_has_coin
 from helper import tables_exist, find_ids, exit_times, create_sim_input, \
     h5out, sqliteout, clean_outs, to_ary, which_outfile
 
@@ -24,6 +25,9 @@ def test_source_to_sink():
 
     This equation is used to test each transaction amount.
     """
+    if not cyclus_has_coin():
+        raise SkipTest("Cyclus does not have COIN")
+
     # A reference simulation input for the trivial cycle simulation.
     ref_input = os.path.join(INPUT, "trivial_cycle.xml")
     # Conversion factors for the three simulations

--- a/tests/toolkit/CMakeLists.txt
+++ b/tests/toolkit/CMakeLists.txt
@@ -4,7 +4,19 @@ SET(
   PARENT_SCOPE
   )
 
+set(CYCLUS_TOOLKIT_TEST_COIN_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/building_manager_tests.cc"
+    )
+
 FILE(GLOB cc_files "${CMAKE_CURRENT_SOURCE_DIR}/*.cc")
+
+# Remove toolkit test source files that rely on COIN if we don't have it
+if(NOT COIN_FOUND)
+  foreach(ccfile ${CYCLUS_TOOLKIT_TEST_COIN_SRC})
+    list(REMOVE_ITEM cc_files ${ccfile})
+  endforeach()
+endif()
+
 SET(
   CYCLUS_CORE_TEST_SOURCE ${CYCLUS_CORE_TEST_SOURCE}
   ${cc_files}

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -25,6 +25,9 @@ integration = attr('integration')
 
 INPUT = os.path.join(os.path.dirname(__file__), "input")
 
+CYCLUS_HAS_COIN = None
+
+
 def cleanfs(paths):
     """Removes the paths from the file system."""
     for p in paths:
@@ -53,6 +56,18 @@ def check_cmd(args, cwd, holdsrtn):
     f.close()
     holdsrtn[0] = rtn
     assert_equal(rtn, 0)
+
+
+def cyclus_has_coin():
+    global CYCLUS_HAS_COIN
+    if CYCLUS_HAS_COIN is not None:
+        return CYCLUS_HAS_COIN
+    s = subprocess.check_output(['cyclus', '--version'], universal_newlines=True)
+    s = s.strip().replace('Dependencies:', '')
+    m = {k.strip(): v.strip() for k,v in [line.split()[:2] for line in s.splitlines()
+                                          if line != '']}
+    CYCLUS_HAS_COIN = m['Coin-Cbc'] != '-1'
+    return CYCLUS_HAS_COIN
 
 
 @contextmanager


### PR DESCRIPTION
This PR turns COIN into an optional, compile-time dependency. In the short term (due to a lack of modern BLAS/LAPACK in conda-forge on Windows), this is necessary to allow Cyclus to build on Windows.  Most of the changes here are pretty minor, ug they are in a lot of places throughout the code base.

CC @FlanFlanagan @bam241 