### PR TITLE
allowing 0 capacity constrain

### DIFF
--- a/src/capacity_constraint.h
+++ b/src/capacity_constraint.h
@@ -68,7 +68,7 @@ class CapacityConstraint {
       : capacity_(capacity),
         converter_(converter),
         id_(next_id_++) {
-    if (capacity_ <= 0)
+    if (capacity_ < 0)
       throw ValueError("Capacity is not positive, no trades will be executed");
   }
 


### PR DESCRIPTION
Allows 0 capacity constrain to be set, this allows developer to set a capacity constrain based on a variable without having to check that the constrain they are setting is `>0` , also this might be hard to debug as it will only show up at run time. 

It is very hard for a developer to own it need to design test for it... So I think that instead of trowing an error at runtime we should allow it, as 0 capacity bid should not impact the DRE solver.

what do you think @gonuke ?