### PR TITLE
fix docker build_deps

### DIFF
--- a/DEPENDENCIES.rst
+++ b/DEPENDENCIES.rst
@@ -55,7 +55,7 @@ Package                Minimum Version
 ====================   ==================
 doxygen (for docs)     1.7.6.1
 tcmalloc (for speed)   any
-Cython                 0.25+
+Cython                  >=0.25 and  <0.27
 Python (dev version)   2.7 or 3.3+
 Jinja2                 any
 NumPy                  1.9+

--- a/circle.yml
+++ b/circle.yml
@@ -10,16 +10,10 @@ jobs:
             # Ensure your image has git (required by git to clone via SSH) so that CircleCI can clone your repo
             - run: apt-get -qq update; apt-get -y install git openssh-client
             - checkout
-            - run: ln -s /opt/conda/bin/x86_64-conda_cos6-linux-gnu-c++ /opt/conda/bin/g++
-            - run: ln -s /opt/conda/bin/x86_64-conda_cos6-linux-gnu-cc /opt/conda/bin/gcc
             - run:
                 name: Build Docker Image
                 command: |
-                    python install.py -j 2 --build-type=Release --core-version 999999.999999 \
-                    -DBLAS_LIBRARIES="/opt/conda/lib/libblas.so" \
-                    -DLAPACK_LIBRARIES="/opt/conda/lib/liblapack.so" \
-                    -DCMAKE_CXX_COMPILER='/opt/conda/bin/x86_64-conda_cos6-linux-gnu-c++' \
-                    -DCMAKE_C_COMPILER='/opt/conda/bin/x86_64-conda_cos6-linux-gnu-cc'
+                    python install.py -j 2 --build-type=Release --core-version 999999.999999 
             - run:
                 name: save SHA to a file
                 command: echo $CIRCLE_SHA1 > .circle-sha

--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,7 @@ jobs:
         working_directory: ~/cyclus
         steps:
             # Ensure your image has git (required by git to clone via SSH) so that CircleCI can clone your repo
+            - run: source /opt/conda/etc/profile.d/conda.sh
             - checkout
             - run:
                 name: Build Docker Image

--- a/circle.yml
+++ b/circle.yml
@@ -8,12 +8,14 @@ jobs:
         working_directory: ~/cyclus
         steps:
             # Ensure your image has git (required by git to clone via SSH) so that CircleCI can clone your repo
-            - run: source /opt/conda/etc/profile.d/conda.sh
+            - run: apt-get -qq update; apt-get -y install git openssh-client
             - checkout
             - run:
                 name: Build Docker Image
                 command: |
-                    python install.py -j 2 --build-type=Release --core-version 999999.999999 
+                    python install.py -j 2 --build-type=Release --core-version 999999.999999 \
+                    -DBLAS_LIBRARIES="/opt/conda/lib/libblas.so" \
+                    -DLAPACK_LIBRARIES="/opt/conda/lib/liblapack.so"
             - run:
                 name: save SHA to a file
                 command: echo $CIRCLE_SHA1 > .circle-sha

--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,6 @@ jobs:
         working_directory: ~/cyclus
         steps:
             # Ensure your image has git (required by git to clone via SSH) so that CircleCI can clone your repo
-            - run: apt-get -qq update; apt-get -y install git openssh-client
             - checkout
             - run:
                 name: Build Docker Image

--- a/circle.yml
+++ b/circle.yml
@@ -15,7 +15,9 @@ jobs:
                 command: |
                     python install.py -j 2 --build-type=Release --core-version 999999.999999 \
                     -DBLAS_LIBRARIES="/opt/conda/lib/libblas.so" \
-                    -DLAPACK_LIBRARIES="/opt/conda/lib/liblapack.so"
+                    -DLAPACK_LIBRARIES="/opt/conda/lib/liblapack.so" \
+                    -DCMAKE_CXX_COMPILER='/opt/conda/bin/x86_64-conda_cos6-linux-gnu-c++' \
+                    -DCMAKE_C_COMPILER='/opt/conda/bin/x86_64-conda_cos6-linux-gnu-cc'
             - run:
                 name: save SHA to a file
                 command: echo $CIRCLE_SHA1 > .circle-sha

--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,7 @@ jobs:
         working_directory: ~/cyclus
         steps:
             # Ensure your image has git (required by git to clone via SSH) so that CircleCI can clone your repo
+            - run: conda install ssh
             - checkout
             - run:
                 name: Build Docker Image

--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,7 @@ jobs:
         working_directory: ~/cyclus
         steps:
             # Ensure your image has git (required by git to clone via SSH) so that CircleCI can clone your repo
+            - run: yum install ssh 
             - checkout
             - run:
                 name: Build Docker Image

--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,6 @@ jobs:
         working_directory: ~/cyclus
         steps:
             # Ensure your image has git (required by git to clone via SSH) so that CircleCI can clone your repo
-            - run: conda install ssh
             - checkout
             - run:
                 name: Build Docker Image

--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,8 @@ jobs:
             # Ensure your image has git (required by git to clone via SSH) so that CircleCI can clone your repo
             - run: apt-get -qq update; apt-get -y install git openssh-client
             - checkout
+            - run: ln -s /opt/conda/bin/x86_64-conda_cos6-linux-gnu-c++ /opt/conda/bin/g++
+            - run: ln -s /opt/conda/bin/x86_64-conda_cos6-linux-gnu-cc /opt/conda/bin/gcc
             - run:
                 name: Build Docker Image
                 command: |

--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,6 @@ jobs:
         working_directory: ~/cyclus
         steps:
             # Ensure your image has git (required by git to clone via SSH) so that CircleCI can clone your repo
-            - run: yum install ssh 
             - checkout
             - run:
                 name: Build Docker Image

--- a/docker/cyclus-deps/Dockerfile
+++ b/docker/cyclus-deps/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04 
+FROM debian:9 
 
 RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificates \
     libglib2.0-0 libxext6 libsm6 libxrender1

--- a/docker/cyclus-deps/Dockerfile
+++ b/docker/cyclus-deps/Dockerfile
@@ -1,7 +1,7 @@
 FROM condaforge/linux-anvil-comp7
 SHELL ["/bin/bash", "-c"]
 RUN source /opt/conda/etc/profile.d/conda.sh && \
-    conda install -y gxx_linux-64 gcc_linux-64 cmake make docker-pycreds git xo python-json-logger \
+    conda install -y openssh gxx_linux-64 gcc_linux-64 cmake make docker-pycreds git xo python-json-logger \
                      python=3.6 glibmm glib=2.56 libxml2 libxmlpp libblas \
                      libcblas liblapack pkg-config coincbc=2.9 boost-cpp hdf5 \
                      sqlite pcre gettext bzip2 xz setuptools nose pytables \

--- a/docker/cyclus-deps/Dockerfile
+++ b/docker/cyclus-deps/Dockerfile
@@ -41,7 +41,7 @@ RUN conda update -y --all && \
 
 ENV CC /opt/conda/bin/x86_64-conda_cos6-linux-gnu-gcc
 ENV CXX /opt/conda/bin/x86_64-conda_cos6-linux-gnu-g++
-ENV CPP /opt/conda/bin/x86_64-conda_cos6-linux-gnu-cc
+ENV CPP /opt/conda/bin/x86_64-conda_cos6-linux-gnu-cpp
 
 
 #

--- a/docker/cyclus-deps/Dockerfile
+++ b/docker/cyclus-deps/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:8.5
-
+RUN sed -i '/jessie-updates/d' /etc/apt/sources.list  # Now archived
 RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificates \
     libglib2.0-0 libxext6 libsm6 libxrender1
 

--- a/docker/cyclus-deps/Dockerfile
+++ b/docker/cyclus-deps/Dockerfile
@@ -1,9 +1,45 @@
-FROM condaforge/linux-anvil-comp7
-SHELL ["/bin/bash", "-c"]
-RUN source /opt/conda/etc/profile.d/conda.sh && \
+FROM ubuntu:18.04 
+
+RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificates \
+    libglib2.0-0 libxext6 libsm6 libxrender1
+
+RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
+    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
+    /bin/bash ~/miniconda.sh -b -p /opt/conda && \
+    rm ~/miniconda.sh
+
+RUN apt-get install -y curl grep sed dpkg && \
+    TINI_VERSION=`curl https://github.com/krallin/tini/releases/latest | grep -o "/v.*\"" | sed 's:^..\(.*\).$:\1:'` && \
+    curl -L "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini_${TINI_VERSION}.deb" > tini.deb && \
+    dpkg -i tini.deb && \
+    rm tini.deb && \
+    apt-get clean
+
+ENV PATH /root/.local/bin:/opt/conda/bin:$PATH
+
+ENTRYPOINT [ "/usr/bin/tini", "--" ]
+CMD [ "/bin/bash" ]
+
+#
+# apt packages
+#
+RUN apt-get update && \
+    apt-get install -y g++ gcc vim nano && \
+    apt-get clean
+
+#
+# conda packages
+#
+RUN conda config --add channels conda-forge
+RUN conda update -y --all && \
     conda install -y openssh gxx_linux-64 gcc_linux-64 cmake make docker-pycreds git xo python-json-logger \
-                     python=3.6 glibmm glib=2.56 libxml2 libxmlpp libblas \
-                     libcblas liblapack pkg-config coincbc=2.9 boost-cpp hdf5 \
-                     sqlite pcre gettext bzip2 xz setuptools nose pytables \
-                     pandas jinja2 cython websockets pprintpp &&\
+	                     python=3.6 glibmm glib=2.56 libxml2 libxmlpp libblas \
+	                     libcblas liblapack pkg-config coincbc=2.9 boost-cpp hdf5 \
+	                     sqlite pcre gettext bzip2 xz setuptools nose pytables \
+	                     pandas jinja2 cython websockets pprintpp &&\
     conda clean -y --all
+
+#
+# pip packages to overide conda
+#
+RUN pip install docker

--- a/docker/cyclus-deps/Dockerfile
+++ b/docker/cyclus-deps/Dockerfile
@@ -36,7 +36,7 @@ RUN conda update -y --all && \
                      python=3.6 glibmm glib=2.56 libxml2 libxmlpp libblas \
                      libcblas liblapack pkg-config coincbc=2.9 boost-cpp hdf5 \
                      sqlite pcre gettext bzip2 xz setuptools nose pytables \
-                     pandas jinja2 cython websockets pprintpp&& \
+                     pandas jinja2 cython websockets pprintpp gxx_linux-64 gcc_linux-64&& \
     conda clean -y --all
 
 #

--- a/docker/cyclus-deps/Dockerfile
+++ b/docker/cyclus-deps/Dockerfile
@@ -36,7 +36,7 @@ RUN conda update -y --all && \
 	                     python=3.6 glibmm glib=2.56 libxml2 libxmlpp libblas \
 	                     libcblas liblapack pkg-config coincbc=2.9 boost-cpp hdf5 \
 	                     sqlite pcre gettext bzip2 xz setuptools nose pytables \
-	                     pandas jinja2 cython websockets pprintpp &&\
+	                     pandas jinja2 cython==0.26 websockets pprintpp &&\
     conda clean -y --all
 
 #

--- a/docker/cyclus-deps/Dockerfile
+++ b/docker/cyclus-deps/Dockerfile
@@ -39,6 +39,10 @@ RUN conda update -y --all && \
 	                     pandas jinja2 cython==0.26 websockets pprintpp &&\
     conda clean -y --all
 
+ENV CC /opt/conda/bin/x86_64-conda_cos6-linux-gnu-cc
+ENV CXX /opt/conda/bin/x86_64-conda_cos6-linux-gnu-cpp
+
+
 #
 # pip packages to overide conda
 #

--- a/docker/cyclus-deps/Dockerfile
+++ b/docker/cyclus-deps/Dockerfile
@@ -32,8 +32,11 @@ RUN apt-get update && \
 #
 RUN conda config --add channels conda-forge
 RUN conda update -y --all && \
-    conda install -y gcc make docker-pycreds git xo xonsh python-json-logger \
-                     cyclus-build-deps websockets pprintpp && \
+    conda install -y cmake make docker-pycreds git xo python-json-logger \
+                     python=3.6 glibmm glib=2.56 libxml2 libxmlpp libblas \
+                     libcblas liblapack pkg-config coincbc=2.9 boost-cpp hdf5 \
+                     sqlite pcre gettext bzip2 xz setuptools nose pytables \
+                     pandas jinja2 cython websockets pprintpp&& \
     conda clean -y --all
 
 #

--- a/docker/cyclus-deps/Dockerfile
+++ b/docker/cyclus-deps/Dockerfile
@@ -41,6 +41,7 @@ RUN conda update -y --all && \
 
 ENV CC /opt/conda/bin/x86_64-conda_cos6-linux-gnu-gcc
 ENV CXX /opt/conda/bin/x86_64-conda_cos6-linux-gnu-g++
+ENV CPP /opt/conda/bin/x86_64-conda_cos6-linux-gnu-cc
 
 
 #

--- a/docker/cyclus-deps/Dockerfile
+++ b/docker/cyclus-deps/Dockerfile
@@ -24,7 +24,7 @@ CMD [ "/bin/bash" ]
 # apt packages
 #
 RUN apt-get update && \
-    apt-get install -y gcc vim nano && \
+    apt-get install -y vim nano && \
     apt-get clean
 
 #
@@ -32,11 +32,11 @@ RUN apt-get update && \
 #
 RUN conda config --add channels conda-forge
 RUN conda update -y --all && \
-    conda install -y cmake make docker-pycreds git xo python-json-logger \
+    conda install -y gxx_linux-64 gcc_linux-64 cmake make docker-pycreds git xo python-json-logger \
                      python=3.6 glibmm glib=2.56 libxml2 libxmlpp libblas \
                      libcblas liblapack pkg-config coincbc=2.9 boost-cpp hdf5 \
                      sqlite pcre gettext bzip2 xz setuptools nose pytables \
-                     pandas jinja2 cython websockets pprintpp gxx_linux-64 gcc_linux-64&& \
+                     pandas jinja2 cython websockets pprintpp &&\
     conda clean -y --all
 
 #

--- a/docker/cyclus-deps/Dockerfile
+++ b/docker/cyclus-deps/Dockerfile
@@ -24,7 +24,7 @@ CMD [ "/bin/bash" ]
 # apt packages
 #
 RUN apt-get update && \
-    apt-get install -y g++ gcc vim nano && \
+    apt-get install -y vim nano && \
     apt-get clean
 
 #

--- a/docker/cyclus-deps/Dockerfile
+++ b/docker/cyclus-deps/Dockerfile
@@ -1,45 +1,9 @@
-FROM debian:8.5
-RUN sed -i '/jessie-updates/d' /etc/apt/sources.list  # Now archived
-RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificates \
-    libglib2.0-0 libxext6 libsm6 libxrender1
-
-RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
-    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
-    /bin/bash ~/miniconda.sh -b -p /opt/conda && \
-    rm ~/miniconda.sh
-
-RUN apt-get install -y curl grep sed dpkg && \
-    TINI_VERSION=`curl https://github.com/krallin/tini/releases/latest | grep -o "/v.*\"" | sed 's:^..\(.*\).$:\1:'` && \
-    curl -L "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini_${TINI_VERSION}.deb" > tini.deb && \
-    dpkg -i tini.deb && \
-    rm tini.deb && \
-    apt-get clean
-
-ENV PATH /root/.local/bin:/opt/conda/bin:$PATH
-
-ENTRYPOINT [ "/usr/bin/tini", "--" ]
-CMD [ "/bin/bash" ]
-
-#
-# apt packages
-#
-RUN apt-get update && \
-    apt-get install -y vim nano && \
-    apt-get clean
-
-#
-# conda packages
-#
-RUN conda config --add channels conda-forge
-RUN conda update -y --all && \
+FROM condaforge/linux-anvil-comp7
+SHELL ["/bin/bash", "-c"]
+RUN source /opt/conda/etc/profile.d/conda.sh && \
     conda install -y gxx_linux-64 gcc_linux-64 cmake make docker-pycreds git xo python-json-logger \
                      python=3.6 glibmm glib=2.56 libxml2 libxmlpp libblas \
                      libcblas liblapack pkg-config coincbc=2.9 boost-cpp hdf5 \
                      sqlite pcre gettext bzip2 xz setuptools nose pytables \
                      pandas jinja2 cython websockets pprintpp &&\
     conda clean -y --all
-
-#
-# pip packages to overide conda
-#
-RUN pip install docker

--- a/docker/cyclus-deps/Dockerfile
+++ b/docker/cyclus-deps/Dockerfile
@@ -39,8 +39,8 @@ RUN conda update -y --all && \
 	                     pandas jinja2 cython==0.26 websockets pprintpp &&\
     conda clean -y --all
 
-ENV CC /opt/conda/bin/x86_64-conda_cos6-linux-gnu-cc
-ENV CXX /opt/conda/bin/x86_64-conda_cos6-linux-gnu-cpp
+ENV CC /opt/conda/bin/x86_64-conda_cos6-linux-gnu-gcc
+ENV CXX /opt/conda/bin/x86_64-conda_cos6-linux-gnu-g++
 
 
 #

--- a/src/query_backend.h
+++ b/src/query_backend.h
@@ -5,6 +5,7 @@
 #include <list>
 #include <map>
 #include <set>
+#include <boost/version.hpp>
 
 #if BOOST_VERSION / 100 % 1000 <= 67
   #include <boost/uuid/sha1.hpp>

--- a/tests/cycpp_tests.py
+++ b/tests/cycpp_tests.py
@@ -1181,7 +1181,12 @@ def test_nuclide_uitype():
 def test_integration():
     inf = os.path.join(os.path.dirname(__file__), 'cycpp_tests.h')
     outf = tempfile.NamedTemporaryFile()
-    cmd = 'cycpp.py {} -o {} --cpp-path `which g++`'.format(inf, outf.name)
+    cmd = ""
+    # if CXX is set use it, fallback on g++ otherwise
+    if os.getenv("CXX") is not None:
+        cmd = 'cycpp.py {} -o {} --cpp-path `which $CXX`'.format(inf, outf.name)
+    else: 
+        cmd = 'cycpp.py {} -o {} --cpp-path `which g++`'.format(inf, outf.name)
     p = Popen(cmd, shell=True, stdin=PIPE, stdout=PIPE, stderr=STDOUT, close_fds=True)
     assert_equal('', p.stdout.read().decode())
 


### PR DESCRIPTION
the `jessie-updates` apt-get depots have been archived... This allows to remove them form the sources.list in the `cyclus-build-dpes` docker container

this fix #1504 (docker container already updated accordingly in dockerHub