### PR TITLE
limit PR conditions for running this workflow

### DIFF
--- a/.github/workflows/build_test_publish.yml
+++ b/.github/workflows/build_test_publish.yml
@@ -4,6 +4,9 @@ on:
   # allows us to run workflows manually
   workflow_dispatch:
   pull_request:
+    paths:
+      - '.github/workflows/build_test_publish.yml'
+      - 'docker/**'
   push:
     branches:
       - main

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,7 @@ Since last release
   will fail unless update-alternatives has been used to point python at the 
   correct python3 version (#1558)
 * build and test are now fown on githubAction in place or CircleCI (#1569)
-* Have separate workflows for testing, publishing dependency images, and publishing release images (#1597)
+* Have separate workflows for testing, publishing dependency images, and publishing release images (#1597, #1601)
 
 
 **Changed:**


### PR DESCRIPTION
Only run the publish workflow on PRs that have changes in specific files.

Fixes #1600 