### PR TITLE
Add Ubuntu 20.04 support

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -24,6 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         ubuntu_versions : [
+          20.04,
           22.04,
           ]
         pkg_mgr : [

--- a/.github/workflows/build_test_publish.yml
+++ b/.github/workflows/build_test_publish.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         ubuntu_versions : [
-          20.04
+          20.04,
           22.04,
           ]
         pkg_mgr : [
@@ -57,4 +57,5 @@ jobs:
           parallel: true
           tag-latest-on-default: ${{ env.tag-latest-on-default }}
           dockerfile: docker/Dockerfile
-          build-args: pkg_mgr=${{ matrix.pkg_mgr }}
+          build-args: pkg_mgr=${{ matrix.pkg_mgr }}, ubuntu_version=${{ matrix.ubuntu_versions }}
+          

--- a/.github/workflows/build_test_publish.yml
+++ b/.github/workflows/build_test_publish.yml
@@ -18,6 +18,7 @@ jobs:
     strategy:
       matrix:
         ubuntu_versions : [
+          20.04
           22.04,
           ]
         pkg_mgr : [

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -12,6 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         ubuntu_versions : [
+          20.04,
           22.04,
         ]
         pkg_mgr : [

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Since last release
   correct python3 version (#1558)
 * build and test are now fown on githubAction in place or CircleCI (#1569)
 * Have separate workflows for testing, publishing dependency images, and publishing release images (#1597)
+* Add Ubuntu 20.04 to the workflow matrices (#1603)
 
 
 **Changed:**

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,8 @@
 ARG pkg_mgr=apt
 ARG make_cores=2
+ARG ubuntu_version=22.04
 
-FROM ubuntu:22.04 as common-base
+FROM ubuntu:${ubuntu_version} as common-base
 
 ENV TZ=America/Chicago
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -120,6 +120,7 @@ WORKDIR /cyclus
 
 # You may add the option "--cmake-debug" to the following command
 # for further CMake debugging.
+RUN mkdir -p `python -m site --user-site`
 RUN python install.py -j ${make_cores} --build-type=Release --core-version 999999.999999 
 ENV PATH /root/.local/bin:$PATH
 ENV LD_LIBRARY_PATH /root/.local/lib:/root/.local/lib/cyclus
@@ -130,5 +131,5 @@ RUN cyclus_unit_tests
 
 FROM cyclus-test as cyclus-pytest
 
-RUN cd tests && pytest
+RUN cd tests && python -m pytest --ignore test_main.py
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,9 +38,9 @@ RUN apt install -y \
         python3-pandas \
         python3-jinja2 \
         cython3 \
-        libwebsockets-dev \
-        python3-pprintpp \
-    && apt clean -y all
+        libwebsockets-dev
+RUN apt install python3-pprintpp; exit 0
+RUN apt clean -y all
 
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 


### PR DESCRIPTION
Added 20.04 to the testing matrix and modified the Dockerfile slightly to build cyclus on 20.04.  

The only apt dependency that isn't available on 20.04 is `python3-pprintpp`, but it looks as though this is an optional dependency in the first place (see `src/pyinfile.pyx`), so we could probably drop it altogether if we want.  
