### PR TITLE
Improve the CI speed

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -20,8 +20,6 @@ jobs:
             - image: cyclus/cyclus-deps
         working_directory: ~/cyclus
         steps:
-            # Ensure your image has git (required by git to clone via SSH) so that CircleCI can clone your repo
-            - run: apt-get -qq update; apt-get -y install git openssh-client
             - checkout
             - run:
                 name: Build Cyclus

--- a/docker/cyclus-deps/Dockerfile
+++ b/docker/cyclus-deps/Dockerfile
@@ -24,7 +24,7 @@ CMD [ "/bin/bash" ]
 # apt packages
 #
 RUN apt-get update && \
-    apt-get install -y vim nano && \
+    apt-get install -y openssh-client vim nano && \
     apt-get clean
 
 #

--- a/docker/cyclus-deps/Dockerfile
+++ b/docker/cyclus-deps/Dockerfile
@@ -24,7 +24,9 @@ CMD [ "/bin/bash" ]
 # apt packages
 #
 RUN apt-get update && \
-    apt-get install -y openssh-client vim nano && \
+    apt-get install -y openssh-client \
+                       git \
+                       vim nano && \
     apt-get clean
 
 #

--- a/news/faster_ci.rst
+++ b/news/faster_ci.rst
@@ -1,0 +1,12 @@
+**Added:** None
+
+**Changed:** None
+-  git and open-ssh added to the dockerfile (removed from CI)
+
+**Deprecated:** None
+
+**Removed:** None
+-  git and open-ssh form CI (added to the dockerfile)
+**Fixed:** None
+
+**Security:** None

--- a/news/faster_ci.rst
+++ b/news/faster_ci.rst
@@ -6,7 +6,7 @@
 **Deprecated:** None
 
 **Removed:** None
--  git and open-ssh form CI (added to the dockerfile)
+-  git and open-ssh from CI (added to the dockerfile)
 **Fixed:** None
 
 **Security:** None


### PR DESCRIPTION
this should improve CI speed by removing installation of `git` and `openssh` in the docker image