### PR TITLE
Add Code Coverage using Coveralls

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -29,7 +29,7 @@ jobs:
           ]
         pkg_mgr : [
             apt,
-            conda
+            conda,
         ]
     
     container:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Initial Coverage Report
         run: |
-          lcov -c --rc lcov_branch_coverage=1 --initial -d ${PWD}/build/src -o ${HOME}/initial_coverage.info --gcov-tool ${{ env.GCOV }}
+          lcov -c --rc lcov_branch_coverage=1 --initial -d ${PWD}/src -o ${HOME}/initial_coverage.info --gcov-tool ${{ env.GCOV }}
 
       - name: Cyclus Unit Tests
         run: |
@@ -72,11 +72,11 @@ jobs:
 
       - name: Unit Test Coverage Report
         run: |
-          lcov -c --rc lcov_branch_coverage=1 -d ${PWD}/build/src -o ${HOME}/test_coverage.info --gcov-tool ${{ env.GCOV }}
+          lcov -c --rc lcov_branch_coverage=1 -d ${PWD}/src -o ${HOME}/test_coverage.info --gcov-tool ${{ env.GCOV }}
           lcov --add-tracefile ${HOME}/initial_coverage.info --add-tracefile  ${HOME}/test_coverage.info --rc lcov_branch_coverage=1 -o ${HOME}/total_coverage.info
           lcov --remove ${HOME}/total_coverage.info -o ${HOME}/src_coverage.info --rc lcov_branch_coverage=1 "/usr/**" "/opt/**"
           mkdir -p ${HOME}/cyclus_coverage/html
-          genhtml ${HOME}/src_coverage.info --output-directory ${HOME}/cyclus_coverage/html
+          genhtml ${HOME}/src_coverage.info --output-directory ${HOME}/cyclus_coverage/html --branch-coverage
           echo "artifactPath=${HOME}/cyclus_coverage/html/" >> $GITHUB_ENV
      
       - name: Upload Coverage HTML Artifacts

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Building Cyclus
         run: |
           mkdir -p `python -m site --user-site`
-          python install.py -j 2 --build-type=Release --core-version 999999.999999 --allow-milps
+          python install.py -j 2 --build-type=Release --core-version 999999.999999 --allow-milps --code_coverage
           echo "PATH=${HOME}/.local/bin:$PATH" >> "$GITHUB_ENV"
           echo "LD_LIBRARY_PATH=${HOME}/.local/lib:${HOME}/.local/lib/cyclus:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
 

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Initial Coverage Report
         run: |
-          lcov -c --rc lcov_branch_coverage=1 --initial -d ${PWD}/src -o ${HOME}/initial_coverage.info --gcov-tool ${{ env.GCOV }}
+          lcov -c --rc lcov_branch_coverage=1 --initial -d ${PWD}/build/src -o ${HOME}/initial_coverage.info --gcov-tool ${{ env.GCOV }}
 
       - name: Cyclus Unit Tests
         run: |
@@ -72,7 +72,7 @@ jobs:
 
       - name: Unit Test Coverage Report
         run: |
-          lcov -c --rc lcov_branch_coverage=1 -d ${PWD}/src -o ${HOME}/test_coverage.info --gcov-tool ${{ env.GCOV }}
+          lcov -c --rc lcov_branch_coverage=1 -d ${PWD}/build/src -o ${HOME}/test_coverage.info --gcov-tool ${{ env.GCOV }}
           lcov --add-tracefile ${HOME}/initial_coverage.info --add-tracefile  ${HOME}/test_coverage.info --rc lcov_branch_coverage=1 -o ${HOME}/total_coverage.info
           lcov --remove ${HOME}/total_coverage.info -o ${HOME}/src_coverage.info --rc lcov_branch_coverage=1 "/usr/**" "/opt/**"
           mkdir -p ${HOME}/cyclus_coverage/html

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -46,6 +46,22 @@ jobs:
           echo "PATH=${HOME}/.local/bin:$PATH" >> "$GITHUB_ENV"
           echo "LD_LIBRARY_PATH=${HOME}/.local/lib:${HOME}/.local/lib/cyclus:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
 
+      - name: Install lcov for apt
+        if: matrix.pkg_mgr == 'apt'
+        run: |
+          apt update --fix-missing && apt install -y lcov curl
+          echo "GCOV=/usr/bin/gcov" >> "$GITHUB_ENV"
+      
+      - name: Install lcov for conda
+        if: matrix.pkg_mgr == 'conda'
+        run: |
+            mamba install -c conda-forge -y lcov curl
+            echo "GCOV=/opt/conda/bin/x86_64-conda-linux-gnu-gcov" >> "$GITHUB_ENV"
+
+      - name: Initial Coverage Report
+        run: |
+          lcov -c --rc lcov_branch_coverage=1 --initial -d ${PWD}/build/src -o ${HOME}/initial_coverage.info --gcov-tool ${{ env.GCOV }}
+
       - name: Cyclus Unit Tests
         run: |
           cyclus_unit_tests
@@ -53,3 +69,36 @@ jobs:
       - name: Cyclus Python Tests
         run: |
           cd tests && python -m pytest --ignore test_main.py
+
+      - name: Unit Test Coverage Report
+        run: |
+          lcov -c --rc lcov_branch_coverage=1 -d ${PWD}/build/src -o ${HOME}/test_coverage.info --gcov-tool ${{ env.GCOV }}
+          lcov --add-tracefile ${HOME}/initial_coverage.info --add-tracefile  ${HOME}/test_coverage.info --rc lcov_branch_coverage=1 -o ${HOME}/total_coverage.info
+          lcov --remove ${HOME}/total_coverage.info -o ${HOME}/src_coverage.info --rc lcov_branch_coverage=1 "/usr/**" "/opt/**"
+          mkdir -p ${HOME}/cyclus_coverage/html
+          genhtml ${HOME}/src_coverage.info --output-directory ${HOME}/cyclus_coverage/html
+          echo "artifactPath=${HOME}/cyclus_coverage/html/" >> $GITHUB_ENV
+     
+      - name: Upload Coverage HTML Artifacts
+        uses: actions/upload-pages-artifact@v2
+        with:
+          name: cyclus-coverage-report-${{ matrix.ubuntu_versions }}-${{ matrix.pkg_mgr }}
+          path: ${{ env.artifactPath }}
+
+      - name: Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          flag-name: ${{ join(matrix.*, '-') }}
+          parallel: true
+          file: ${HOME}/src_coverage.info
+          format: lcov
+          compare-ref: main
+
+  finish-coveralls:
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Coveralls Finished
+      uses: coverallsapp/github-action@v2
+      with:
+        parallel-finished: true

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Since last release
 * Have separate workflows for testing, publishing dependency images, and publishing release images (#1597, #1602, #1606, #1609)
 * Add Ubuntu 20.04 to the list of supported platforms (#1605, #1608)
 * Add random number generator (Mersenne Twister 19937, from boost) and the ability to set the seed in the simulation control block (#1599)
+* Added code coverage reporting to GitHub workflows (#1616)
 
 **Changed:**
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,11 @@ ELSE()
     MESSAGE(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++17 support. Please use a different C++ compiler.")
 ENDIF()
 
+IF(CODE_COVERAGE)
+    MESSAGE(STATUS "Compiling with --coverage flag for code coverage analysis")
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
+ENDIF()
+
 # enable assembly
 enable_language(ASM)
 

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,8 @@
 Cyclus
 ------
+.. image:: https://coveralls.io/repos/github/cyclus/cyclus/badge.svg
+  :target: https://coveralls.io/github/cyclus/cyclus
+
 
 The Cyclus fuel cycle simulator is an agent-based and extensible framework for
 modeling the flow of material through future nuclear fuel cycles.  For more

--- a/install.py
+++ b/install.py
@@ -85,6 +85,8 @@ def install_cyclus(args):
             cmake_cmd += ['-D' + x for x in args.D]
         if args.cmake_debug:
             cmake_cmd += ['-Wdev', '--debug-output']
+        if args.code_coverage is not None:
+            cmake_cmd += ['-DCODE_COVERAGE=' + ('TRUE' if args.code_coverage else 'FALSE')]
         if args.fast is not None:
             fast = 'TRUE' if args.fast else 'FALSE'
             cmake_cmd.append('-DCYCLUS_FAST_COMPILE=' + fast)
@@ -196,6 +198,10 @@ def main():
     parser.add_argument('--cmake-debug', action='store_true', default=False,
                         dest='cmake_debug', help='puts CMake itself in a debug mode '
                                                  'when dealing with build system issues.')
+
+    code_coverage = "Enable code coverage analysis using gcov/lcov"
+    parser.add_argument('--code_coverage', help=code_coverage, default=False, action="store_true")
+
     parser.add_argument('--fast', default=None, dest='fast',
                         action='store_true', help="Will try to compile "
                         "from assembly, if possible. This is faster than "


### PR DESCRIPTION
Adds a build option to enable code coverage and generates coverage reports in the `build_test.yml` workflow.

The workflows will generate html artifacts that can be downloaded and push coverage reports to [Coveralls](https://coveralls.io/github/cyclus/cyclus).  The settings in Coveralls allow us to define failure thresholds for PRs.

Fixes #1591 
