### PR TITLE
Python 3.7 name conflict fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,7 +374,7 @@ IF(NOT CYCLUS_DOC_ONLY)
 
 
     if(Cython_FOUND)
-        INCLUDE_DIRECTORIES("${PYTHON_INCLUDE_DIRS}"
+        INCLUDE_DIRECTORIES(AFTER "${PYTHON_INCLUDE_DIRS}"
             "${NUMPY_INCLUDE_DIRS}")
     endif(Cython_FOUND)
     # set core version, one way or the other

--- a/agents/CMakeLists.txt
+++ b/agents/CMakeLists.txt
@@ -1,4 +1,4 @@
-INCLUDE_DIRECTORIES(${CYCLUS_CORE_INCLUDE_DIRS})
+INCLUDE_DIRECTORIES(BEFORE ${CYCLUS_CORE_INCLUDE_DIRS})
 
 use_cyclus("agents" "null_inst")
 use_cyclus("agents" "null_region")

--- a/circle.yml
+++ b/circle.yml
@@ -27,7 +27,7 @@ jobs:
             - run:
                 name: Build Docker Image
                 command: |
-                    python install.py -j 2 --build-type=Release --core-version 999999.999999 \
+                    python install.py -j 2 --prefix="/home/conda/.local" --build-type=Release --core-version 999999.999999 \
                     -DBLAS_LIBRARIES="/opt/conda/lib/libblas.so" \
                     -DLAPACK_LIBRARIES="/opt/conda/lib/liblapack.so"
             - run:
@@ -57,7 +57,7 @@ jobs:
 
     nosetest:
         docker:
-            - image: cyclus/cyclus-deps
+            - image: cyclus/cyclus-deps_py37
         working_directory: /root
         steps:
             - run:

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ jobs:
     # News update check
     news_update:
         docker:
-            - image: cyclus/cyclus-deps
+            - image: cyclus/cyclus-deps_py37
         working_directory: ~/cyclus
         steps:
             # Ensure your image has git (required by git to clone via SSH) so that CircleCI can clone your repo

--- a/circle.yml
+++ b/circle.yml
@@ -24,6 +24,8 @@ jobs:
             - run:
                 name: Build Cyclus
                 command: mkdir -p /root/.local/lib/python3.7/site-packages
+            - run:
+                name: Build Docker Image
                 command: |
                     python install.py -j 2 --build-type=Release --core-version 999999.999999 \
                     -DBLAS_LIBRARIES="/opt/conda/lib/libblas.so" \

--- a/circle.yml
+++ b/circle.yml
@@ -42,7 +42,7 @@ jobs:
     # Test Jobs
     unit_test:
         docker:
-            - image: cyclus/cyclus-deps_py37
+            - image: cyclus/cyclus-deps
         working_directory: /root
         steps:
             - run:
@@ -57,7 +57,7 @@ jobs:
 
     nosetest:
         docker:
-            - image: cyclus/cyclus-deps_py37
+            - image: cyclus/cyclus-deps
         working_directory: /root
         steps:
             - run:
@@ -132,7 +132,7 @@ jobs:
 # Checking Cycamore and Cymetric compatibilities with the changes
     cycamore_master: ## Cycamore/master against Cyclus/dev
         docker:
-            - image: cyclus/cyclus-deps_py37
+            - image: cyclus/cyclus-deps
         working_directory: /root
         steps:
             # Ensure your image has git (required by git to clone via SSH) so that CircleCI can clone your repo
@@ -166,7 +166,7 @@ jobs:
 
     cymetric_master: ## Cymetric/master against Cyclus/dev + Cycamore/dev
         docker:
-            - image: cyclus/cyclus-deps_py37
+            - image: cyclus/cyclus-deps
         working_directory: /root
         steps:
             # Ensure your image has git (required by git to clone via SSH) so that CircleCI can clone your repo

--- a/circle.yml
+++ b/circle.yml
@@ -23,6 +23,7 @@ jobs:
             - checkout
             - run:
                 name: Build Cyclus
+                command: mkdir -p /root/.local/lib/python3.7/site-packages
                 command: |
                     python install.py -j 2 --build-type=Release --core-version 999999.999999 \
                     -DBLAS_LIBRARIES="/opt/conda/lib/libblas.so" \

--- a/circle.yml
+++ b/circle.yml
@@ -132,7 +132,7 @@ jobs:
 # Checking Cycamore and Cymetric compatibilities with the changes
     cycamore_master: ## Cycamore/master against Cyclus/dev
         docker:
-            - image: cyclus/cyclus-deps
+            - image: cyclus/cyclus-deps_py37
         working_directory: /root
         steps:
             # Ensure your image has git (required by git to clone via SSH) so that CircleCI can clone your repo
@@ -166,7 +166,7 @@ jobs:
 
     cymetric_master: ## Cymetric/master against Cyclus/dev + Cycamore/dev
         docker:
-            - image: cyclus/cyclus-deps
+            - image: cyclus/cyclus-deps_py37
         working_directory: /root
         steps:
             # Ensure your image has git (required by git to clone via SSH) so that CircleCI can clone your repo

--- a/circle.yml
+++ b/circle.yml
@@ -42,7 +42,7 @@ jobs:
     # Test Jobs
     unit_test:
         docker:
-            - image: cyclus/cyclus-deps
+            - image: cyclus/cyclus-deps_py37
         working_directory: /root
         steps:
             - run:

--- a/circle.yml
+++ b/circle.yml
@@ -27,7 +27,7 @@ jobs:
             - run:
                 name: Build Docker Image
                 command: |
-                    python install.py -j 2 --prefix="/home/conda/.local" --build-type=Release --core-version 999999.999999 \
+                    python install.py -j 2 --build-type=Release --core-version 999999.999999 \
                     -DBLAS_LIBRARIES="/opt/conda/lib/libblas.so" \
                     -DLAPACK_LIBRARIES="/opt/conda/lib/liblapack.so"
             - run:

--- a/circle.yml
+++ b/circle.yml
@@ -3,11 +3,9 @@ jobs:
     # News update check
     news_update:
         docker:
-            - image: cyclus/cyclus-deps_py37
+            - image: cyclus/cyclus-deps
         working_directory: ~/cyclus
         steps:
-            # Ensure your image has git (required by git to clone via SSH) so that CircleCI can clone your repo
-            - run: apt-get -qq update; apt-get -y install git openssh-client
             - checkout
             - run: git fetch --all
             - run:
@@ -23,9 +21,6 @@ jobs:
             - checkout
             - run:
                 name: Build Cyclus
-                command: mkdir -p /root/.local/lib/python3.7/site-packages
-            - run:
-                name: Build Docker Image
                 command: |
                     python install.py -j 2 --build-type=Release --core-version 999999.999999 \
                     -DBLAS_LIBRARIES="/opt/conda/lib/libblas.so" \

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -2,7 +2,7 @@
 ##################################### begin cyclus app #######################################
 ##############################################################################################
 
-INCLUDE_DIRECTORIES(${CYCLUS_CORE_INCLUDE_DIRS})
+INCLUDE_DIRECTORIES(BEFORE ${CYCLUS_CORE_INCLUDE_DIRS})
 
 # Build the cyclus executable from the CYCLUS_SOURCE source files
 SET(CYCLUS_SOURCE ${CYCLUS_SOURCE}

--- a/docker/cyclus-deps/Dockerfile
+++ b/docker/cyclus-deps/Dockerfile
@@ -73,7 +73,7 @@ RUN conda update -y --all && \
 ENV CC /opt/conda/bin/x86_64-conda_cos6-linux-gnu-gcc
 ENV CXX /opt/conda/bin/x86_64-conda_cos6-linux-gnu-g++
 ENV CPP /opt/conda/bin/x86_64-conda_cos6-linux-gnu-cpp
-ENV PYTHONPATH /home/conda/.local/lib/python3.7/site-packages/
+ENV PYTHONPATH "/home/conda/.local/lib/python3.7/site-packages/:/root/.local/lib/python3.7/site-packages/"
 # required for the nosetest
 ENV PYTHONWARNINGS ignore
 RUN mkdir -p /root/.local/lib/python3.7/site-packages/

--- a/docker/cyclus-deps/Dockerfile
+++ b/docker/cyclus-deps/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificate
     libglib2.0-0 libxext6 libsm6 libxrender1
 
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
-    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
+    wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
     /bin/bash ~/miniconda.sh -b -p /opt/conda && \
     rm ~/miniconda.sh
 
@@ -33,21 +33,21 @@ RUN apt-get update && \
 # conda packages
 #
 RUN conda config --add channels conda-forge
+RUN conda update -n base -c defaults conda
 RUN conda update -y --all && \
     conda install -y openssh gxx_linux-64 gcc_linux-64 cmake make docker-pycreds git xo python-json-logger \
-                         python glibmm glib=2.56 libxml2 libxmlpp libblas \
+                         glib=2.56 libxml2 libxmlpp libblas \
                          libcblas liblapack pkg-config coincbc=2.9 boost-cpp hdf5 \
                          sqlite pcre gettext bzip2 xz setuptools nose pytables \
-                         pandas jinja2 cython==0.28 websockets pprintpp &&\
+                         pandas jinja2 "cython<=0.28.5" websockets pprintpp &&\
     conda clean -y --all
-
 ENV CC /opt/conda/bin/x86_64-conda_cos6-linux-gnu-gcc
 ENV CXX /opt/conda/bin/x86_64-conda_cos6-linux-gnu-g++
 ENV CPP /opt/conda/bin/x86_64-conda_cos6-linux-gnu-cpp
 ENV PYTHONPATH /home/conda/.local/lib/python3.7/site-packages/
 # required for the nosetest
 ENV PYTHONWARNINGS ignore
-
+RUN mkdir -p /root/.local/lib/python3.7/site-packages/
 #
 # pip packages to overide conda
 #

--- a/docker/cyclus-deps/Dockerfile
+++ b/docker/cyclus-deps/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && \
 RUN conda config --add channels conda-forge
 RUN conda update -y --all && \
     conda install -y openssh gxx_linux-64 gcc_linux-64 cmake make docker-pycreds git xo python-json-logger \
-                         python=3.6 glibmm glib=2.56 libxml2 libxmlpp libblas \
+                         python=3.7 glibmm glib=2.56 libxml2 libxmlpp libblas \
                          libcblas liblapack pkg-config coincbc=2.9 boost-cpp hdf5 \
                          sqlite pcre gettext bzip2 xz setuptools nose pytables \
                          pandas jinja2 cython==0.28 websockets pprintpp &&\

--- a/docker/cyclus-deps/Dockerfile
+++ b/docker/cyclus-deps/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:9 
+FROM debian:9
 
 RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificates \
     libglib2.0-0 libxext6 libsm6 libxrender1
@@ -35,16 +35,18 @@ RUN apt-get update && \
 RUN conda config --add channels conda-forge
 RUN conda update -y --all && \
     conda install -y openssh gxx_linux-64 gcc_linux-64 cmake make docker-pycreds git xo python-json-logger \
-	                     python=3.6 glibmm glib=2.56 libxml2 libxmlpp libblas \
-	                     libcblas liblapack pkg-config coincbc=2.9 boost-cpp hdf5 \
-	                     sqlite pcre gettext bzip2 xz setuptools nose pytables \
-	                     pandas jinja2 cython==0.26 websockets pprintpp &&\
+                         python=3.6 glibmm glib=2.56 libxml2 libxmlpp libblas \
+                         libcblas liblapack pkg-config coincbc=2.9 boost-cpp hdf5 \
+                         sqlite pcre gettext bzip2 xz setuptools nose pytables \
+                         pandas jinja2 cython==0.26 websockets pprintpp &&\
     conda clean -y --all
 
 ENV CC /opt/conda/bin/x86_64-conda_cos6-linux-gnu-gcc
 ENV CXX /opt/conda/bin/x86_64-conda_cos6-linux-gnu-g++
 ENV CPP /opt/conda/bin/x86_64-conda_cos6-linux-gnu-cpp
 
+# required for the nosetest
+ENV PYTHONWARNINGS ignore
 
 #
 # pip packages to overide conda

--- a/docker/cyclus-deps/Dockerfile
+++ b/docker/cyclus-deps/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && \
 RUN conda config --add channels conda-forge
 RUN conda update -y --all && \
     conda install -y openssh gxx_linux-64 gcc_linux-64 cmake make docker-pycreds git xo python-json-logger \
-                         python=3.7 glibmm glib=2.56 libxml2 libxmlpp libblas \
+                         python glibmm glib=2.56 libxml2 libxmlpp libblas \
                          libcblas liblapack pkg-config coincbc=2.9 boost-cpp hdf5 \
                          sqlite pcre gettext bzip2 xz setuptools nose pytables \
                          pandas jinja2 cython==0.28 websockets pprintpp &&\
@@ -44,7 +44,7 @@ RUN conda update -y --all && \
 ENV CC /opt/conda/bin/x86_64-conda_cos6-linux-gnu-gcc
 ENV CXX /opt/conda/bin/x86_64-conda_cos6-linux-gnu-g++
 ENV CPP /opt/conda/bin/x86_64-conda_cos6-linux-gnu-cpp
-
+ENV PYTHONPATH /home/conda/.local/lib/python3.7/site-packages/
 # required for the nosetest
 ENV PYTHONWARNINGS ignore
 

--- a/docker/cyclus-deps/Dockerfile
+++ b/docker/cyclus-deps/Dockerfile
@@ -38,7 +38,7 @@ RUN conda update -y --all && \
                          python=3.6 glibmm glib=2.56 libxml2 libxmlpp libblas \
                          libcblas liblapack pkg-config coincbc=2.9 boost-cpp hdf5 \
                          sqlite pcre gettext bzip2 xz setuptools nose pytables \
-                         pandas jinja2 cython==0.26 websockets pprintpp &&\
+                         pandas jinja2 cython==0.28 websockets pprintpp &&\
     conda clean -y --all
 
 ENV CC /opt/conda/bin/x86_64-conda_cos6-linux-gnu-gcc

--- a/docker/cyclus-deps/Dockerfile
+++ b/docker/cyclus-deps/Dockerfile
@@ -35,11 +35,40 @@ RUN apt-get update && \
 RUN conda config --add channels conda-forge
 RUN conda update -n base -c defaults conda
 RUN conda update -y --all && \
-    conda install -y openssh gxx_linux-64 gcc_linux-64 cmake make docker-pycreds git xo python-json-logger \
-                         glib=2.56 libxml2 libxmlpp libblas \
-                         libcblas liblapack pkg-config coincbc=2.9 boost-cpp hdf5 \
-                         sqlite pcre gettext bzip2 xz setuptools nose pytables \
-                         pandas jinja2 "cython<=0.28.5" websockets pprintpp &&\
+    conda install -y \
+               openssh \
+               gxx_linux-64 \
+               gcc_linux-64 \
+               cmake \
+               make \
+               docker-pycreds \
+               git \
+               xo \
+               python-json-logger \
+               glib=2.56 \
+               libxml2 \
+               libxmlpp \
+               libblas \
+               libcblas \
+               liblapack \
+               pkg-config \
+               coincbc=2.9 \
+               boost-cpp \
+               hdf5 \
+               sqlite \
+               pcre \
+               gettext \
+               bzip2 \
+               xz \
+               setuptools \
+               nose \
+               pytables \
+               pandas \
+               jinja2 \
+               "cython<=0.28.5" \
+               websockets \
+               pprintpp \
+               && \
     conda clean -y --all
 ENV CC /opt/conda/bin/x86_64-conda_cos6-linux-gnu-gcc
 ENV CXX /opt/conda/bin/x86_64-conda_cos6-linux-gnu-g++

--- a/news/py37_compatibility.rst
+++ b/news/py37_compatibility.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+- allows build against Python => 3.7
+- change cyclus-deps Docekrfile accordingly. (changing cython version to 0.28.5)
+
+**Security:** None

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ import re
 import os
 import sys
 from distutils.core import setup
+import setuptools
 from pprint import pprint
 
 PROJECT = 'cyclus'

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -157,7 +157,7 @@ endif(Cython_FOUND)
 ######### build libcyclus #######################################
 #################################################################
 
-INCLUDE_DIRECTORIES("${CMAKE_CURRENT_SOURCE_DIR}")
+INCLUDE_DIRECTORIES(BEFORE "${CMAKE_CURRENT_SOURCE_DIR}")
 
 set(CYCLUS_COIN_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/prog_solver.cc"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,7 +28,7 @@ SET(GTest
     "${CMAKE_CURRENT_SOURCE_DIR}/GoogleTest/gtest/gtest-all.cc"
     )
 
-INCLUDE_DIRECTORIES("${CMAKE_CURRENT_SOURCE_DIR}")
+INCLUDE_DIRECTORIES(BEFORE "${CMAKE_CURRENT_SOURCE_DIR}")
 
 ADD_LIBRARY(gtest ${GTest})
 
@@ -59,7 +59,7 @@ INSTALL(FILES GoogleTest/gtest/gtest.h
 ################################### begin cyclus testing ######################
 ###############################################################################
 
-INCLUDE_DIRECTORIES(${CYCLUS_CORE_INCLUDE_DIRS})
+INCLUDE_DIRECTORIES(BEFORE ${CYCLUS_CORE_INCLUDE_DIRS})
 
 set(CYCLUS_TEST_COIN_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/solver_factory_tests.cc"

--- a/tests/test_agents/CMakeLists.txt
+++ b/tests/test_agents/CMakeLists.txt
@@ -1,4 +1,4 @@
-INCLUDE_DIRECTORIES(${CYCLUS_CORE_INCLUDE_DIRS})
+INCLUDE_DIRECTORIES(BEFORE ${CYCLUS_CORE_INCLUDE_DIRS})
 
 install_cyclus_standalone("TestAgent" "test_agent" "tests")
 install_cyclus_standalone("TestFacility" "test_facility" "tests")


### PR DESCRIPTION
This resolve #1528 .

sadly it brings back the `cython > 0.27` issue (segfault) ##1512


Note: CI in its actual state will only test the `python3.6(+cython=0.26)` compatibility....