### PR TITLE
bunch of fixes

### DIFF
--- a/cli/cycpp.py
+++ b/cli/cycpp.py
@@ -67,6 +67,10 @@ if sys.version_info[0] == 2:
     STRING_TYPES = (str, unicode, basestring)
 elif sys.version_info[0] >= 3:
     STRING_TYPES = (str,)
+
+# Get system $CPP variable
+sys_cpp = os.environ.get('CPP', 'cpp')
+
 # Non-capturing and must be used wit re.DOTALL, DO NOT COMPILE!
 RE_MULTILINE_COMMENT = "(?:\s*?/\*(?!\*/)*?\*/)"
 RE_SINGLE_LINE_COMMENT = "(?:\s*?//[^\n]*?\n\s*?)"
@@ -146,7 +150,7 @@ def prepare_type(cpptype, othertype):
 #
 # pass 1
 #
-def preprocess_file(filename, includes=(), cpp_path='cpp',
+def preprocess_file(filename, includes=(), cpp_path=sys_cpp,
                     cpp_args=('-xc++', '-pipe', '-E', '-DCYCPP')):
     """Preprocess a file using cpp.
 
@@ -2331,7 +2335,7 @@ def main():
                               "with --pass3-use-pp."), dest="pass3_use_pp")
     parser.add_argument('-o', '--output', help=("output file name"))
     parser.add_argument('--cpp-path', dest='cpp_path', help="preprocessor to use",
-                        default='cpp')
+                        default=sys_cpp)
     parser.add_argument('-I', '--includes', action="append",
                         help=("include directories for preprocessing. Can be "
                               "a variable number of arguments (i.e., list of "

--- a/cmake/UseCyclus.cmake
+++ b/cmake/UseCyclus.cmake
@@ -89,7 +89,11 @@ MACRO(USE_CYCLUS lib_root src_root)
 
 
     # set cpp path
-    
+    # Now use by default the $CPP enviromnement variable first, if not fallback
+    # on the previous behavior, so in order:
+    #   1- if defined use ${CPP}
+    #   2- if clang++ present use it
+    #   3- otherwise use cpp
     IF(DEFINED ENV{CPP})
         SET(SYS_CPP "$ENV{CPP}")
     ELSEIF("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")

--- a/cmake/UseCyclus.cmake
+++ b/cmake/UseCyclus.cmake
@@ -89,10 +89,10 @@ MACRO(USE_CYCLUS lib_root src_root)
 
 
     # set cpp path
-    # Now use by default the $CPP enviromnement variable first, if not fallback
-    # on the previous behavior, so in order:
-    #   1- if defined use ${CPP}
-    #   2- if clang++ present use it
+    # Now check first if the $CPP enrironment variable is defined, if not
+    # fallback on the previous behavior, so in order:
+    #   1- if defined uses ${CPP}
+    #   2- if clang++ is present, use it
     #   3- otherwise use cpp
     IF(DEFINED ENV{CPP})
         SET(SYS_CPP "$ENV{CPP}")

--- a/cmake/UseCyclus.cmake
+++ b/cmake/UseCyclus.cmake
@@ -89,11 +89,15 @@ MACRO(USE_CYCLUS lib_root src_root)
 
 
     # set cpp path
-    IF("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-        SET(PREPROCESSOR "--cpp-path=clang++")
+    
+    IF(DEFINED ENV{CPP})
+        SET(SYS_CPP "ENV{CPP}")
+    ELSEIF("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+        SET(SYS_CPP "clang++")
     ELSE()
-        SET(PREPROCESSOR "--cpp-path=cpp")
+        SET(SYS_CPP "cpp")
     ENDIF()
+    SET(PREPROCESSOR "--cpp-path=${SYS_CPP}")
 
     # copy custom headers
     FOREACH(fname ${CYCLUS_CUSTOM_HEADERS})

--- a/cmake/UseCyclus.cmake
+++ b/cmake/UseCyclus.cmake
@@ -91,7 +91,7 @@ MACRO(USE_CYCLUS lib_root src_root)
     # set cpp path
     
     IF(DEFINED ENV{CPP})
-        SET(SYS_CPP "ENV{CPP}")
+        SET(SYS_CPP "$ENV{CPP}")
     ELSEIF("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
         SET(SYS_CPP "clang++")
     ELSE()

--- a/cmake/UseCyclus.cmake
+++ b/cmake/UseCyclus.cmake
@@ -91,9 +91,9 @@ MACRO(USE_CYCLUS lib_root src_root)
     # set cpp path
     # Now check first if the $CPP enrironment variable is defined, if not
     # fallback on the previous behavior, so in order:
-    #   1- if defined uses ${CPP}
-    #   2- if clang++ is present, use it
-    #   3- otherwise use cpp
+    #   1- if defined, uses ${CPP}
+    #   2- if clang++ is present, uses it
+    #   3- otherwise, uses cpp
     IF(DEFINED ENV{CPP})
         SET(SYS_CPP "$ENV{CPP}")
     ELSEIF("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")

--- a/src/OsiCbcSolverInterface.cpp
+++ b/src/OsiCbcSolverInterface.cpp
@@ -13,6 +13,9 @@
 
 
 // for some reason these symbol doesn't exist in the mac binaries
+// Those were also not present in condaforge/linux-anvil-comp7 docker container
+// used to build conda recipes, using cpp/cxx 7.3, it also works with the docker
+// in unit test...
 void OsiSolverInterface::addCol(CoinPackedVectorBase const& vec, double collb,
                                 double colub, double obj, std::string name) {
   // just ignore the name

--- a/src/OsiCbcSolverInterface.cpp
+++ b/src/OsiCbcSolverInterface.cpp
@@ -12,7 +12,6 @@
 #endif
 
 
-#ifdef __APPLE__
 // for some reason these symbol doesn't exist in the mac binaries
 void OsiSolverInterface::addCol(CoinPackedVectorBase const& vec, double collb,
                                 double colub, double obj, std::string name) {
@@ -38,4 +37,3 @@ void OsiSolverInterface::addRow(CoinPackedVectorBase const& vec, double rowlb,
   // just ignore the name
   addRow(vec, rowlb, rowub);
 }
-#endif

--- a/src/query_backend.h
+++ b/src/query_backend.h
@@ -6,7 +6,7 @@
 #include <map>
 #include <set>
 
-#include <boost/uuid/sha1.hpp>
+#include <boost/uuid/detail/sha1.hpp>
 
 #include "blob.h"
 #include "rec_backend.h"

--- a/src/query_backend.h
+++ b/src/query_backend.h
@@ -6,7 +6,11 @@
 #include <map>
 #include <set>
 
-#include <boost/uuid/detail/sha1.hpp>
+#if BOOST_VERSION / 100 % 1000 <= 67
+  #include <boost/uuid/sha1.hpp>
+#else
+  #include <boost/uuid/detail/sha1.hpp>
+#endif
 
 #include "blob.h"
 #include "rec_backend.h"


### PR DESCRIPTION
Allows to build a conda recipe for cyclus
Also address deprecation from boost 1.68 also.

change in `src/OsiCbcSolverInterface.cpp` were required to build on `condaforge/linux-anvil-comp7`, I don't know if it will break the linux build... 

the change in `cycpp.py` and in `UseCyclus` should be transparent unless you have a `$CPP` variable setup on your system, if so `cmake` will use this value in place of `cpp` executable...