### PR TITLE
Fix news check

### DIFF
--- a/news/news_test.sh
+++ b/news/news_test.sh
@@ -1,15 +1,25 @@
 #!/bin/sh
+# folder to look for addition
 folder=$1
-#setup temp remote 
+
+# default main repo setup
+master_repo="https://github.com/cyclus/cyclus.git"
+default_branch="master"
+
+
+# setup temp remote 
 git_remote_name=ci_news_`git log --pretty=format:'%h' -n 1`
-echo $git_remote_name
-git remote add ${git_remote_name} https://github.com/cyclus/cyclus.git
+git remote add ${git_remote_name} ${master_repo}
 git fetch ${git_remote_name}
+
 # diff against temp remote
-added_news_file=$((`git diff ${git_remote_name}/master --name-only $folder |wc -l`))
-#cleaning temp remote
+added_news_file=$((`git diff ${git_remote_name}/${default_branch} --name-only $folder |wc -l`))
+
+# cleaning temp remote
 git remote remove ${git_remote_name}
 
+
+# analysing the diff and returning accordingly
 if [ $added_news_file -eq 0 ]; then
     exit 1
 fi

--- a/news/news_test.sh
+++ b/news/news_test.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 folder=$1
 #setup temp remote 
-git_remote_name=ci_news_ #`git log --pretty=format:'%h' -n 1`
+git_remote_name=ci_news_`git log --pretty=format:'%h' -n 1`
 echo $git_remote_name
-git remote add ${git_remote_name} http://github.com/cyclus/cyclus.git
+git remote add ${git_remote_name} https://github.com/cyclus/cyclus.git
 git fetch ${git_remote_name}
 # diff against temp remote
 added_news_file=$((`git diff ${git_remote_name}/master --name-only $folder |wc -l`))

--- a/news/news_test.sh
+++ b/news/news_test.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 folder=$1
-added_news_file=$((`git diff origin/master --name-only $folder |wc -l`))
+git_remote_name=ci_news_`git log --pretty=format:'%h' -n 1`
+git remote add ${git_remote_name} https://github.com/cyclus/cyclus/
+git fetch ${git_remote_name}
+added_news_file=$((`git diff ${git_remote_name}/master --name-only $folder |wc -l`))
+git remote remove ${git_remote_name}
 if [ $added_news_file -eq 0 ]; then
     exit 1
 fi

--- a/news/news_test.sh
+++ b/news/news_test.sh
@@ -2,6 +2,7 @@
 folder=$1
 #setup temp remote 
 git_remote_name=ci_news_`git log --pretty=format:'%h' -n 1`
+echo $git_remote_name
 git remote add ${git_remote_name} https://github.com/cyclus/cyclus/
 git fetch ${git_remote_name}
 # diff against temp remote

--- a/news/news_test.sh
+++ b/news/news_test.sh
@@ -3,7 +3,7 @@ folder=$1
 #setup temp remote 
 git_remote_name=ci_news_ #`git log --pretty=format:'%h' -n 1`
 echo $git_remote_name
-git remote add ${git_remote_name} https://github.com/cyclus/cyclus/
+git remote add ${git_remote_name} http://github.com/cyclus/cyclus.git
 git fetch ${git_remote_name}
 # diff against temp remote
 added_news_file=$((`git diff ${git_remote_name}/master --name-only $folder |wc -l`))

--- a/news/news_test.sh
+++ b/news/news_test.sh
@@ -1,10 +1,14 @@
 #!/bin/sh
 folder=$1
+#setup temp remote 
 git_remote_name=ci_news_`git log --pretty=format:'%h' -n 1`
 git remote add ${git_remote_name} https://github.com/cyclus/cyclus/
 git fetch ${git_remote_name}
+# diff against temp remote
 added_news_file=$((`git diff ${git_remote_name}/master --name-only $folder |wc -l`))
+#cleaning temp remote
 git remote remove ${git_remote_name}
+
 if [ $added_news_file -eq 0 ]; then
     exit 1
 fi

--- a/news/news_test.sh
+++ b/news/news_test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 folder=$1
 #setup temp remote 
-git_remote_name=ci_news_`git log --pretty=format:'%h' -n 1`
+git_remote_name=ci_news_ #`git log --pretty=format:'%h' -n 1`
 echo $git_remote_name
 git remote add ${git_remote_name} https://github.com/cyclus/cyclus/
 git fetch ${git_remote_name}

--- a/news/news_test_fix.rst
+++ b/news/news_test_fix.rst
@@ -1,0 +1,12 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+- news check now diff against cyclus/master not origin/master
+
+**Security:** None


### PR DESCRIPTION
The news test was somethings failing because it was checking against the origin remote.
if the origin/master was not up-to-date with upstream/master... but the PRed branch was, then the diff was capturing old news file.

this should ensure we always diff the news file against the correct correct `master` branch

*ci is actually pulling owners PR fork not the cyclus repo.*
