### PR TITLE
use update-alternatives even with single python version

### DIFF
--- a/DEPENDENCIES.rst
+++ b/DEPENDENCIES.rst
@@ -187,6 +187,20 @@ From now on, to switch between different versions, use:
 
    sudo update-alternatives --config python
 
+Even if you only have a single python installation, you may have to use update-alternatives to point python at the correct version to avoid build errors.
+
+Check your current python version with the following command:
+
+ .. code-block:: bash
+
+   python --version
+
+Then make Ubuntu aware of your current python version. Run the following command, using the python version you just checked. The following command uses version python3.8 as an example and will fail if you do not replace 3.8 with your own version number.
+
+ .. code-block:: bash
+
+   sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.8 2
+
 
 Cython Note
 ^^^^^^^^^^^

--- a/news/update-alternatives-single-python-version.rst
+++ b/news/update-alternatives-single-python-version.rst
@@ -1,0 +1,11 @@
+**Added:** None
+Added several lines to DEPENDENCIES.rst to explain that even when using a machine with a single python3 install (such as a fresh Ubuntu 20.04), install will fail unless update-alternatives has been used to point python at the correct python3 version
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None


### PR DESCRIPTION
I was running into build errors on a fresh Ubuntu 20.04 VM. The fix, helpfully provided by @bam241, was using `update-alternatives` to point `python` at the right version. `DEPENDENCIES.rst` currently makes it seem like the user only needed to use `update-alternatives` if they had both python 2.7 and python3 (3.5) installed on their machine, this PR adds a few lines noting that it may be necessary even with a single version of python installed.