### PR TITLE
Fix deploy_latest job

### DIFF
--- a/docker/cyclus-ci/Dockerfile
+++ b/docker/cyclus-ci/Dockerfile
@@ -7,8 +7,6 @@ WORKDIR /cyclus
 # This is sometimes useful for debugging.
 #ENV VERBOSE=1
 
-RUN conda update -y --all && conda clean -y --all
-
 # You may add the option "--cmake-debug" to the following command
 # for further CMake debugging.
 RUN python install.py -j 2 --build-type=Release --core-version 999999.999999 \


### PR DESCRIPTION
This should fix the deploy_latest job allowing us to get a `cyclus/cyclus` working docker image, which `cycamore` and `cycmetric` CI relies on.