### PR TITLE
Life time

### DIFF
--- a/cyclus/agents.pyx
+++ b/cyclus/agents.pyx
@@ -586,7 +586,7 @@ cdef cppclass CyclusFacilityShim "CyclusFacilityShim" (cpp_cyclus.Facility):
         (<object> this.self).decision()
 
     cpp_bool CheckDecommissionCondition() except +:
-        rtn = (<object> this.self).check_decomission_condition()
+        rtn = (<object> this.self).check_decommission_condition()
         return bool_to_cpp(rtn)
 
     std_set[shared_ptr[cpp_cyclus.RequestPortfolio[cpp_cyclus.Material]]] GetMatlRequests() except +:
@@ -1101,7 +1101,7 @@ cdef class _Region(_Agent):
         rtn = bool_to_py((<CyclusRegionShim*> (<_Agent> self).shim).DecendentOf(cpp_other))
         return rtn
 
-    def decomission(self):
+    def Decommission(self):
         """Decommissions the agent, removing it from the simulation. Results in
         destruction of the agent object. If agents write their own decommission()
         function, they must call their superclass' decommission function at the
@@ -1199,7 +1199,7 @@ cdef class _Region(_Agent):
         """The default time step at which this agent will exit the
         simulation (-1 if the agent has an infinite lifetime).
 
-        Decomissioning happens at the end of a time step. With a lifetime of 1, we
+        decommissioning happens at the end of a time step. With a lifetime of 1, we
         expect an agent to go through only 1 entire time step. In this case, the
         agent should be decommissioned on the same time step it was
         created. Therefore, for agents with non-infinite lifetimes, the exit_time
@@ -1301,7 +1301,7 @@ cdef class _Institution(_Agent):
         rtn = bool_to_py((<CyclusInstitutionShim*> (<_Agent> self).shim).DecendentOf(cpp_other))
         return rtn
 
-    def decomission(self):
+    def Decommission(self):
         """Decommissions the agent, removing it from the simulation. Results in
         destruction of the agent object. If agents write their own decommission()
         function, they must call their superclass' decommission function at the
@@ -1399,7 +1399,7 @@ cdef class _Institution(_Agent):
         """The default time step at which this agent will exit the
         simulation (-1 if the agent has an infinite lifetime).
 
-        Decomissioning happens at the end of a time step. With a lifetime of 1, we
+        decommissioning happens at the end of a time step. With a lifetime of 1, we
         expect an agent to go through only 1 entire time step. In this case, the
         agent should be decommissioned on the same time step it was
         created. Therefore, for agents with non-infinite lifetimes, the exit_time
@@ -1502,13 +1502,15 @@ cdef class _Facility(_Agent):
         rtn = bool_to_py((<CyclusFacilityShim*> (<_Agent> self).shim).DecendentOf(cpp_other))
         return rtn
 
-    def decomission(self):
+    def Decommission(self):
         """Decommissions the agent, removing it from the simulation. Results in
         destruction of the agent object. If agents write their own decommission()
         function, they must call their superclass' decommission function at the
         END of their decommission() function.
         """
+        print('decomm2py')
         (<CyclusFacilityShim*> (<_Agent> self).shim).Decommission()
+        print('enddecomm2py')
 
     @property
     def annotations(self):
@@ -1600,7 +1602,7 @@ cdef class _Facility(_Agent):
         """The default time step at which this agent will exit the
         simulation (-1 if the agent has an infinite lifetime).
 
-        Decomissioning happens at the end of a time step. With a lifetime of 1, we
+        decommissioning happens at the end of a time step. With a lifetime of 1, we
         expect an agent to go through only 1 entire time step. In this case, the
         agent should be decommissioned on the same time step it was
         created. Therefore, for agents with non-infinite lifetimes, the exit_time
@@ -1647,10 +1649,10 @@ class Facility(_Facility):
         """
         pass
 
-    def check_decomission_condition(self):
+    def check_decommission_condition(self):
         """facilities over write this method if a condition must be met
         before their destructors can be called. Return True means that
-        the facility is ready for decomission. False prevents decomission.
+        the facility is ready for decommission. False prevents decommission.
         """
         return True
 

--- a/cyclus/agents.pyx
+++ b/cyclus/agents.pyx
@@ -1101,7 +1101,7 @@ cdef class _Region(_Agent):
         rtn = bool_to_py((<CyclusRegionShim*> (<_Agent> self).shim).DecendentOf(cpp_other))
         return rtn
 
-    def Decommission(self):
+    def decommission(self):
         """Decommissions the agent, removing it from the simulation. Results in
         destruction of the agent object. If agents write their own decommission()
         function, they must call their superclass' decommission function at the
@@ -1301,7 +1301,7 @@ cdef class _Institution(_Agent):
         rtn = bool_to_py((<CyclusInstitutionShim*> (<_Agent> self).shim).DecendentOf(cpp_other))
         return rtn
 
-    def Decommission(self):
+    def decommission(self):
         """Decommissions the agent, removing it from the simulation. Results in
         destruction of the agent object. If agents write their own decommission()
         function, they must call their superclass' decommission function at the
@@ -1502,7 +1502,7 @@ cdef class _Facility(_Agent):
         rtn = bool_to_py((<CyclusFacilityShim*> (<_Agent> self).shim).DecendentOf(cpp_other))
         return rtn
 
-    def Decommission(self):
+    def decommission(self):
         """Decommissions the agent, removing it from the simulation. Results in
         destruction of the agent object. If agents write their own decommission()
         function, they must call their superclass' decommission function at the

--- a/cyclus/agents.pyx
+++ b/cyclus/agents.pyx
@@ -1188,8 +1188,8 @@ cdef class _Region(_Agent):
         return (<CyclusRegionShim*> (<_Agent> self).shim).get_lifetime()
 
     @lifetime.setter
-    def lifetime(self, int n_timesteps):
-        (<CyclusRegionShim*> (<_Agent> self).shim).lifetime(n_timesteps)
+    def lifetime(self, int n_timesteps, cpp_bool force):
+        (<CyclusRegionShim*> (<_Agent> self).shim).lifetime(n_timesteps, force)
 
     @property
     def exit_time(self):
@@ -1385,8 +1385,8 @@ cdef class _Institution(_Agent):
         return (<CyclusInstitutionShim*> (<_Agent> self).shim).get_lifetime()
 
     @lifetime.setter
-    def lifetime(self, int n_timesteps):
-        (<CyclusInstitutionShim*> (<_Agent> self).shim).lifetime(n_timesteps)
+    def lifetime(self, int n_timesteps, cpp_bool force):
+        (<CyclusInstitutionShim*> (<_Agent> self).shim).lifetime(n_timesteps, force)
 
     @property
     def exit_time(self):
@@ -1583,8 +1583,8 @@ cdef class _Facility(_Agent):
         return (<CyclusFacilityShim*> (<_Agent> self).shim).get_lifetime()
 
     @lifetime.setter
-    def lifetime(self, int n_timesteps):
-        (<CyclusFacilityShim*> (<_Agent> self).shim).lifetime(n_timesteps)
+    def lifetime(self, int n_timesteps, cpp_bool force):
+        (<CyclusFacilityShim*> (<_Agent> self).shim).lifetime(n_timesteps, force)
 
     @property
     def exit_time(self):

--- a/cyclus/agents.pyx
+++ b/cyclus/agents.pyx
@@ -1508,9 +1508,7 @@ cdef class _Facility(_Agent):
         function, they must call their superclass' decommission function at the
         END of their decommission() function.
         """
-        print('decomm2py')
         (<CyclusFacilityShim*> (<_Agent> self).shim).Decommission()
-        print('enddecomm2py')
 
     @property
     def annotations(self):

--- a/cyclus/agents.pyx
+++ b/cyclus/agents.pyx
@@ -1188,8 +1188,11 @@ cdef class _Region(_Agent):
         return (<CyclusRegionShim*> (<_Agent> self).shim).get_lifetime()
 
     @lifetime.setter
-    def lifetime(self, int n_timesteps, cpp_bool force):
-        (<CyclusRegionShim*> (<_Agent> self).shim).lifetime(n_timesteps, force)
+    def lifetime(self, int n_timesteps):
+        (<CyclusRegionShim*> (<_Agent> self).shim).lifetime(n_timesteps)
+
+    def lifetime_force(self, int n_timesteps):
+        (<CyclusRegionShim*> (<_Agent> self).shim).lifetime_force(n_timesteps)
 
     @property
     def exit_time(self):
@@ -1385,8 +1388,11 @@ cdef class _Institution(_Agent):
         return (<CyclusInstitutionShim*> (<_Agent> self).shim).get_lifetime()
 
     @lifetime.setter
-    def lifetime(self, int n_timesteps, cpp_bool force):
-        (<CyclusInstitutionShim*> (<_Agent> self).shim).lifetime(n_timesteps, force)
+    def lifetime(self, int n_timesteps):
+        (<CyclusInstitutionShim*> (<_Agent> self).shim).lifetime(n_timesteps)
+
+    def lifetime_force(self, int n_timesteps):
+        (<CyclusInstitutionShim*> (<_Agent> self).shim).lifetime_force(n_timesteps)
 
     @property
     def exit_time(self):
@@ -1583,8 +1589,11 @@ cdef class _Facility(_Agent):
         return (<CyclusFacilityShim*> (<_Agent> self).shim).get_lifetime()
 
     @lifetime.setter
-    def lifetime(self, int n_timesteps, cpp_bool force):
-        (<CyclusFacilityShim*> (<_Agent> self).shim).lifetime(n_timesteps, force)
+    def lifetime(self, int n_timesteps):
+        (<CyclusFacilityShim*> (<_Agent> self).shim).lifetime(n_timesteps)
+
+    def lifetime_force(self, int n_timesteps):
+        (<CyclusFacilityShim*> (<_Agent> self).shim).lifetime_force(n_timesteps)
 
     @property
     def exit_time(self):

--- a/cyclus/agents.pyx
+++ b/cyclus/agents.pyx
@@ -1508,6 +1508,7 @@ cdef class _Facility(_Agent):
         function, they must call their superclass' decommission function at the
         END of their decommission() function.
         """
+        print('decom_fac')
         (<CyclusFacilityShim*> (<_Agent> self).shim).Decommission()
 
     @property

--- a/cyclus/cpp_cyclus.pxd
+++ b/cyclus/cpp_cyclus.pxd
@@ -655,7 +655,7 @@ cdef extern from "agent.h" namespace "cyclus":
         void EnterNotify()
         void BuildNotify(Agent*)
         void DecomNotify(Agent*)
-        void Decommission()
+        void Decommission() except +
         void AdjustMatlPrefs(PrefMap[Material].type&)
         void AdjustProductPrefs(PrefMap[Product].type&)
         std_string schema()
@@ -755,7 +755,7 @@ cdef extern from "facility.h" namespace "cyclus":
         void Tick()
         void Tock()
         void Decision()
-        cpp_bool CheckDecommissionCondition()
+        cpp_bool CheckDecommissionCondition() except +
         set[RequestPortfolio[Material].Ptr] GetMatlRequests()
         set[RequestPortfolio[Product].Ptr] GetProductRequests()
         set[BidPortfolio[Material].Ptr] GetMatlBids(CommodMap[Material].type&)

--- a/cyclus/cpp_cyclus.pxd
+++ b/cyclus/cpp_cyclus.pxd
@@ -672,6 +672,7 @@ cdef extern from "agent.h" namespace "cyclus":
         const int enter_time()
         const int get_lifetime "lifetime" ()
         void lifetime(int)
+        void lifetime_force(int)
         const int exit_time()
         const set[Agent*]& children()
 

--- a/cyclus/lib.pyx
+++ b/cyclus/lib.pyx
@@ -1483,13 +1483,12 @@ cdef class _Agent:
         """
         return (<cpp_cyclus.Agent*> self.ptx).get_lifetime()
 
-    #@lifetime.setter
-    #def lifetime(self, int n_timesteps):
-    #    (<cpp_cyclus.Agent*> self.ptx).lifetime(n_timesteps)
-
     @lifetime.setter
-    def lifetime(self, int n_timesteps, cpp_bool force):
-        (<cpp_cyclus.Agent*> self.ptx).lifetime(n_timesteps, force)
+    def lifetime(self, int n_timesteps):
+        (<cpp_cyclus.Agent*> self.ptx).lifetime(n_timesteps)
+
+    def lifetime_force(self, int n_timesteps):
+        (<cpp_cyclus.Agent*> self.ptx).lifetime_force(n_timesteps)
 
     @property
     def exit_time(self):

--- a/cyclus/lib.pyx
+++ b/cyclus/lib.pyx
@@ -1483,9 +1483,13 @@ cdef class _Agent:
         """
         return (<cpp_cyclus.Agent*> self.ptx).get_lifetime()
 
+    #@lifetime.setter
+    #def lifetime(self, int n_timesteps):
+    #    (<cpp_cyclus.Agent*> self.ptx).lifetime(n_timesteps)
+
     @lifetime.setter
-    def lifetime(self, int n_timesteps):
-        (<cpp_cyclus.Agent*> self.ptx).lifetime(n_timesteps)
+    def lifetime(self, int n_timesteps, cpp_bool force):
+        (<cpp_cyclus.Agent*> self.ptx).lifetime(n_timesteps, force)
 
     @property
     def exit_time(self):

--- a/cyclus/lib.pyx
+++ b/cyclus/lib.pyx
@@ -1381,7 +1381,7 @@ cdef class _Agent:
         rtn = bool_to_py((<cpp_cyclus.Agent*> self.ptx).DecendentOf(cpp_other))
         return rtn
 
-    def Decommission(self):
+    def decommission(self):
         """Decommissions the agent, removing it from the simulation. Results in
         destruction of the agent object. If agents write their own decommission()
         function, they must call their superclass' decommission function at the

--- a/cyclus/lib.pyx
+++ b/cyclus/lib.pyx
@@ -1387,6 +1387,7 @@ cdef class _Agent:
         function, they must call their superclass' decommission function at the
         END of their decommission() function.
         """
+        print('decom_agent')
         (<cpp_cyclus.Agent*> self.ptx).Decommission()
 
     @property
@@ -1658,12 +1659,14 @@ cdef class _Context:
         self.ptx.SchedBuild(dynamic_agent_ptr(parent),
                             str_py_to_cpp(proto_name), t)
 
-    def schedule_decom(self, parent, int t=-1):
+    def schedule_decom(self, agent, int t=-1):
         """Schedules the given Agent to be decommissioned at the specified timestep
         t. The default t=-1 results in the decommission being scheduled for the
         next decommission phase (i.e. the end of the current timestep).
         """
-        self.ptx.SchedDecom(dynamic_agent_ptr(parent), t)
+        print('schedule')
+        self.ptx.SchedDecom(dynamic_agent_ptr(agent), t)
+        print('schedule2')
 
     def new_datum(self, title):
         """Returns a new datum instance."""

--- a/cyclus/lib.pyx
+++ b/cyclus/lib.pyx
@@ -1387,9 +1387,7 @@ cdef class _Agent:
         function, they must call their superclass' decommission function at the
         END of their decommission() function.
         """
-        print('enter Decom call')
         (<cpp_cyclus.Agent*> self.ptx).Decommission()
-        print('exit decom call')
 
     @property
     def schema(self):

--- a/cyclus/lib.pyx
+++ b/cyclus/lib.pyx
@@ -1381,13 +1381,15 @@ cdef class _Agent:
         rtn = bool_to_py((<cpp_cyclus.Agent*> self.ptx).DecendentOf(cpp_other))
         return rtn
 
-    def decomission(self):
+    def Decommission(self):
         """Decommissions the agent, removing it from the simulation. Results in
         destruction of the agent object. If agents write their own decommission()
         function, they must call their superclass' decommission function at the
         END of their decommission() function.
         """
+        print('enter Decom call')
         (<cpp_cyclus.Agent*> self.ptx).Decommission()
+        print('exit decom call')
 
     @property
     def schema(self):
@@ -1495,7 +1497,7 @@ cdef class _Agent:
         """The default time step at which this agent will exit the
         simulation (-1 if the agent has an infinite lifetime).
 
-        Decomissioning happens at the end of a time step. With a lifetime of 1, we
+        Decommissioning happens at the end of a time step. With a lifetime of 1, we
         expect an agent to go through only 1 entire time step. In this case, the
         agent should be decommissioned on the same time step it was
         created. Therefore, for agents with non-infinite lifetimes, the exit_time

--- a/src/agent.cc
+++ b/src/agent.cc
@@ -175,9 +175,9 @@ void Agent::Connect(Agent* parent) {
 }
 
 void Agent::Decommission() {
+  std::cout << "Decommission2" << std::endl;
   CLOG(LEV_INFO3) << prototype() << "(" << this << ")"
                   << " is being decommissioned";
-
   ctx_->NewDatum("AgentExit")
       ->AddVal("AgentId", id())
       ->AddVal("ExitTime", ctx_->time())

--- a/src/agent.cc
+++ b/src/agent.cc
@@ -104,9 +104,17 @@ std::string Agent::str() {
      << " ) ";
   return ss.str();
 }
-
+/*
 void Agent::lifetime(int n_timesteps) {
   if (enter_time_ != -1) {
+    throw ValueError("cannot set the lifetime of an already-built facility");
+  }
+  lifetime_ = n_timesteps;
+}
+*/
+void Agent::lifetime(int n_timesteps, bool force) {
+  std::cout<<force;
+  if (enter_time_ != -1 && force == false) {
     throw ValueError("cannot set the lifetime of an already-built facility");
   }
   lifetime_ = n_timesteps;

--- a/src/agent.cc
+++ b/src/agent.cc
@@ -113,12 +113,10 @@ void Agent::lifetime(int n_timesteps) {
 }
 
 void Agent::lifetime_force(int n_timesteps) {
-  std::cout<<"force";
   try{
     lifetime(n_timesteps);
   }
-  catch (exception e){
-    std::cout<<e;
+  catch (ValueError e){
     lifetime_ = n_timesteps;
   }
 }

--- a/src/agent.cc
+++ b/src/agent.cc
@@ -118,7 +118,7 @@ void Agent::lifetime_force(int n_timesteps) {
   }
   catch (ValueError e){
     if(enter_time_+n_timesteps <= context()->time()){
-      lifetime(context()->time() - enter_time + 1);
+      lifetime(context()->time() - enter_time_ + 1);
     }
     else{
       lifetime_ = n_timesteps;    

--- a/src/agent.cc
+++ b/src/agent.cc
@@ -180,7 +180,6 @@ void Agent::Connect(Agent* parent) {
 }
 
 void Agent::Decommission() {
-  std::cout << "Decommission2" << std::endl;
   CLOG(LEV_INFO3) << prototype() << "(" << this << ")"
                   << " is being decommissioned";
   ctx_->NewDatum("AgentExit")

--- a/src/agent.cc
+++ b/src/agent.cc
@@ -118,7 +118,7 @@ void Agent::lifetime_force(int n_timesteps) {
   }
   catch (ValueError e){
     if(enter_time_+n_timesteps <= context()->time()){
-      lifetime(context()->time()+1);
+      lifetime(context()->time() - enter_time + 1);
     }
     else{
       lifetime_ = n_timesteps;    

--- a/src/agent.cc
+++ b/src/agent.cc
@@ -117,7 +117,12 @@ void Agent::lifetime_force(int n_timesteps) {
     lifetime(n_timesteps);
   }
   catch (ValueError e){
-    lifetime_ = n_timesteps;
+    if(enter_time_+n_timesteps <= context()->time()){
+      throw ValueError("cannot set lifetime to be less than current context time");
+    }
+    else{
+      lifetime_ = n_timesteps;    
+    }
   }
 }
 

--- a/src/agent.cc
+++ b/src/agent.cc
@@ -117,8 +117,10 @@ void Agent::lifetime_force(int n_timesteps) {
   try{
     lifetime(n_timesteps);
   }
-  catch (ValueError) {}
-  lifetime_ = n_timesteps;
+  catch (exception e){
+    std::cout<<e;
+    lifetime_ = n_timesteps;
+  }
 }
 
 bool Agent::AncestorOf(Agent* other) {

--- a/src/agent.cc
+++ b/src/agent.cc
@@ -104,19 +104,20 @@ std::string Agent::str() {
      << " ) ";
   return ss.str();
 }
-/*
+
 void Agent::lifetime(int n_timesteps) {
   if (enter_time_ != -1) {
     throw ValueError("cannot set the lifetime of an already-built facility");
   }
   lifetime_ = n_timesteps;
 }
-*/
-void Agent::lifetime(int n_timesteps, bool force) {
-  std::cout<<force;
-  if (enter_time_ != -1 && force == false) {
-    throw ValueError("cannot set the lifetime of an already-built facility");
+
+void Agent::lifetime_force(int n_timesteps) {
+  std::cout<<"force";
+  try{
+    lifetime(n_timesteps);
   }
+  catch (ValueError) {}
   lifetime_ = n_timesteps;
 }
 

--- a/src/agent.cc
+++ b/src/agent.cc
@@ -118,7 +118,7 @@ void Agent::lifetime_force(int n_timesteps) {
   }
   catch (ValueError e){
     if(enter_time_+n_timesteps <= context()->time()){
-      throw ValueError("cannot set lifetime to be less than current context time");
+      lifetime(context()->time()+1);
     }
     else{
       lifetime_ = n_timesteps;    

--- a/src/agent.h
+++ b/src/agent.h
@@ -314,7 +314,7 @@ class Agent : public StateWrangler, virtual public Ider {
   /// initially existing agents are being setup.
   virtual void BuildNotify(Agent* m) {}
 
-  /// Called when a new child of this agent is about to be decommissioned.
+  /// Called when a child of this agent is about to be decommissioned.
   virtual void DecomNotify(Agent* m) {}
 
   /// Decommissions the agent, removing it from the simulation. Results in

--- a/src/agent.h
+++ b/src/agent.h
@@ -389,8 +389,7 @@ class Agent : public StateWrangler, virtual public Ider {
   void lifetime(int n_timesteps);
 
   /// Sets the number of time steps this agent operates between building and
-  /// decommissioning (-1 if the agent has an infinite lifetime).  The boolean
-  /// allows for an agent to override the ValueError.
+  /// decommissioning (-1 if the agent has an infinite lifetime).  
   void lifetime_force(int n_timesteps);
 
   /// Returns the number of time steps this agent operates between building and

--- a/src/agent.h
+++ b/src/agent.h
@@ -386,7 +386,12 @@ class Agent : public StateWrangler, virtual public Ider {
   /// decommissioning (-1 if the agent has an infinite lifetime).  This should
   /// generally only be called BEFORE an agent is added to a context as a
   /// prototype.  Throws ValueError if the agent has already been deployed.
-  void lifetime(int n_timesteps);
+  ///void lifetime(int n_timesteps);
+
+  /// Sets the number of time steps this agent operates between building and
+  /// decommissioning (-1 if the agent has an infinite lifetime).  The boolean
+  /// allows for an agent to override the ValueError.
+  void lifetime(int n_timesteps, bool force=false);
 
   /// Returns the number of time steps this agent operates between building and
   /// decommissioning (-1 if the agent has an infinite lifetime).

--- a/src/agent.h
+++ b/src/agent.h
@@ -382,16 +382,16 @@ class Agent : public StateWrangler, virtual public Ider {
   /// the agent has never been built).
   inline const int enter_time() const { return enter_time_; }
 
-  /// Sets the number of time steps this agent operates between building and
+  ///Sets the number of time steps this agent operates between building and
   /// decommissioning (-1 if the agent has an infinite lifetime).  This should
   /// generally only be called BEFORE an agent is added to a context as a
   /// prototype.  Throws ValueError if the agent has already been deployed.
-  ///void lifetime(int n_timesteps);
+  void lifetime(int n_timesteps);
 
   /// Sets the number of time steps this agent operates between building and
   /// decommissioning (-1 if the agent has an infinite lifetime).  The boolean
   /// allows for an agent to override the ValueError.
-  void lifetime(int n_timesteps, bool force=false);
+  void lifetime_force(int n_timesteps);
 
   /// Returns the number of time steps this agent operates between building and
   /// decommissioning (-1 if the agent has an infinite lifetime).


### PR DESCRIPTION
This adds a new lifetime_force function that is made to force a change in lifetime for agents already in existence. 

The reason this behavior is required is that automated decommissioning can not always be done by calling the Decommission() function on an agent (if the Decommission_Condition returns false). This allows the user to change the lifetime of the agent, and hopefully force it to begin it's decommission process on it's own. 