### PR TITLE
Address Issue #1595

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,4 +1,4 @@
-name: Linux Build/Test for PR and collaborator push
+name: Build/Test for PR and collaborator push
 
 on:
   # allows us to run workflows manually
@@ -35,7 +35,7 @@ jobs:
         ]
 
     container:
-      image: ghcr.io/${{ github.repository_owner }}/cyclus_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}
+      image: ghcr.io/cyclus/cyclus_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/${{ matrix.pkg_mgr }}-deps
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -8,6 +8,7 @@ on:
       - main
     paths-ignore:
       - '.github/workflows/build_test_publish.yml'
+      - '.github/workflows/build_test.yml'
       - '.github/workflows/changelog_test.yml'
       - 'docker/**'
       - 'doc/**'
@@ -21,7 +22,7 @@ on:
       - 'doc/**'
 
 jobs:
-  BuildTest:
+  build-and-test:
     runs-on: ubuntu-latest
 
     strategy:
@@ -45,7 +46,7 @@ jobs:
         run: python install.py -j 2 --build-type=Release --core-version 999999.999999 
 
       - name: Cyclus Unit Tests
-        run: cyclus_unit
+        run: cyclus_unit_test
 
       - name: Cyclus Python Tests
         run: pytest tests

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -12,8 +12,6 @@ on:
       - 'docker/**'
       - 'doc/**'
   push:
-    branches:
-      - main
     paths-ignore:
       - '.github/workflows/build_test_publish.yml'
       - '.github/workflows/changelog_test.yml'

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -34,7 +34,7 @@ jobs:
             apt,
             conda
         ]
-
+    
     container:
       image: ghcr.io/cyclus/cyclus_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/${{ matrix.pkg_mgr }}-deps
 
@@ -45,8 +45,14 @@ jobs:
       - name: Building Cyclus
         run: python install.py -j 2 --build-type=Release --core-version 999999.999999 
 
+      - name: Add bins to PATH
+        run: echo "/root/.local/bin:$PATH" >> $GITHUB_PATH
+
+      - name: Add libs to LD_LIBRARY_PATH
+        run: echo "/root/.local/lib:/root/.local/lib/cyclus:$LD_LIBRARYPATH" >> $GITHUB_PATH
+
       - name: Cyclus Unit Tests
-        run: ./build/bin/cyclus_unit_tests
+        run: cyclus_unit_tests
 
       - name: Cyclus Python Tests
         run: cd tests && python -m pytest --ignore test_main.py

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -45,14 +45,21 @@ jobs:
       - name: Building Cyclus
         run: python install.py -j 2 --build-type=Release --core-version 999999.999999 
 
-      - name: Add bins to PATH
-        run: echo "/root/.local/bin:$PATH" >> $GITHUB_PATH
+      # - name: Add bins to PATH
+      #   run: echo "/root/.local/bin:$PATH" >> $GITHUB_PATH
 
-      - name: Add libs to LD_LIBRARY_PATH
-        run: echo "/root/.local/lib:/root/.local/lib/cyclus:$LD_LIBRARYPATH" >> $GITHUB_PATH
+      # - name: Add libs to LD_LIBRARY_PATH
+      #   run: echo "/root/.local/lib:/root/.local/lib/cyclus:$LD_LIBRARY_PATH" >> $GITHUB_PATH
 
       - name: Cyclus Unit Tests
-        run: cyclus_unit_tests
+        run: | 
+          export PATH=$PATH:/root/.local/bin 
+          export LD_LIBRARY_PATH=/root/.local/lib:/root/.local/lib/cyclus:$LD_LIBRARY_PATH
+          cyclus_unit_tests
 
       - name: Cyclus Python Tests
-        run: cd tests && python -m pytest --ignore test_main.py
+        run: |
+          export PATH=$PATH:/root/.local/bin 
+          export LD_LIBRARY_PATH=/root/.local/lib:/root/.local/lib/cyclus:$LD_LIBRARY_PATH
+          cd tests
+          python -m pytest --ignore test_main.py

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,0 +1,51 @@
+name: Linux Build/Test for PR and collaborator push
+
+on:
+  # allows us to run workflows manually
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '.github/workflows/build_test_publish.yml'
+      - '.github/workflows/changelog_test.yml'
+      - 'docker/**'
+      - 'doc/**'
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '.github/workflows/build_test_publish.yml'
+      - '.github/workflows/changelog_test.yml'
+      - 'docker/**'
+      - 'doc/**'
+
+jobs:
+  BuildTest:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ubuntu_versions : [
+          22.04,
+          ]
+        pkg_mgr : [
+            apt,
+            conda
+        ]
+
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/cyclus_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Building Cyclus
+        run: python install.py -j 2 --build-type=Release --core-version 999999.999999 
+
+      - name: Cyclus Unit Tests
+        run: cyclus_unit
+
+      - name: Cyclus Python Tests
+        run: pytest tests

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -46,7 +46,7 @@ jobs:
         run: python install.py -j 2 --build-type=Release --core-version 999999.999999 
 
       - name: Cyclus Unit Tests
-        run: /root/.local/bin/cyclus_unit_tests
+        run: ./build/bin/cyclus_unit_tests
 
       - name: Cyclus Python Tests
-        run: pytest-3 tests
+        run: cd tests && python -m pytest

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -46,13 +46,25 @@ jobs:
         run: python install.py -j 2 --build-type=Release --core-version 999999.999999 
 
       - name: Add bins to PATH
-        run: echo "PATH=/root/.local/bin:$PATH" >> $GITHUB_ENV
+        run: |
+          echo "PATH=/root/.local/bin:$PATH" >> $GITHUB_ENV
 
       - name: Add libs to LD_LIBRARY_PATH
-        run: echo "LD_LIBRARY_PATH=/root/.local/lib:/root/.local/lib/cyclus:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+        run: |
+          echo "LD_LIBRARY_PATH=/root/.local/lib:/root/.local/lib/cyclus:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+
+      - name: Confirm PATH
+        run: |
+          echo $PATH
+
+      - name: Confirm LD_LIBRARY_PATH
+        run: |
+          echo $LD_LIBRARY_PATH
 
       - name: Cyclus Unit Tests
-        run: cyclus_unit_tests
+        run: |
+          cyclus_unit_tests
 
       - name: Cyclus Python Tests
-        run: cd tests  python -m pytest --ignore test_main.py
+        run: |
+          cd tests && python -m pytest --ignore test_main.py

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -49,4 +49,4 @@ jobs:
         run: ./build/bin/cyclus_unit_tests
 
       - name: Cyclus Python Tests
-        run: cd tests && python -m pytest
+        run: cd tests && python -m pytest --ignore test_main.py

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -45,21 +45,14 @@ jobs:
       - name: Building Cyclus
         run: python install.py -j 2 --build-type=Release --core-version 999999.999999 
 
-      # - name: Add bins to PATH
-      #   run: echo "/root/.local/bin:$PATH" >> $GITHUB_PATH
+      - name: Add bins to PATH
+        run: echo "/root/.local/bin:$PATH" >> $GITHUB_ENV
 
-      # - name: Add libs to LD_LIBRARY_PATH
-      #   run: echo "/root/.local/lib:/root/.local/lib/cyclus:$LD_LIBRARY_PATH" >> $GITHUB_PATH
+      - name: Add libs to LD_LIBRARY_PATH
+        run: echo "/root/.local/lib:/root/.local/lib/cyclus:$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
       - name: Cyclus Unit Tests
-        run: | 
-          export PATH=$PATH:/root/.local/bin 
-          export LD_LIBRARY_PATH=/root/.local/lib:/root/.local/lib/cyclus:$LD_LIBRARY_PATH
-          cyclus_unit_tests
+        run: cyclus_unit_tests
 
       - name: Cyclus Python Tests
-        run: |
-          export PATH=$PATH:/root/.local/bin 
-          export LD_LIBRARY_PATH=/root/.local/lib:/root/.local/lib/cyclus:$LD_LIBRARY_PATH
-          cd tests
-          python -m pytest --ignore test_main.py
+        run: cd tests  python -m pytest --ignore test_main.py

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -46,10 +46,10 @@ jobs:
         run: python install.py -j 2 --build-type=Release --core-version 999999.999999 
 
       - name: Add bins to PATH
-        run: echo "/root/.local/bin:$PATH" >> $GITHUB_ENV
+        run: echo "PATH=/root/.local/bin:$PATH" >> $GITHUB_ENV
 
       - name: Add libs to LD_LIBRARY_PATH
-        run: echo "/root/.local/lib:/root/.local/lib/cyclus:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+        run: echo "LD_LIBRARY_PATH=/root/.local/lib:/root/.local/lib/cyclus:$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
       - name: Cyclus Unit Tests
         run: cyclus_unit_tests

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -4,8 +4,6 @@ on:
   # allows us to run workflows manually
   workflow_dispatch:
   pull_request:
-    branches:
-      - main
     paths-ignore:
       - '.github/workflows/build_test_publish.yml'
       - '.github/workflows/changelog_test.yml'
@@ -37,7 +35,7 @@ jobs:
       image: ghcr.io/${{ github.repository_owner }}/cyclus_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/${{ matrix.pkg_mgr }}-deps
 
     steps:
-      - name: Checkout repository
+      - name: Checkout and Build Cyclus
         uses: actions/checkout@v3
 
       - name: Building Cyclus

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Building Cyclus
         run: python install.py -j 2 --build-type=Release --core-version 999999.999999 
 
+      - name: Add Cyclus binaries to PATH
+        run: export PATH=/root/.local/bin:$PATH
+
       - name: Cyclus Unit Tests
         run: cyclus_unit_tests
 

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -45,11 +45,8 @@ jobs:
       - name: Building Cyclus
         run: python install.py -j 2 --build-type=Release --core-version 999999.999999 
 
-      - name: Add Cyclus binaries to PATH
-        run: echo "PATH=/root/.local/bin:$PATH" >> "$GITHUB_ENV"
-
       - name: Cyclus Unit Tests
-        run: cyclus_unit_tests
+        run: /root/.local/bin/cyclus_unit_tests
 
       - name: Cyclus Python Tests
-        run: pytest tests
+        run: pytest-3 tests

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -34,7 +34,7 @@ jobs:
         ]
     
     container:
-      image: ghcr.io/cyclus/cyclus_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/${{ matrix.pkg_mgr }}-deps
+      image: ghcr.io/${{ github.repository_owner }}/cyclus_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/${{ matrix.pkg_mgr }}-deps
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -47,15 +47,15 @@ jobs:
 
       - name: Add bins to PATH
         run: |
-          echo "PATH=/root/.local/bin:$PATH" >> "$GITHUB_ENV"
+          echo "PATH=${HOME}/.local/bin:$PATH" >> "$GITHUB_ENV"
 
       - name: Add libs to LD_LIBRARY_PATH
         run: |
-          echo "LD_LIBRARY_PATH=/root/.local/lib:/root/.local/lib/cyclus:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=${HOME}/.local/lib:${HOME}/.local/lib/cyclus:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
 
       - name: Cyclus Unit Tests
         run: |
-          /root/.local/bin/cyclus_unit_tests
+          cyclus_unit_tests
 
       - name: Cyclus Python Tests
         run: |

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -53,17 +53,9 @@ jobs:
         run: |
           echo "LD_LIBRARY_PATH=/root/.local/lib:/root/.local/lib/cyclus:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
 
-      - name: Confirm PATH
-        run: |
-          echo $PATH
-
-      - name: Confirm LD_LIBRARY_PATH
-        run: |
-          echo $LD_LIBRARY_PATH
-
       - name: Cyclus Unit Tests
         run: |
-          cyclus_unit_tests
+          /root/.local/bin/cyclus_unit_tests
 
       - name: Cyclus Python Tests
         run: |

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -47,11 +47,11 @@ jobs:
 
       - name: Add bins to PATH
         run: |
-          echo "PATH=/root/.local/bin:$PATH" >> $GITHUB_ENV
+          echo "PATH=/root/.local/bin:$PATH" >> "$GITHUB_ENV"
 
       - name: Add libs to LD_LIBRARY_PATH
         run: |
-          echo "LD_LIBRARY_PATH=/root/.local/lib:/root/.local/lib/cyclus:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=/root/.local/lib:/root/.local/lib/cyclus:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
 
       - name: Confirm PATH
         run: |

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -8,7 +8,6 @@ on:
       - main
     paths-ignore:
       - '.github/workflows/build_test_publish.yml'
-      - '.github/workflows/build_test.yml'
       - '.github/workflows/changelog_test.yml'
       - 'docker/**'
       - 'doc/**'
@@ -47,7 +46,7 @@ jobs:
         run: python install.py -j 2 --build-type=Release --core-version 999999.999999 
 
       - name: Cyclus Unit Tests
-        run: cyclus_unit_test
+        run: cyclus_unit_tests
 
       - name: Cyclus Python Tests
         run: pytest tests

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -46,7 +46,7 @@ jobs:
         run: python install.py -j 2 --build-type=Release --core-version 999999.999999 
 
       - name: Add Cyclus binaries to PATH
-        run: export PATH=/root/.local/bin:$PATH
+        run: echo "PATH=/root/.local/bin:$PATH" >> "$GITHUB_ENV"
 
       - name: Cyclus Unit Tests
         run: cyclus_unit_tests

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -41,14 +41,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Building Cyclus
-        run: python install.py -j 2 --build-type=Release --core-version 999999.999999 
-
-      - name: Add bins to PATH
         run: |
+          python install.py -j 2 --build-type=Release --core-version 999999.999999 
           echo "PATH=${HOME}/.local/bin:$PATH" >> "$GITHUB_ENV"
-
-      - name: Add libs to LD_LIBRARY_PATH
-        run: |
           echo "LD_LIBRARY_PATH=${HOME}/.local/lib:${HOME}/.local/lib/cyclus:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
 
       - name: Cyclus Unit Tests

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -26,6 +26,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         ubuntu_versions : [
           22.04,

--- a/.github/workflows/build_test_publish.yml
+++ b/.github/workflows/build_test_publish.yml
@@ -9,8 +9,6 @@ on:
       - '.github/workflows/build_test_publish.yml'
       - '.github/workflows/changelog_test.yml'
       - 'docker/**'
-    paths-ignore:
-      - 'doc/**'
 
 jobs:
   build-dependency-and-test-img:

--- a/.github/workflows/build_test_publish.yml
+++ b/.github/workflows/build_test_publish.yml
@@ -1,4 +1,4 @@
-name: Build, Test & Publish docker images for future CI and other users
+name: Build and Test Dependency Images
 
 on:
   # allows us to run workflows manually

--- a/.github/workflows/build_test_publish.yml
+++ b/.github/workflows/build_test_publish.yml
@@ -5,8 +5,12 @@ on:
   workflow_dispatch:
   pull_request:
   push:
-    branches:
-      - main
+    paths:
+      - '.github/workflows/build_test_publish.yml'
+      - '.github/workflows/changelog_test.yml'
+      - 'docker/**'
+    paths-ignore:
+      - 'doc/**'
 
 jobs:
   build-dependency-and-test-img:

--- a/.github/workflows/build_test_publish.yml
+++ b/.github/workflows/build_test_publish.yml
@@ -5,6 +5,8 @@ on:
   workflow_dispatch:
   pull_request:
   push:
+    branches:
+      - main
     paths:
       - '.github/workflows/build_test_publish.yml'
       - 'docker/**'

--- a/.github/workflows/build_test_publish.yml
+++ b/.github/workflows/build_test_publish.yml
@@ -7,7 +7,6 @@ on:
   push:
     paths:
       - '.github/workflows/build_test_publish.yml'
-      - '.github/workflows/changelog_test.yml'
       - 'docker/**'
 
 jobs:

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,0 +1,55 @@
+name: Publish Cyclus Release
+
+on:
+  # allows us to run workflows manually
+  workflow_dispatch:
+  release:
+    types: [published, created, edited]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ubuntu_versions : [
+          22.04,
+        ]
+        pkg_mgr : [
+          apt,
+          conda
+        ]
+
+    name: Installing Dependencies, Building cyclus and running tests
+    steps:
+      - name: default environment
+        run: |
+            echo "tag-latest-on-default=false" >> "$GITHUB_ENV"
+    
+      - name: condition on trigger parameters
+        if: ${{ github.repository_owner == 'cyclus' }}
+        run: |
+            echo "tag-latest-on-default=true" >> "$GITHUB_ENV"
+    
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Installing Dependencies in Docker image
+        uses: firehed/multistage-docker-build-action@v1
+        with:
+          repository: ghcr.io/${{ github.repository_owner }}/cyclus_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}_${{ github.ref }}
+          stages: ${{ matrix.pkg_mgr }}-deps, cyclus # nice to have the deps image pushed for a release
+          server-stage: cyclus-test
+          quiet: false
+          parallel: true
+          tag-latest-on-default: ${{ env.tag-latest-on-default }}
+          dockerfile: docker/Dockerfile
+          build-args: pkg_mgr=${{ matrix.pkg_mgr }}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -5,7 +5,7 @@ on:
     types: [published, created, edited]
 
 jobs:
-  build-and-test:
+  build-and-test-for-release:
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,8 +1,6 @@
 name: Publish Cyclus Release
 
 on:
-  # allows us to run workflows manually
-  workflow_dispatch:
   release:
     types: [published, created, edited]
 
@@ -46,7 +44,7 @@ jobs:
         uses: firehed/multistage-docker-build-action@v1
         with:
           repository: ghcr.io/${{ github.repository_owner }}/cyclus_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}_${{ github.ref }}
-          stages: ${{ matrix.pkg_mgr }}-deps, cyclus # nice to have the deps image pushed for a release
+          stages: ${{ matrix.pkg_mgr }}-deps, cyclus
           server-stage: cyclus-test
           quiet: false
           parallel: true

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Since last release
   will fail unless update-alternatives has been used to point python at the 
   correct python3 version (#1558)
 * build and test are now fown on githubAction in place or CircleCI (#1569)
+* Have separate workflows for testing, publishing dependency images, and publishing release images (#1597)
 
 
 **Changed:**

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -59,8 +59,13 @@ RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
 ENV PATH /opt/conda/bin:$PATH
 
 RUN conda config --add channels conda-forge
+# RUN conda config --set channel_priority flexible
 RUN conda update -n base -c defaults conda
+RUN conda install -y conda-libmamba-solver
+RUN conda config --set solver libmamba
 RUN conda install -y mamba
+RUN conda uninstall conda-libmamba-solver
+RUN conda config --set solver classic
 RUN conda update -y --all && \
     mamba install -y \
                openssh \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -59,12 +59,11 @@ RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
 ENV PATH /opt/conda/bin:$PATH
 
 RUN conda config --add channels conda-forge
-# RUN conda config --set channel_priority flexible
 RUN conda update -n base -c defaults conda
 RUN conda install -y conda-libmamba-solver
 RUN conda config --set solver libmamba
 RUN conda install -y mamba
-RUN conda uninstall conda-libmamba-solver
+RUN conda uninstall -y conda-libmamba-solver
 RUN conda config --set solver classic
 RUN conda update -y --all && \
     mamba install -y \


### PR DESCRIPTION
This PR separates the Cycles workflows into: 

- One that is run from the upstream repo that pushes new dependency images (and is only triggered on changes to the workflow/Dockerfile)
- One that can be run from contributor's forks that pulls the dependency image from cyclus/cyclus package repository, and builds/tests cyclus with those dependencies


I also added a third workflow that is triggered on a release.  It is mostly copied from the build-test-publish.yml, the main differences are the triggers and the image tag
