### PR TITLE
Link against libraries, don't recompile everything

### DIFF
--- a/agents/CMakeLists.txt
+++ b/agents/CMakeLists.txt
@@ -9,6 +9,8 @@ use_cyclus("agents" "prey")
 use_cyclus("agents" "predator")
 install_cyclus_module("agents" "" "NONE")
 
+MESSAGE("agents_TEST_CC: ${agents_TEST_CC}")
+
 SET(
     CYCLUS_CORE_TEST_SOURCE "${CYCLUS_CORE_TEST_SOURCE}"
     "${agents_TEST_CC}"

--- a/agents/CMakeLists.txt
+++ b/agents/CMakeLists.txt
@@ -9,8 +9,6 @@ use_cyclus("agents" "prey")
 use_cyclus("agents" "predator")
 install_cyclus_module("agents" "" "NONE")
 
-MESSAGE("agents_TEST_CC: ${agents_TEST_CC}")
-
 SET(
     CYCLUS_CORE_TEST_SOURCE "${CYCLUS_CORE_TEST_SOURCE}"
     "${agents_TEST_CC}"

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -51,6 +51,7 @@ TARGET_LINK_LIBRARIES(
     dl
     ${LIBS}
     cyclus
+    agents
     ${CYCLUS_TEST_LIBRARIES}
     )
 

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -47,8 +47,10 @@ ADD_EXECUTABLE(
     )
 
 TARGET_LINK_LIBRARIES(
-    cyclus_unit_tests dl
+    cyclus_unit_tests
+    dl
     ${LIBS}
+    cyclus
     ${CYCLUS_TEST_LIBRARIES}
     )
 

--- a/cmake/UseCyclus.cmake
+++ b/cmake/UseCyclus.cmake
@@ -212,7 +212,7 @@ MACRO(USE_CYCLUS lib_root src_root)
             DEPENDS ${CYCLUS_CUSTOM_HEADERS}
             COMMENT "Copying ${CCTIN} to ${CCTOUT}."
             )
-        SET("${lib_root}_TEST_CC" "${${lib_root}_TEST_CC}" "${CCOUT}" "${CCTOUT}"
+        SET("${lib_root}_TEST_CC" "${${lib_root}_TEST_CC}" "${CCTOUT}"
             CACHE INTERNAL "Agent test source" FORCE)
     ENDIF(EXISTS "${CCTIN}")
     MESSAGE(STATUS "Finished construction of build files for agent: ${src_root}")
@@ -290,6 +290,7 @@ MACRO(INSTALL_AGENT_TESTS_ lib_name test_src test_h driver inst_dir)
         TARGET_LINK_LIBRARIES(
             ${TGT} dl
             ${LIBS}
+            ${lib_name}
             ${CYCLUS_TEST_LIBRARIES}
             )
         INSTALL(

--- a/news/ncrb.rst
+++ b/news/ncrb.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:**
+
+* Unit tests now link to libcyclus and agents, rather than recompiling all the sources
+  into the test executable.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -89,7 +89,6 @@ ADD_SUBDIRECTORY(toolkit)
 ADD_SUBDIRECTORY(agent_tests)
 SET(
     CYCLUS_CORE_TEST_SOURCE "${CYCLUS_CORE_TEST_SOURCE}"
-    "${CYCLUS_CORE_SRC}"
     "${cc_files}"
     PARENT_SCOPE
     )


### PR DESCRIPTION
This fixes the build system so that ALL of the sources aren't recompiled into the unit tests. This should speed up clean build times considerably.

CC @FlanFlanagan @cyclus/pushers 