### PR TITLE
Remove unused dependency

### DIFF
--- a/src/datum.cc
+++ b/src/datum.cc
@@ -2,7 +2,6 @@
 
 #include <boost/pool/singleton_pool.hpp>
 
-#include "timer.h"
 
 namespace cyclus {
 


### PR DESCRIPTION
`timer.h` is not required to compile and run cyclus_unit_test