### PR TITLE
news check trigger

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -225,7 +225,7 @@ workflows:
             - news_update:
                 filters:
                     branches:
-                        only: /.*/
+                        ignore: master
                     tags:
                         ignore: /.*/
             - build

--- a/news/news_trigger.rst
+++ b/news/news_trigger.rst
@@ -1,0 +1,12 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+- news check trigger now on PRs only
+
+**Security:** None


### PR DESCRIPTION
This should disable news check after a merge.
Only PRs should trigger news test