### PR TITLE
Fix redeclaration error

### DIFF
--- a/news/redeclaration_error.rst
+++ b/news/redeclaration_error.rst
@@ -1,0 +1,12 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+- Redeclaration error in ``src/hdf5_back.cc`` during compilation with G++
+
+**Security:** None

--- a/src/hdf5_back.cc.in
+++ b/src/hdf5_back.cc.in
@@ -337,7 +337,6 @@ void Hdf5Back::CreateTable(Datum* d) {
   using std::vector;
   using std::list;
   using std::pair;
-  using std::list;
   using std::map;
   Datum::Vals vals = d->vals();
   hsize_t nvals = vals.size();

--- a/src/hdf5_back.h.in
+++ b/src/hdf5_back.h.in
@@ -1,6 +1,7 @@
 #ifndef CYCLUS_SRC_HDF5_BACK_H_
 #define CYCLUS_SRC_HDF5_BACK_H_
 
+#include <list>
 #include <map>
 #include <set>
 #include <string>


### PR DESCRIPTION
I ran into the following issue when compiling Cyclus with GCC and G++ v10.2.1:
```
/home/maxschalz/NVD/cyclus/src/hdf5_back.cc: In member function ‘void cyclus::Hdf5Back::CreateTable(cyclus::Datum*)’:
/home/maxschalz/NVD/cyclus/src/hdf5_back.cc:7672:14: error: redeclaration of ‘template<class _Tp, class _Alloc> class std::__cxx11::list’
 7672 |   using std::list;
      |              ^~~~
```
When compiling with clang, I did not encounter this problem but the compilation failed for other reasons, so deleting the declaration in `src/hdf5back.cc.in` solved the issue and allowed me to stick with g++.