### PR TITLE
Add 20.04 support for PR and Publish workflows

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -39,6 +39,11 @@ jobs:
       - name: Checkout and Build Cyclus
         uses: actions/checkout@v3
 
+      - name: echo some stuff
+        run: |
+          python -m site --user-site
+          ls /github/home/.local/lib/python3.8/site-packages
+
       - name: Building Cyclus
         run: |
           python install.py -j 2 --build-type=Release --core-version 999999.999999 

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -39,11 +39,6 @@ jobs:
       - name: Checkout and Build Cyclus
         uses: actions/checkout@v3
 
-      - name: echo some stuff
-        run: |
-          python -m site --user-site
-          ls /github/home/.local/lib/python3.8/site-packages
-
       - name: Building Cyclus
         run: |
           mkdir `python -m site --user-site`

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -41,7 +41,6 @@ jobs:
 
       - name: Building Cyclus
         run: |
-          mkdir -p `python -m site --user-site`
           python install.py -j 2 --build-type=Release --core-version 999999.999999 
           echo "PATH=${HOME}/.local/bin:$PATH" >> "$GITHUB_ENV"
           echo "LD_LIBRARY_PATH=${HOME}/.local/lib:${HOME}/.local/lib/cyclus:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -46,6 +46,7 @@ jobs:
 
       - name: Building Cyclus
         run: |
+          mkdir `python -m site --user-site`
           python install.py -j 2 --build-type=Release --core-version 999999.999999 
           echo "PATH=${HOME}/.local/bin:$PATH" >> "$GITHUB_ENV"
           echo "LD_LIBRARY_PATH=${HOME}/.local/lib:${HOME}/.local/lib/cyclus:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Building Cyclus
         run: |
-          mkdir `python -m site --user-site`
+          mkdir -p `python -m site --user-site`
           python install.py -j 2 --build-type=Release --core-version 999999.999999 
           echo "PATH=${HOME}/.local/bin:$PATH" >> "$GITHUB_ENV"
           echo "LD_LIBRARY_PATH=${HOME}/.local/lib:${HOME}/.local/lib/cyclus:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -41,6 +41,7 @@ jobs:
 
       - name: Building Cyclus
         run: |
+          mkdir -p `python -m site --user-site`
           python install.py -j 2 --build-type=Release --core-version 999999.999999 
           echo "PATH=${HOME}/.local/bin:$PATH" >> "$GITHUB_ENV"
           echo "LD_LIBRARY_PATH=${HOME}/.local/lib:${HOME}/.local/lib/cyclus:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -24,6 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         ubuntu_versions : [
+          20.04,
           22.04,
           ]
         pkg_mgr : [

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -12,6 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         ubuntu_versions : [
+          20.04,
           22.04,
         ]
         pkg_mgr : [
@@ -50,4 +51,4 @@ jobs:
           parallel: true
           tag-latest-on-default: ${{ env.tag-latest-on-default }}
           dockerfile: docker/Dockerfile
-          build-args: pkg_mgr=${{ matrix.pkg_mgr }}
+          build-args: pkg_mgr=${{ matrix.pkg_mgr }}, ubuntu_version=${{ matrix.ubuntu_versions }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Since last release
   correct python3 version (#1558)
 * build and test are now fown on githubAction in place or CircleCI (#1569)
 * Have separate workflows for testing, publishing dependency images, and publishing release images (#1597, #1602, #1606)
-* Add Ubuntu 20.04 to the list of supported platforms (#1605)
+* Add Ubuntu 20.04 to the list of supported platforms (#1605, #1608)
 
 **Changed:**
 


### PR DESCRIPTION
Relies on #1605  to be merged first.  The `build_test.yml` needs the dependency images for 20.04 to be published as `latest` before all the workflows will pass