### PR TITLE
Python Agent Attribute Access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,8 @@ tests/default-toaster.json
 tests/default-toaster.h5
 tests/attr-toaster-comapny.h5
 tests/attr-toaster-comapny.json
+tests/attr-toaster-region.h5
+tests/attr-toaster-region.json
 rs.cred
 
 # Docker stuff

--- a/.gitignore
+++ b/.gitignore
@@ -45,10 +45,12 @@ tests/libcyclus-orig.h5
 tests/libcyclus-orig.sqlite
 tests/libcyclus-test.h5
 tests/libcyclus-test.sqlite
-test/dummy.json
-test/dummy.h5
-test/default-toaster.json
-test/default-toaster.h5
+tests/dummy.json
+tests/dummy.h5
+tests/default-toaster.json
+tests/default-toaster.h5
+tests/attr-toaster-comapny.h5
+tests/attr-toaster-comapny.json
 rs.cred
 
 # Docker stuff

--- a/cyclus/agents.pyx
+++ b/cyclus/agents.pyx
@@ -1150,6 +1150,18 @@ cdef class _Facility(_Agent):
         rtn = std_string_to_py((<CyclusFacilityShim*> (<_Agent> self).shim).kind())
         return rtn
 
+    @property
+    def prototype(self):
+        """The agent's prototype."""
+        rtn = std_string_to_py((<CyclusFacilityShim*> (<_Agent> self).shim).get_prototype())
+        return rtn
+
+    @prototype.setter
+    def prototype(self, str p):
+        cdef std_string cpp_p = str_py_to_cpp(p)
+        (<CyclusFacilityShim*> (<_Agent> self).shim).prototype(cpp_p)
+
+
 
 class Facility(_Facility):
     """Python Facility that is subclassable into a facility archetype.

--- a/cyclus/agents.pyx
+++ b/cyclus/agents.pyx
@@ -1172,6 +1172,10 @@ cdef class _Facility(_Agent):
         cdef std_string cpp_new_impl = str_py_to_cpp(new_impl)
         (<CyclusFacilityShim*> (<_Agent> self).shim).spec(cpp_new_impl)
 
+    def __str__(self):
+        rtn = std_string_to_py((<CyclusFacilityShim*> (<_Agent> self).shim).str())
+        return rtn
+
     def parent(self):
         """Returns parent of this agent.  Returns None if the agent has no parent.
         """
@@ -1182,6 +1186,46 @@ cdef class _Facility(_Agent):
     def parent_id(self):
         """The id for this agent's parent or -1 if this agent has no parent."""
         return (<CyclusFacilityShim*> (<_Agent> self).shim).parent_id()
+
+    @property
+    def enter_time(self):
+        """The time step at which this agent's Build function was called
+        (-1 if the agent has never been built).
+        """
+        return (<CyclusFacilityShim*> (<_Agent> self).shim).enter_time()
+
+    @property
+    def lifetime(self):
+        """The number of time steps this agent operates between building and
+        decommissioning (-1 if the agent has an infinite lifetime)
+        """
+        return (<CyclusFacilityShim*> (<_Agent> self).shim).get_lifetime()
+
+    @lifetime.setter
+    def lifetime(self, int n_timesteps):
+        (<CyclusFacilityShim*> (<_Agent> self).shim).lifetime(n_timesteps)
+
+    @property
+    def exit_time(self):
+        """The default time step at which this agent will exit the
+        simulation (-1 if the agent has an infinite lifetime).
+
+        Decomissioning happens at the end of a time step. With a lifetime of 1, we
+        expect an agent to go through only 1 entire time step. In this case, the
+        agent should be decommissioned on the same time step it was
+        created. Therefore, for agents with non-infinite lifetimes, the exit_time
+        will be the enter time plus its lifetime less 1.
+        """
+        return (<CyclusFacilityShim*> (<_Agent> self).shim).exit_time()
+
+    @property
+    def children(self):
+        """A frozen set of the children of this agent."""
+        kids = []
+        for kid_ptx in (<CyclusFacilityShim*> (<_Agent> self).shim).children():
+            kid = lib.agent_to_py(kid_ptx, None)
+            kids.append(kid)
+        return frozenset(kids)
 
 
 class Facility(_Facility):

--- a/cyclus/agents.pyx
+++ b/cyclus/agents.pyx
@@ -1161,6 +1161,16 @@ cdef class _Facility(_Agent):
         cdef std_string cpp_p = str_py_to_cpp(p)
         (<CyclusFacilityShim*> (<_Agent> self).shim).prototype(cpp_p)
 
+    @property
+    def spec(self):
+        """The agent's spec."""
+        rtn = std_string_to_py((<CyclusFacilityShim*> (<_Agent> self).shim).get_spec())
+        return rtn
+
+    @spec.setter
+    def spec(self, str new_impl):
+        cdef std_string cpp_new_impl = str_py_to_cpp(new_impl)
+        (<CyclusFacilityShim*> (<_Agent> self).shim).spec(cpp_new_impl)
 
 
 class Facility(_Facility):

--- a/cyclus/agents.pyx
+++ b/cyclus/agents.pyx
@@ -1172,6 +1172,17 @@ cdef class _Facility(_Agent):
         cdef std_string cpp_new_impl = str_py_to_cpp(new_impl)
         (<CyclusFacilityShim*> (<_Agent> self).shim).spec(cpp_new_impl)
 
+    def parent(self):
+        """Returns parent of this agent.  Returns None if the agent has no parent.
+        """
+        rtn = lib.agent_to_py((<CyclusFacilityShim*> (<_Agent> self).shim).parent(), None)
+        return rtn
+
+    @property
+    def parent_id(self):
+        """The id for this agent's parent or -1 if this agent has no parent."""
+        return (<CyclusFacilityShim*> (<_Agent> self).shim).parent_id()
+
 
 class Facility(_Facility):
     """Python Facility that is subclassable into a facility archetype.

--- a/cyclus/agents.pyx
+++ b/cyclus/agents.pyx
@@ -1052,6 +1052,154 @@ cdef class _Region(_Agent):
         else:
             self.ptx = self.shim = NULL
 
+    def children_str(self):
+        """Returns recursively generated string of the parent-child tree."""
+        return std_string_to_py((<CyclusRegionShim*> (<_Agent> self).shim).PrintChildren())
+
+    def tree_strs(self, m):
+        """Returns a list of children strings representing the parent-child tree
+        at the node for Agent m.
+        """
+        cdef cpp_cyclus.Agent* cpp_m = <cpp_cyclus.Agent*> (<_Agent> m).ptx
+        rtn = std_vector_std_string_to_py(
+                (<CyclusRegionShim*> (<_Agent> self).shim).GetTreePrintOuts(cpp_m))
+        return rtn
+
+    def in_family_tree(self, other):
+        """Returns true if this agent is in the parent-child family tree of an
+        other agent.
+        """
+        cdef cpp_cyclus.Agent* cpp_other = <cpp_cyclus.Agent*> (<_Agent> other).ptx
+        rtn = bool_to_py((<CyclusRegionShim*> (<_Agent> self).shim).InFamilyTree(cpp_other))
+        return rtn
+
+    def ancestor_of(self, other):
+        """Returns true if this agent is an ancestor of an other agent (i.e., resides
+        above an other agent in the family tree).
+        """
+        cdef cpp_cyclus.Agent* cpp_other = <cpp_cyclus.Agent*> (<_Agent> other).ptx
+        rtn = bool_to_py((<CyclusRegionShim*> (<_Agent> self).shim).AncestorOf(cpp_other))
+        return rtn
+
+    def decendent_of(self, other):
+        """Returns true if this agent is an decendent of an other agent (i.e., resides
+        above an other agent in the family tree).
+        """
+        cdef cpp_cyclus.Agent* cpp_other = <cpp_cyclus.Agent*> (<_Agent> other).ptx
+        rtn = bool_to_py((<CyclusRegionShim*> (<_Agent> self).shim).DecendentOf(cpp_other))
+        return rtn
+
+    def decomission(self):
+        """Decommissions the agent, removing it from the simulation. Results in
+        destruction of the agent object. If agents write their own decommission()
+        function, they must call their superclass' decommission function at the
+        END of their decommission() function.
+        """
+        (<CyclusRegionShim*> (<_Agent> self).shim).Decommission()
+
+    @property
+    def annotations(self):
+        """Agent annotations."""
+        cdef jsoncpp.Value cpp_rtn = jsoncpp.Value()
+        if self._annotations is None:
+            cpp_rtn._inst[0] = (<CyclusRegionShim*> (<_Agent> self).shim).annotations()
+        self._annotations = cpp_rtn
+        return self._annotations
+
+    @property
+    def prototype(self):
+        """The agent's prototype."""
+        rtn = std_string_to_py((<CyclusRegionShim*> (<_Agent> self).shim).get_prototype())
+        return rtn
+
+    @prototype.setter
+    def prototype(self, str p):
+        cdef std_string cpp_p = str_py_to_cpp(p)
+        (<CyclusRegionShim*> (<_Agent> self).shim).prototype(cpp_p)
+
+    @property
+    def spec(self):
+        """The agent's spec."""
+        rtn = std_string_to_py((<CyclusRegionShim*> (<_Agent> self).shim).get_spec())
+        return rtn
+
+    @spec.setter
+    def spec(self, str new_impl):
+        cdef std_string cpp_new_impl = str_py_to_cpp(new_impl)
+        (<CyclusRegionShim*> (<_Agent> self).shim).spec(cpp_new_impl)
+
+    @property
+    def id(self):
+        """The agent instance's unique ID within a simulation."""
+        return (<CyclusRegionShim*> (<_Agent> self).shim).id()
+
+    @property
+    def id(self):
+        """The agent instance's unique ID within a simulation."""
+        return (<CyclusRegionShim*> (<_Agent> self).shim).id()
+
+    @property
+    def kind(self):
+        """Returns a string that describes the agent subclass (e.g. Region,
+        Facility, etc.)
+        """
+        rtn = std_string_to_py((<CyclusRegionShim*> (<_Agent> self).shim).kind())
+        return rtn
+
+    def __str__(self):
+        rtn = std_string_to_py((<CyclusRegionShim*> (<_Agent> self).shim).str())
+        return rtn
+
+    def parent(self):
+        """Returns parent of this agent.  Returns None if the agent has no parent.
+        """
+        rtn = lib.agent_to_py((<CyclusRegionShim*> (<_Agent> self).shim).parent(), None)
+        return rtn
+
+    @property
+    def parent_id(self):
+        """The id for this agent's parent or -1 if this agent has no parent."""
+        return (<CyclusRegionShim*> (<_Agent> self).shim).parent_id()
+
+    @property
+    def enter_time(self):
+        """The time step at which this agent's Build function was called
+        (-1 if the agent has never been built).
+        """
+        return (<CyclusRegionShim*> (<_Agent> self).shim).enter_time()
+
+    @property
+    def lifetime(self):
+        """The number of time steps this agent operates between building and
+        decommissioning (-1 if the agent has an infinite lifetime)
+        """
+        return (<CyclusRegionShim*> (<_Agent> self).shim).get_lifetime()
+
+    @lifetime.setter
+    def lifetime(self, int n_timesteps):
+        (<CyclusRegionShim*> (<_Agent> self).shim).lifetime(n_timesteps)
+
+    @property
+    def exit_time(self):
+        """The default time step at which this agent will exit the
+        simulation (-1 if the agent has an infinite lifetime).
+
+        Decomissioning happens at the end of a time step. With a lifetime of 1, we
+        expect an agent to go through only 1 entire time step. In this case, the
+        agent should be decommissioned on the same time step it was
+        created. Therefore, for agents with non-infinite lifetimes, the exit_time
+        will be the enter time plus its lifetime less 1.
+        """
+        return (<CyclusRegionShim*> (<_Agent> self).shim).exit_time()
+
+    @property
+    def children(self):
+        """A frozen set of the children of this agent."""
+        kids = []
+        for kid_ptx in (<CyclusRegionShim*> (<_Agent> self).shim).children():
+            kid = lib.agent_to_py(kid_ptx, None)
+            kids.append(kid)
+        return frozenset(kids)
 
 
 class Region(_Region):
@@ -1096,9 +1244,9 @@ cdef class _Institution(_Agent):
         else:
             self.ptx = self.shim = NULL
 
-    #def children_str(self):
-    #    """Returns recursively generated string of the parent-child tree."""
-    #    return std_string_to_py((<CyclusInstitutionShim*> (<_Agent> self).shim).PrintChildren())
+    def children_str(self):
+        """Returns recursively generated string of the parent-child tree."""
+        return std_string_to_py((<CyclusInstitutionShim*> (<_Agent> self).shim).PrintChildren())
 
     def tree_strs(self, m):
         """Returns a list of children strings representing the parent-child tree

--- a/cyclus/cpp_cyclus.pxd
+++ b/cyclus/cpp_cyclus.pxd
@@ -670,8 +670,8 @@ cdef extern from "agent.h" namespace "cyclus":
         Agent* parent()
         const int parent_id()
         const int enter_time()
+        const int get_lifetime "lifetime" ()
         void lifetime(int)
-        const int lifetime()
         const int exit_time()
         const set[Agent*]& children()
 

--- a/cyclus/cpp_cyclus.pxd
+++ b/cyclus/cpp_cyclus.pxd
@@ -660,7 +660,7 @@ cdef extern from "agent.h" namespace "cyclus":
         void AdjustProductPrefs(PrefMap[Product].type&)
         std_string schema()
         cpp_jsoncpp.Value annotations() except +
-        const std_string prototype()
+        const std_string get_prototype "prototype" ()
         void prototype(std_string)
         std_string spec()
         void spec(std_string)
@@ -898,8 +898,8 @@ cdef extern from "toolkit/timeseries.h" namespace "cyclus::toolkit":
     cdef enum TimeSeriesType:
         POWER
         ENRICH_SWU
-        ENRICH_FEED        
-    
+        ENRICH_FEED
+
     void RecordTimeSeries[T](std_string, Agent*, T)
     void RecordTimeSeriesPower "cyclus::toolkit::RecordTimeSeries<cyclus::toolkit::POWER>" (Agent*, double)
     void RecordTimeSeriesEnrichSWU "cyclus::toolkit::RecordTimeSeries<cyclus::toolkit::ENRICH_SWU>" (Agent*, double)

--- a/cyclus/cpp_cyclus.pxd
+++ b/cyclus/cpp_cyclus.pxd
@@ -662,7 +662,7 @@ cdef extern from "agent.h" namespace "cyclus":
         cpp_jsoncpp.Value annotations() except +
         const std_string get_prototype "prototype" ()
         void prototype(std_string)
-        std_string spec()
+        std_string get_spec "spec" ()
         void spec(std_string)
         const std_string kind()
         Context* context()

--- a/cyclus/lib.pyx
+++ b/cyclus/lib.pyx
@@ -1429,7 +1429,7 @@ cdef class _Agent:
     @property
     def spec(self):
         """The agent's spec."""
-        rtn = std_string_to_py((<cpp_cyclus.Agent*> self.ptx).spec())
+        rtn = std_string_to_py((<cpp_cyclus.Agent*> self.ptx).get_spec())
         return rtn
 
     @spec.setter

--- a/cyclus/lib.pyx
+++ b/cyclus/lib.pyx
@@ -1480,7 +1480,7 @@ cdef class _Agent:
         """The number of time steps this agent operates between building and
         decommissioning (-1 if the agent has an infinite lifetime)
         """
-        return (<cpp_cyclus.Agent*> self.ptx).lifetime()
+        return (<cpp_cyclus.Agent*> self.ptx).get_lifetime()
 
     @lifetime.setter
     def lifetime(self, int n_timesteps):

--- a/cyclus/lib.pyx
+++ b/cyclus/lib.pyx
@@ -1410,7 +1410,7 @@ cdef class _Agent:
     @property
     def prototype(self):
         """The agent's prototype."""
-        rtn = std_string_to_py((<cpp_cyclus.Agent*> self.ptx).prototype())
+        rtn = std_string_to_py((<cpp_cyclus.Agent*> self.ptx).get_prototype())
         return rtn
 
     @prototype.setter
@@ -1435,7 +1435,7 @@ cdef class _Agent:
     @spec.setter
     def spec(self, str new_impl):
         cdef std_string cpp_new_impl = str_py_to_cpp(new_impl)
-        (<cpp_cyclus.Agent*> self.ptx).prototype(cpp_new_impl)
+        (<cpp_cyclus.Agent*> self.ptx).spec(cpp_new_impl)
 
     @property
     def kind(self):

--- a/tests/test_toaster.py
+++ b/tests/test_toaster.py
@@ -3,7 +3,7 @@ import re
 import json
 import subprocess
 
-from nose.tools import assert_in, assert_true
+from nose.tools import assert_in, assert_true, assert_equals
 
 
 DEFAULTFILE = {'simulation': {'archetypes': {'spec': [
@@ -43,8 +43,6 @@ def test_pyagent_defaults():
         os.remove('default-toaster.h5')
 
 
-RE_ID = re.compile('\w+ id is \d+')
-
 ATTRFILE = {'simulation': {'archetypes': {'spec': [
                                         {'lib': 'toaster', 'name': 'AttrToaster'},
                                         {'lib': 'agents', 'name': 'NullRegion'},
@@ -74,10 +72,14 @@ def test_pyagent_attr_toasters():
     env['PYTHONPATH'] = "."
     s = subprocess.check_output(['cyclus', '-o', oname, iname],
                                 universal_newlines=True, env=env)
-    # ids
-    assert_true(RE_ID.match(s[s.find('AttrToaster id is'):]) is not None)
-    # tests we can get prototype
-    assert_in("AttrToaster Prototype is HappyToaster", s)
+    info = s.split('=== Start AttrToaster ===\n')[-1].split('\n=== End AttrToaster ===')[0]
+    info = json.loads(info)
+    # test attrs
+    assert_true(isinstance(info['id'], int))
+    assert_equals(info['kind'], 'Facility')
+    assert_equals(info['spec'], ':toaster:AttrToaster')
+    assert_equals(info['version'], '0.0.0')
+    assert_equals(info['prototype'], 'HappyToaster')
     # clean up
     if os.path.exists(iname):
         os.remove(iname)

--- a/tests/test_toaster.py
+++ b/tests/test_toaster.py
@@ -96,3 +96,59 @@ def test_pyagent_attr_toasters():
         os.remove(iname)
     if os.path.exists(oname):
         os.remove(oname)
+
+
+COMPANYFILE = {'simulation': {'archetypes': {'spec': [
+                                        {'lib': 'agents', 'name': 'Source'},
+                                        {'lib': 'agents', 'name': 'NullRegion'},
+                                        {'lib': 'toaster', 'name': 'NullInst'}
+                                        ]},
+                'control': {'duration': '2',
+                            'startmonth': '1',
+                            'startyear': '2000'},
+                'facility': [{'config': {'Source': {}},
+                              'name': 'HappyToaster'}],
+                'region': {'config': {'NullRegion': None},
+                           'institution': {'config': {'AttrToasterCompany': None},
+                                           'initialfacilitylist': {'entry': [{'number': '1',
+                                                                              'prototype': 'HappyToaster'}]},
+                                           'name': 'FamousToastersLLC'},
+                           'name': 'SingleRegion'}}}
+
+
+def test_pyagent_attr_toaster_company():
+    oname = 'attr-toaster-company.h5'
+    iname = 'attr-toaster-company.json'
+    if os.path.exists(oname):
+        os.remove(oname)
+    with open(iname, 'w') as f:
+        json.dump(COMPANYFILE, f)
+    env = dict(os.environ)
+    env['PYTHONPATH'] = "."
+    s = subprocess.check_output(['cyclus', '-o', oname, iname],
+                                universal_newlines=True, env=env)
+    info = s.split('=== Start AttrToasterCompany ===\n')[-1]
+    info = info.split('\n=== End AttrToasterCompany ===')[0]
+    info = json.loads(info)
+    # test ids
+    assert_true(isinstance(info['id'], int))
+    assert_true(isinstance(info['parent'], int))
+    assert_true(info['parent'] != info['id'])
+    assert_true(0 <= info['parent'] < 10)
+    assert_true(info['id'] == info['hash'])
+    # test attrs
+    assert_true(info['str'].startswith('Facility_HappyToaster'))
+    assert_equals(info['kind'], 'Facility')
+    assert_equals(info['spec'], ':toaster:AttrToaster')
+    assert_equals(info['version'], '0.0.0')
+    assert_equals(info['prototype'], 'HappyToaster')
+    assert_equals(info['enter_time'], 0)
+    assert_equals(info['lifetime'], -1)
+    assert_equals(info['exit_time'], -1)
+    assert_equals(len(info['childern']), 0)
+    assert_true(len(info['annotations']) > 0)
+    # clean up
+    if os.path.exists(iname):
+        os.remove(iname)
+    if os.path.exists(oname):
+        os.remove(oname)

--- a/tests/test_toaster.py
+++ b/tests/test_toaster.py
@@ -74,15 +74,22 @@ def test_pyagent_attr_toasters():
                                 universal_newlines=True, env=env)
     info = s.split('=== Start AttrToaster ===\n')[-1].split('\n=== End AttrToaster ===')[0]
     info = json.loads(info)
-    # test attrs
+    # test ids
     assert_true(isinstance(info['id'], int))
     assert_true(isinstance(info['parent'], int))
     assert_true(info['parent'] != info['id'])
     assert_true(0 <= info['parent'] < 10)
+    assert_true(info['id'] == info['hash'])
+    # test attrs
+    assert_true(info['str'].startswith('Facility_HappyToaster'))
     assert_equals(info['kind'], 'Facility')
     assert_equals(info['spec'], ':toaster:AttrToaster')
     assert_equals(info['version'], '0.0.0')
     assert_equals(info['prototype'], 'HappyToaster')
+    assert_equals(info['enter_time'], 0)
+    assert_equals(info['lifetime'], -1)
+    assert_equals(info['exit_time'], -1)
+    assert_equals(len(info['childern']), 0)
     # clean up
     if os.path.exists(iname):
         os.remove(iname)

--- a/tests/test_toaster.py
+++ b/tests/test_toaster.py
@@ -152,3 +152,59 @@ def test_pyagent_attr_toaster_company():
         os.remove(iname)
     if os.path.exists(oname):
         os.remove(oname)
+
+
+REGIONFILE = {'simulation': {'archetypes': {'spec': [
+                                        {'lib': 'toaster', 'name': 'DefaultToaster'},
+                                        {'lib': 'toaster', 'name': 'AttrToasterRegion'},
+                                        {'lib': 'agents', 'name': 'NullInst'}
+                                        ]},
+                'control': {'duration': '2',
+                            'startmonth': '1',
+                            'startyear': '2000'},
+                'facility': [{'config': {'DefaultToaster': {}},
+                              'name': 'HappyToaster'}],
+                'region': {'config': {'AttrToasterRegion': {}},
+                           'institution': {'config': {'NullInst': None},
+                                           'initialfacilitylist': {'entry': [{'number': '1',
+                                                                              'prototype': 'HappyToaster'}]},
+                                           'name': 'SingleInstitution'},
+                           'name': 'RepublicOfToast'}}}
+
+
+def test_pyagent_attr_toaster_region():
+    oname = 'attr-toaster-region.h5'
+    iname = 'attr-toaster-region.json'
+    if os.path.exists(oname):
+        os.remove(oname)
+    with open(iname, 'w') as f:
+        json.dump(REGIONFILE, f)
+    env = dict(os.environ)
+    env['PYTHONPATH'] = "."
+    s = subprocess.check_output(['cyclus', '-o', oname, iname],
+                                universal_newlines=True, env=env)
+    info = s.split('=== Start AttrToasterRegion ===\n')[-1]
+    info = info.split('\n=== End AttrToasterRegion ===')[0]
+    info = json.loads(info)
+    # test ids
+    assert_true(isinstance(info['id'], int))
+    assert_true(isinstance(info['parent'], int))
+    assert_true(info['parent'] != info['id'])
+    assert_equal(info['parent'], -1)
+    assert_true(info['id'] == info['hash'])
+    # test attrs
+    assert_true(info['str'].startswith('Region_RepublicOfToast'))
+    assert_equals(info['kind'], 'Region')
+    assert_equals(info['spec'], ':toaster:AttrToasterRegion')
+    assert_equals(info['version'], '0.0.0')
+    assert_equals(info['prototype'], 'RepublicOfToast')
+    assert_equals(info['enter_time'], 0)
+    assert_equals(info['lifetime'], -1)
+    assert_equals(info['exit_time'], -1)
+    assert_equals(len(info['childern']), 1)
+    assert_true(len(info['annotations']) > 0)
+    # clean up
+    if os.path.exists(iname):
+        os.remove(iname)
+    if os.path.exists(oname):
+        os.remove(oname)

--- a/tests/test_toaster.py
+++ b/tests/test_toaster.py
@@ -78,7 +78,7 @@ def test_pyagent_attr_toasters():
     assert_true(isinstance(info['id'], int))
     assert_true(isinstance(info['parent'], int))
     assert_true(info['parent'] != info['id'])
-    assert_true(0 <= info['parent'] < 10)
+    assert_true(0 <= info['parent'] < 100)
     assert_true(info['id'] == info['hash'])
     # test attrs
     assert_true(info['str'].startswith('Facility_HappyToaster'))
@@ -134,7 +134,7 @@ def test_pyagent_attr_toaster_company():
     assert_true(isinstance(info['id'], int))
     assert_true(isinstance(info['parent'], int))
     assert_true(info['parent'] != info['id'])
-    assert_true(0 <= info['parent'] <= 10)
+    assert_true(0 <= info['parent'] <= 100)
     assert_true(info['id'] == info['hash'])
     # test attrs
     assert_true(info['str'].startswith('Inst_FamousToastersLLC'))

--- a/tests/test_toaster.py
+++ b/tests/test_toaster.py
@@ -76,6 +76,9 @@ def test_pyagent_attr_toasters():
     info = json.loads(info)
     # test attrs
     assert_true(isinstance(info['id'], int))
+    assert_true(isinstance(info['parent'], int))
+    assert_true(info['parent'] != info['id'])
+    assert_true(0 <= info['parent'] < 10)
     assert_equals(info['kind'], 'Facility')
     assert_equals(info['spec'], ':toaster:AttrToaster')
     assert_equals(info['version'], '0.0.0')

--- a/tests/test_toaster.py
+++ b/tests/test_toaster.py
@@ -190,7 +190,7 @@ def test_pyagent_attr_toaster_region():
     assert_true(isinstance(info['id'], int))
     assert_true(isinstance(info['parent'], int))
     assert_true(info['parent'] != info['id'])
-    assert_equal(info['parent'], -1)
+    assert_equals(info['parent'], -1)
     assert_true(info['id'] == info['hash'])
     # test attrs
     assert_true(info['str'].startswith('Region_RepublicOfToast'))

--- a/tests/test_toaster.py
+++ b/tests/test_toaster.py
@@ -1,11 +1,12 @@
+import os
+import re
 import json
 import subprocess
-import os
 
-from nose.tools import assert_in
+from nose.tools import assert_in, assert_true
 
 
-INPUTFILE = {'simulation': {'archetypes': {'spec': [
+DEFAULTFILE = {'simulation': {'archetypes': {'spec': [
                                         {'lib': 'toaster', 'name': 'DefaultToaster'},
                                         {'lib': 'agents', 'name': 'NullRegion'},
                                         {'lib': 'agents', 'name': 'NullInst'}
@@ -27,7 +28,7 @@ def test_pyagent_defaults():
     if os.path.exists('default-toaster.h5'):
         os.remove('default-toaster.h5')
     with open('default-toaster.json', 'w') as f:
-        json.dump(INPUTFILE, f)
+        json.dump(DEFAULTFILE, f)
     env = dict(os.environ)
     env['PYTHONPATH'] = "."
     s = subprocess.check_output(['cyclus', '-o', 'default-toaster.h5', 'default-toaster.json'],
@@ -40,3 +41,45 @@ def test_pyagent_defaults():
         os.remove('default-toaster.json')
     if os.path.exists('default-toaster.h5'):
         os.remove('default-toaster.h5')
+
+
+RE_ID = re.compile('\w+ id is \d+')
+
+ATTRFILE = {'simulation': {'archetypes': {'spec': [
+                                        {'lib': 'toaster', 'name': 'AttrToaster'},
+                                        {'lib': 'agents', 'name': 'NullRegion'},
+                                        {'lib': 'agents', 'name': 'NullInst'}
+                                        ]},
+                'control': {'duration': '2',
+                            'startmonth': '1',
+                            'startyear': '2000'},
+                'facility': [{'config': {'AttrToaster': {}},
+                              'name': 'HappyToaster'}],
+                'region': {'config': {'NullRegion': None},
+                           'institution': {'config': {'NullInst': None},
+                                           'initialfacilitylist': {'entry': [{'number': '1',
+                                                                              'prototype': 'HappyToaster'}]},
+                                           'name': 'SingleInstitution'},
+                           'name': 'SingleRegion'}}}
+
+
+def test_pyagent_attr_toasters():
+    oname = 'attr-toaster.h5'
+    iname = 'attr-toaster.json'
+    if os.path.exists(oname):
+        os.remove(oname)
+    with open(iname, 'w') as f:
+        json.dump(ATTRFILE, f)
+    env = dict(os.environ)
+    env['PYTHONPATH'] = "."
+    s = subprocess.check_output(['cyclus', '-o', oname, iname],
+                                universal_newlines=True, env=env)
+    # ids
+    assert_true(RE_ID.match(s[s.find('AttrToaster id is'):]) is not None)
+    # tests we can get prototype
+    assert_in("AttrToaster Prototype is HappyToaster", s)
+    # clean up
+    if os.path.exists(iname):
+        os.remove(iname)
+    if os.path.exists(oname):
+        os.remove(oname)

--- a/tests/test_toaster.py
+++ b/tests/test_toaster.py
@@ -90,6 +90,7 @@ def test_pyagent_attr_toasters():
     assert_equals(info['lifetime'], -1)
     assert_equals(info['exit_time'], -1)
     assert_equals(len(info['childern']), 0)
+    assert_true(len(info['annotations']) > 0)
     # clean up
     if os.path.exists(iname):
         os.remove(iname)

--- a/tests/test_toaster.py
+++ b/tests/test_toaster.py
@@ -99,17 +99,17 @@ def test_pyagent_attr_toasters():
 
 
 COMPANYFILE = {'simulation': {'archetypes': {'spec': [
-                                        {'lib': 'agents', 'name': 'Source'},
+                                        {'lib': 'toaster', 'name': 'DefaultToaster'},
                                         {'lib': 'agents', 'name': 'NullRegion'},
-                                        {'lib': 'toaster', 'name': 'NullInst'}
+                                        {'lib': 'toaster', 'name': 'AttrToasterCompany'}
                                         ]},
                 'control': {'duration': '2',
                             'startmonth': '1',
                             'startyear': '2000'},
-                'facility': [{'config': {'Source': {}},
+                'facility': [{'config': {'DefaultToaster': {}},
                               'name': 'HappyToaster'}],
                 'region': {'config': {'NullRegion': None},
-                           'institution': {'config': {'AttrToasterCompany': None},
+                           'institution': {'config': {'AttrToasterCompany': {}},
                                            'initialfacilitylist': {'entry': [{'number': '1',
                                                                               'prototype': 'HappyToaster'}]},
                                            'name': 'FamousToastersLLC'},
@@ -134,18 +134,18 @@ def test_pyagent_attr_toaster_company():
     assert_true(isinstance(info['id'], int))
     assert_true(isinstance(info['parent'], int))
     assert_true(info['parent'] != info['id'])
-    assert_true(0 <= info['parent'] < 10)
+    assert_true(0 <= info['parent'] <= 10)
     assert_true(info['id'] == info['hash'])
     # test attrs
-    assert_true(info['str'].startswith('Facility_HappyToaster'))
-    assert_equals(info['kind'], 'Facility')
-    assert_equals(info['spec'], ':toaster:AttrToaster')
+    assert_true(info['str'].startswith('Inst_FamousToastersLLC'))
+    assert_equals(info['kind'], 'Inst')
+    assert_equals(info['spec'], ':toaster:AttrToasterCompany')
     assert_equals(info['version'], '0.0.0')
-    assert_equals(info['prototype'], 'HappyToaster')
+    assert_equals(info['prototype'], 'FamousToastersLLC')
     assert_equals(info['enter_time'], 0)
     assert_equals(info['lifetime'], -1)
     assert_equals(info['exit_time'], -1)
-    assert_equals(len(info['childern']), 0)
+    assert_equals(len(info['childern']), 1)
     assert_true(len(info['annotations']) > 0)
     # clean up
     if os.path.exists(iname):

--- a/tests/toaster.py
+++ b/tests/toaster.py
@@ -1,3 +1,5 @@
+import json
+
 from cyclus.agents import Facility
 from cyclus import lib
 import cyclus.typesystem as ts
@@ -18,7 +20,14 @@ class AttrToaster(Facility):
     """Meant for testing attributes values"""
 
     def tick(self):
-        print("=== Start AttrToaster ===\n{")
-        print('"id": {0},'.format(self.id))
-        print('"prototype": "{0}"'.format(self.prototype))
-        print("}\n=== End AttrToaster === ")
+        info = {
+            'id': self.id,
+            'kind': self.kind,
+            'spec': self.spec,
+            'version': self.version,
+            'prototype': self.prototype,
+            }
+        s = json.dumps(info)
+        print("=== Start AttrToaster ===\n")
+        print(s)
+        print("\n=== End AttrToaster ===")

--- a/tests/toaster.py
+++ b/tests/toaster.py
@@ -22,11 +22,17 @@ class AttrToaster(Facility):
     def tick(self):
         info = {
             'id': self.id,
+            'str': str(self),
+            'hash': hash(self),
             'kind': self.kind,
             'spec': self.spec,
             'version': self.version,
             'parent': self.parent_id,
             'prototype': self.prototype,
+            'enter_time': self.enter_time,
+            'lifetime': self.lifetime,
+            'exit_time': self.exit_time,
+            'childern': list(self.children),
             }
         s = json.dumps(info)
         print("=== Start AttrToaster ===\n")

--- a/tests/toaster.py
+++ b/tests/toaster.py
@@ -41,6 +41,8 @@ class AttrTick(object):
         print("=== Start " + self.__class__.__name__ + " ===\n")
         print(s)
         print("\n=== End " + self.__class__.__name__ + " ===")
+        if isinstance(self, Region):
+            return  # following tests not applicable to regions
         # Can't easilty convert to JSON.
         # Make sure these don't segfault
         p = self.parent()

--- a/tests/toaster.py
+++ b/tests/toaster.py
@@ -34,7 +34,7 @@ class AttrTick(object):
             'enter_time': self.enter_time,
             'lifetime': self.lifetime,
             'exit_time': self.exit_time,
-            'childern': list(self.children),
+            'childern': [kid.id for kid in self.children],
             'annotations': str(self.annotations),
             }
         s = json.dumps(info)
@@ -44,8 +44,8 @@ class AttrTick(object):
         # Can't easilty convert to JSON.
         # Make sure these don't segfault
         p = self.parent()
-        self.children_str()
-        self.tree_strs(p)
+        #self.children_str()  # <- likely broken, see #1447
+        #self.tree_strs(p)    # <- likely broken, see #1447
         self.in_family_tree(p)
         self.ancestor_of(p)
         self.decendent_of(p)

--- a/tests/toaster.py
+++ b/tests/toaster.py
@@ -1,6 +1,6 @@
 import json
 
-from cyclus.agents import Facility
+from cyclus.agents import Facility, Institution
 from cyclus import lib
 import cyclus.typesystem as ts
 
@@ -16,7 +16,7 @@ class DefaultToaster(Facility):
         print('Toast level is {0}'.format(self.level))
 
 
-class AttrToaster(Facility):
+class AttrTick(object):
     """Meant for testing attributes values"""
 
     def tick(self):
@@ -38,16 +38,24 @@ class AttrToaster(Facility):
             'annotations': str(self.annotations),
             }
         s = json.dumps(info)
-        print("=== Start AttrToaster ===\n")
+        print("=== Start " + self.__class__.__name__ + " ===\n")
         print(s)
-        print("\n=== End AttrToaster ===")
+        print("\n=== End " + self.__class__.__name__ + " ===")
         # Can't easilty convert to JSON.
         # Make sure these don't segfault
         p = self.parent()
         self.children_str()
         self.tree_strs(p)
-        self.in_family_tree(p),
-        self.ancestor_of(p),
-        self.decendent_of(p),
-        self.decomission()
+        self.in_family_tree(p)
+        self.ancestor_of(p)
+        self.decendent_of(p)
+        if isinstance(self, Facility):
+            self.decomission()
 
+
+class AttrToaster(AttrTick, Facility):
+    """A toaster for testing attributes values"""
+
+
+class AttrToasterCompany(AttrTick, Institution):
+    """A toaster company testing attributes values"""

--- a/tests/toaster.py
+++ b/tests/toaster.py
@@ -12,3 +12,13 @@ class DefaultToaster(Facility):
     def tick(self):
         print('Bread is ' + self.bread)
         print('Toast level is {0}'.format(self.level))
+
+
+class AttrToaster(Facility):
+    """Meant for testing attributes values"""
+
+    def tick(self):
+        print("=== Start AttrToaster ===\n{")
+        print('"id": {0},'.format(self.id))
+        print('"prototype": "{0}"'.format(self.prototype))
+        print("}\n=== End AttrToaster === ")

--- a/tests/toaster.py
+++ b/tests/toaster.py
@@ -1,6 +1,6 @@
 import json
 
-from cyclus.agents import Facility, Institution
+from cyclus.agents import Facility, Institution, Region
 from cyclus import lib
 import cyclus.typesystem as ts
 
@@ -59,3 +59,7 @@ class AttrToaster(AttrTick, Facility):
 
 class AttrToasterCompany(AttrTick, Institution):
     """A toaster company testing attributes values"""
+
+
+class AttrToasterRegion(AttrTick, Region):
+    """A toaster region testing attributes values"""

--- a/tests/toaster.py
+++ b/tests/toaster.py
@@ -20,12 +20,14 @@ class AttrToaster(Facility):
     """Meant for testing attributes values"""
 
     def tick(self):
+        # easily convertible to JSON
         info = {
             'id': self.id,
             'str': str(self),
             'hash': hash(self),
             'kind': self.kind,
             'spec': self.spec,
+            'schema': self.schema,
             'version': self.version,
             'parent': self.parent_id,
             'prototype': self.prototype,
@@ -33,8 +35,19 @@ class AttrToaster(Facility):
             'lifetime': self.lifetime,
             'exit_time': self.exit_time,
             'childern': list(self.children),
+            'annotations': str(self.annotations),
             }
         s = json.dumps(info)
         print("=== Start AttrToaster ===\n")
         print(s)
         print("\n=== End AttrToaster ===")
+        # Can't easilty convert to JSON.
+        # Make sure these don't segfault
+        p = self.parent()
+        self.children_str()
+        self.tree_strs(p)
+        self.in_family_tree(p),
+        self.ancestor_of(p),
+        self.decendent_of(p),
+        self.decomission()
+

--- a/tests/toaster.py
+++ b/tests/toaster.py
@@ -25,6 +25,7 @@ class AttrToaster(Facility):
             'kind': self.kind,
             'spec': self.spec,
             'version': self.version,
+            'parent': self.parent_id,
             'prototype': self.prototype,
             }
         s = json.dumps(info)


### PR DESCRIPTION
This fixes Python agents to enable standard attribute access, such as prototype and parent.

CC @FlanFlanagan @cyclus/pushers 