### PR TITLE
Buy policy can cycle back and forth between actively buying and dormant based on time step

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Since last release
 * Have separate workflows for testing, publishing dependency images, and publishing release images (#1597, #1602, #1606, #1609)
 * Add Ubuntu 20.04 to the list of supported platforms (#1605, #1608)
 * Add random number generator (Mersenne Twister 19937, from boost) and the ability to set the seed in the simulation control block (#1599)
+* Adds active and dormant buying cycles in buy policy (#1596)
 
 **Changed:**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Since last release
 * Add Ubuntu 20.04 to the list of supported platforms (#1605, #1608)
 * Add random number generator (Mersenne Twister 19937, from boost) and the ability to set the seed in the simulation control block (#1599)
 * Adds active and dormant buying cycles in buy policy (#1596)
+* Add random number generator (Mersenne Twister 19937, from boost) and the ability to set the seed in the simulation control block (#1599)
 
 **Changed:**
 

--- a/src/toolkit/matl_buy_policy.cc
+++ b/src/toolkit/matl_buy_policy.cc
@@ -163,7 +163,7 @@ std::set<RequestPortfolio<Material>::Ptr> MatlBuyPolicy::GetMatlRequests() {
   bool make_req = buf_->quantity() < req_when_under_ * buf_->capacity();
   double amt;
   int cycle = freq_active_ + freq_dormant_;
-  if ((context()->time() % cycle) < freq_active_) {
+  if ((manager()->context()->time() % cycle) < freq_active_) {
     amt = TotalQty();
   }
   else {

--- a/src/toolkit/matl_buy_policy.cc
+++ b/src/toolkit/matl_buy_policy.cc
@@ -74,11 +74,15 @@ MatlBuyPolicy& MatlBuyPolicy::Init(Agent* manager, ResBuf<Material>* buf,
 }
 
 MatlBuyPolicy& MatlBuyPolicy::Init(Agent* manager, ResBuf<Material>* buf,
-                                   std::string name, double throughput) {
+                                   std::string name, double throughput, int active, int dormant) {
   Trader::manager_ = manager;
   buf_ = buf;
   name_ = name;
   set_throughput(throughput);
+  set_active(active);
+  set_dormant(dormant);
+  LGH(INFO3) << "has buy policy with active = " << active_ \
+             << "time steps and dormant = " << dormant_ << " time steps." ;
   return *this;
 }
 
@@ -90,21 +94,6 @@ MatlBuyPolicy& MatlBuyPolicy::Init(Agent* manager, ResBuf<Material>* buf,
   name_ = name;
   set_fill_to(fill_to);
   set_req_when_under(req_when_under);
-  return *this;
-}
-
-MatlBuyPolicy& MatlBuyPolicy::Init(Agent* manager, ResBuf<Material>* buf,
-                                   std::string name, double throughput,
-                                   int active,
-                                   int dormant) {
-  Trader::manager_ = manager;
-  buf_ = buf;
-  name_ = name;
-  set_throughput(throughput);
-  set_active(active);
-  set_dormant(dormant);
-  LGH(INFO3) << "has buy policy with active = " << active_ \
-             << "time steps and dormant = " << dormant_ << " time steps." ;
   return *this;
 }
 
@@ -168,10 +157,12 @@ std::set<RequestPortfolio<Material>::Ptr> MatlBuyPolicy::GetMatlRequests() {
   if (dormant_ > 0 && manager()->context()->time() % (active_ + dormant_) < active_) {
     amt = TotalQty();
   }
+  else if (dormant_ == 0)
+    amt = TotalQty();
   else {
     // in dormant part of cycle, return empty portfolio
     amt = 0;
-    LGH(INFO3) << "in dormant period for time step " << manager()->context()->time() << ", requesting " << amt << " kg." ;
+    LGH(INFO3) << "in dormant period, no request";
   }
   if (!make_req || amt < eps())
     return ports;

--- a/src/toolkit/matl_buy_policy.cc
+++ b/src/toolkit/matl_buy_policy.cc
@@ -165,7 +165,7 @@ std::set<RequestPortfolio<Material>::Ptr> MatlBuyPolicy::GetMatlRequests() {
   bool make_req = buf_->quantity() < req_when_under_ * buf_->capacity();
   double amt;
   
-  if (manager()->context()->time() % (active_ + dormant_) < active_) {
+  if (dormant_ > 0 && manager()->context()->time() % (active_ + dormant_) < active_) {
     amt = TotalQty();
   }
   else {

--- a/src/toolkit/matl_buy_policy.cc
+++ b/src/toolkit/matl_buy_policy.cc
@@ -20,8 +20,8 @@ MatlBuyPolicy::MatlBuyPolicy() :
     quantize_(-1),
     fill_to_(1),
     req_when_under_(1),
-    frequency_active(1),
-    frequency_dormant(0){
+    freq_active_(1),
+    freq_dormant_(0){
   Warn<EXPERIMENTAL_WARNING>(
       "MatlBuyPolicy is experimental and its API may be subject to change");
 }
@@ -100,8 +100,6 @@ MatlBuyPolicy& MatlBuyPolicy::Init(Agent* manager, ResBuf<Material>* buf,
   Trader::manager_ = manager;
   buf_ = buf;
   name_ = name;
-  set_fill_to(fill_to);
-  set_req_when_under(req_when_under);
   set_throughput(throughput);
   set_freq_active(freq_active);
   set_freq_dormant(freq_dormant);
@@ -165,11 +163,13 @@ std::set<RequestPortfolio<Material>::Ptr> MatlBuyPolicy::GetMatlRequests() {
   bool make_req = buf_->quantity() < req_when_under_ * buf_->capacity();
   double amt;
   int cycle = freq_active_ + freq_dormant_;
-  if (context()->time() % cycle) < freq_active_;
+  if ((context()->time() % cycle) < freq_active_) {
     amt = TotalQty();
-  else
+  }
+  else {
     // in dormant part of cycle, return empty portfolio
     amt = 0;
+  }
   if (!make_req || amt < eps())
     return ports;
 

--- a/src/toolkit/matl_buy_policy.h
+++ b/src/toolkit/matl_buy_policy.h
@@ -78,12 +78,23 @@ class MatlBuyPolicy : public Trader {
   /// be sent to fill the buffer's empty space.
   /// @warning, (s, S) policy values are ambiguous for buffers with a capacity
   /// in (0, 1]. However that is a rare case.
+  /// The following features, if used, will set the policy to so that agents
+  /// cycle through "on" phases, where the buf will attemp to be filled, and
+  /// "off" or dormant phases, where no requests will be made regardless of
+  /// capacity.  The "on" and "off" phases are sampled and rounded to the
+  /// nearest integer number of time steps from a truncated normal
+  /// distribution from a mean, standard deviation, min, and max value.
+  /// @param freq_active the length of the on, actively buying period
+  /// @param freq_dormant the length of the dormant period
   /// @{
   MatlBuyPolicy& Init(Agent* manager, ResBuf<Material>* buf, std::string name);
   MatlBuyPolicy& Init(Agent* manager, ResBuf<Material>* buf, std::string name,
                       double throughput);
   MatlBuyPolicy& Init(Agent* manager, ResBuf<Material>* buf, std::string name,
                       double fill_to, double req_when_under);
+  MatlBuyPolicy& Init(Agent* manager, ResBuf<Material>* buf, std::string name,
+                      double throughput, int freq_active,
+                      int freq_dormant);
   MatlBuyPolicy& Init(Agent* manager, ResBuf<Material>* buf, std::string name,
                       double throughput, double fill_to,
                       double req_when_under, double quantize);
@@ -161,10 +172,13 @@ class MatlBuyPolicy : public Trader {
   void set_req_when_under(double x);
   void set_quantize(double x);
   void set_throughput(double x);
+  void set_freq_active(int x);
+  void set_freq_dormant(int x);
 
   ResBuf<Material>* buf_;
   std::string name_;
   double fill_to_, req_when_under_, quantize_, throughput_;
+  int freq_active_, freq_dormant_;
   std::map<Material::Ptr, std::string> rsrc_commods_;
   std::map<std::string, CommodDetail> commod_details_;
 };

--- a/src/toolkit/matl_buy_policy.h
+++ b/src/toolkit/matl_buy_policy.h
@@ -84,8 +84,8 @@ class MatlBuyPolicy : public Trader {
   /// capacity.  The "on" and "off" phases are sampled and rounded to the
   /// nearest integer number of time steps from a truncated normal
   /// distribution from a mean, standard deviation, min, and max value.
-  /// @param freq_active the length of the on, actively buying period
-  /// @param freq_dormant the length of the dormant period
+  /// @param active the length of the on, actively buying period
+  /// @param dormant the length of the dormant period
   /// @{
   MatlBuyPolicy& Init(Agent* manager, ResBuf<Material>* buf, std::string name);
   MatlBuyPolicy& Init(Agent* manager, ResBuf<Material>* buf, std::string name,
@@ -93,8 +93,8 @@ class MatlBuyPolicy : public Trader {
   MatlBuyPolicy& Init(Agent* manager, ResBuf<Material>* buf, std::string name,
                       double fill_to, double req_when_under);
   MatlBuyPolicy& Init(Agent* manager, ResBuf<Material>* buf, std::string name,
-                      double throughput, int freq_active,
-                      int freq_dormant);
+                      double throughput, int active,
+                      int dormant);
   MatlBuyPolicy& Init(Agent* manager, ResBuf<Material>* buf, std::string name,
                       double throughput, double fill_to,
                       double req_when_under, double quantize);
@@ -172,13 +172,13 @@ class MatlBuyPolicy : public Trader {
   void set_req_when_under(double x);
   void set_quantize(double x);
   void set_throughput(double x);
-  void set_freq_active(int x);
-  void set_freq_dormant(int x);
+  void set_active(int x);
+  void set_dormant(int x);
 
   ResBuf<Material>* buf_;
   std::string name_;
   double fill_to_, req_when_under_, quantize_, throughput_;
-  int freq_active_, freq_dormant_;
+  int active_, dormant_;
   std::map<Material::Ptr, std::string> rsrc_commods_;
   std::map<std::string, CommodDetail> commod_details_;
 };

--- a/src/toolkit/matl_buy_policy.h
+++ b/src/toolkit/matl_buy_policy.h
@@ -179,7 +179,11 @@ class MatlBuyPolicy : public Trader {
   std::string name_;
   double fill_to_, req_when_under_, quantize_, throughput_;
   int active_, dormant_;
+  std::map<Material::Ptr, std::string> rsrc_commods_;
   std::map<std::string, CommodDetail> commod_details_;
+};
+  
+}  // namespace toolkit
 }  // namespace cyclus
 
 #endif

--- a/src/toolkit/matl_buy_policy.h
+++ b/src/toolkit/matl_buy_policy.h
@@ -84,17 +84,18 @@ class MatlBuyPolicy : public Trader {
   /// capacity.  The "on" and "off" phases are sampled and rounded to the
   /// nearest integer number of time steps from a truncated normal
   /// distribution from a mean, standard deviation, min, and max value.
+  /// Note that the (s, S) policy is not currently compatible with active and
+  /// dormant buying perionds 
   /// @param active the length of the on, actively buying period
   /// @param dormant the length of the dormant period
+  /// Note that active and dormant periods are note currently compatible with
+  /// (s, S) inventory management
   /// @{
   MatlBuyPolicy& Init(Agent* manager, ResBuf<Material>* buf, std::string name);
   MatlBuyPolicy& Init(Agent* manager, ResBuf<Material>* buf, std::string name,
-                      double throughput);
+                      double throughput, int active = 1, int dormant = 0);
   MatlBuyPolicy& Init(Agent* manager, ResBuf<Material>* buf, std::string name,
                       double fill_to, double req_when_under);
-  MatlBuyPolicy& Init(Agent* manager, ResBuf<Material>* buf, std::string name,
-                      double throughput, int active,
-                      int dormant);
   MatlBuyPolicy& Init(Agent* manager, ResBuf<Material>* buf, std::string name,
                       double throughput, double fill_to,
                       double req_when_under, double quantize);

--- a/src/toolkit/matl_buy_policy.h
+++ b/src/toolkit/matl_buy_policy.h
@@ -179,11 +179,7 @@ class MatlBuyPolicy : public Trader {
   std::string name_;
   double fill_to_, req_when_under_, quantize_, throughput_;
   int active_, dormant_;
-  std::map<Material::Ptr, std::string> rsrc_commods_;
   std::map<std::string, CommodDetail> commod_details_;
-};
-
-}  // namespace toolkit
 }  // namespace cyclus
 
 #endif

--- a/tests/toolkit/matl_buy_policy_tests.cc
+++ b/tests/toolkit/matl_buy_policy_tests.cc
@@ -92,23 +92,25 @@ TEST_F(MatlBuyPolicyTests, StartStop) {
   ASSERT_THROW(p.Stop(), ValueError);
 }
 
+// Tests that matlbuypolicy sends out a request properly
 TEST_F(MatlBuyPolicyTests, OneReq) {
   double cap = 5;
   ResBuf<Material> buff;
   buff.capacity(cap);
-  std::string commod1("foo"), commod2("bar");
-  double p2 = 2.5;
   cyclus::Composition::Ptr c1 = cyclus::Composition::Ptr(new TestComp()); 
-  cyclus::Composition::Ptr c2 = cyclus::Composition::Ptr(new TestComp()); 
   MatlBuyPolicy p;
 
-  p.Init(fac1, &buff, "").Set(commod1, c1);
+  p.Init(fac1, &buff, "").Set("commod1", c1);
   std::set<RequestPortfolio<Material>::Ptr> obs = p.GetMatlRequests();
   ASSERT_EQ(obs.size(), 1);
   ASSERT_EQ((*obs.begin())->requests().size(), 1);
+  Request<Material>* req = (*obs.begin())->requests().at(0);
+  ASSERT_EQ(req->commodity(), "commod1");
+  ASSERT_FLOAT_EQ(req->target()->quantity(), cap);
 }
 
-TEST_F(MatlBuyPolicyTests, Reqs) {
+// Tests that matlbuypolicy can send out requests for multiple commodities
+TEST_F(MatlBuyPolicyTests, MultipleReqs) {
   double cap = 5;
   ResBuf<Material> buff;
   buff.capacity(cap);
@@ -133,19 +135,54 @@ TEST_F(MatlBuyPolicyTests, Reqs) {
   }
   ASSERT_FALSE(req->exclusive());
   ASSERT_FLOAT_EQ(req->target()->quantity(), cap);
-  
-  // two portfolios with quantize
+}
+
+// Test single quantized request
+TEST_F(MatlBuyPolicyTests, Quantize) {
+  double cap = 5;
+  ResBuf<Material> buff;
+  buff.capacity(cap);
+  double p2 = 2.5;
+  cyclus::Composition::Ptr c1 = cyclus::Composition::Ptr(new TestComp()); 
+  MatlBuyPolicy p;
+
   double quantize = 2.5;
-  p.Init(fac1, &buff, "", std::numeric_limits<double>::max(), 1, 1, quantize);
-  obs = p.GetMatlRequests();
+  p.Init(fac1, &buff, "", std::numeric_limits<double>::max(), 1, 1, quantize).Set("commod1", c1);
+  std::set<RequestPortfolio<Material>::Ptr> obs = p.GetMatlRequests();
   ASSERT_EQ(obs.size(), 2);
-  ASSERT_EQ((*obs.begin())->requests().size(), 2);
-  ASSERT_EQ((*(obs.begin()++))->requests().size(), 2);
-  req = (*obs.begin())->requests().at(0);
+  ASSERT_EQ((*obs.begin())->requests().size(), 1);
+  Request<Material>* req = (*obs.begin())->requests().at(0);
   ASSERT_TRUE(req->exclusive());
   ASSERT_FLOAT_EQ(req->target()->quantity(), quantize);
 }
 
+// Test two quantized requests
+TEST_F(MatlBuyPolicyTests, MultiReqQuantize) {
+    double cap = 5;
+  ResBuf<Material> buff;
+  buff.capacity(cap);
+  cyclus::Composition::Ptr c1 = cyclus::Composition::Ptr(new TestComp()); 
+  cyclus::Composition::Ptr c2 = cyclus::Composition::Ptr(new TestComp()); 
+  MatlBuyPolicy p;
+  
+  // two portfolios with quantize
+  double quantize = 2.5;
+  p.Init(fac1, &buff, "", std::numeric_limits<double>::max(), 1, 1, quantize).Set("commod1", c1).Set("commod2", c2);
+  std::set<RequestPortfolio<Material>::Ptr> obs = p.GetMatlRequests();
+  ASSERT_EQ(obs.size(), 2);
+  ASSERT_EQ((*obs.begin())->requests().size(), 2);
+  ASSERT_EQ((*(obs.begin()++))->requests().size(), 2);
+  Request<Material>* req = (*obs.begin())->requests().at(0);
+  ASSERT_TRUE(req->exclusive());
+  ASSERT_FLOAT_EQ(req->target()->quantity(), quantize);
+
+  req = (*(obs.begin()++))->requests().at(0);
+  ASSERT_TRUE(req->exclusive());
+  ASSERT_FLOAT_EQ(req->target()->quantity(), quantize);
+}
+
+// Tests that agent cycles between active and dormant cycles during a mock
+// sim, only buying when active.
 TEST_F(MatlBuyPolicyTests, ActiveDormant) {
   int active = 2;
   int dormant = 3;
@@ -164,8 +201,6 @@ TEST_F(MatlBuyPolicyTests, ActiveDormant) {
   cyclus::toolkit::MatlBuyPolicy policy;
   policy.Init(fac, &inbuf, "inbuf", throughput, active, dormant)
         .Set("commod1").Start();
-
-  cyclus::Composition::Ptr c1 = cyclus::Composition::Ptr(new TestComp()); 
 
   EXPECT_NO_THROW(sim.Run());
   EXPECT_DOUBLE_EQ(2, inbuf.quantity());

--- a/tests/toolkit/matl_buy_policy_tests.cc
+++ b/tests/toolkit/matl_buy_policy_tests.cc
@@ -213,7 +213,7 @@ TEST_F(MatlBuyPolicyTests, ActiveDormantMultipleCycles) {
 
   int active = 2;
   int dormant = 3;
-  int dur = 15;
+  int dur = 16;
   double throughput = 1;
 
   cyclus::MockSim sim(dur);


### PR DESCRIPTION
Two new buy policy parameters, `active` and `dormant`. Both are integers representing a number of time steps.

- For `active` part of the cycle, buying behavior is unchanged
- For `dormant`, agent will not request any new material from DRE