### PR TITLE
Updated Readme file to work properly with Ubuntu 22.04

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,7 @@ Since last release
 * Moved to unified CHANGELOG Entry and check them with GithubAction (#1571)
 * Major update and modernization of build (#1587)
 * Changed Json formatting for compatibility with current python standards (#1587)
+* Changed README.rst installation instructions, tested on fresh Ubuntu-22.04 system with Python 3.11 (#1617)
 
 **Removed:**
 

--- a/README.rst
+++ b/README.rst
@@ -108,11 +108,11 @@ To install Cyclus and its dependencies onto a clean Ubuntu machine (tested on 18
 
 - ``conda config --add channels conda-forge``
 
-- ``conda create -n cyclus python=3.8``
+- ``conda create -n cyclus python=3.11``
 
 - ``conda activate cyclus``
 
-- ``conda install -y openssh gxx_linux-64 gcc_linux-64 cmake make docker-pycreds git xo python-json-logger glib libxml2 libxmlpp libblas libcblas liblapack pkg-config coincbc boost-cpp hdf5 sqlite pcre gettext bzip2 xz setuptools pytest pytables pandas jinja2 "cython<3" websockets pprintpp``
+- ``conda install -y openssh gxx_linux-64 gcc_linux-64 cmake make docker-pycreds git xo python-json-logger glib glibmm libxml2 libxmlpp libxmlpp-4.0 libblas libcblas liblapack pkg-config coincbc boost-cpp hdf5 sqlite pcre gettext bzip2 xz setuptools pytest pytables pandas jinja2 "cython<3" websockets pprintpp``
 
 - ``conda install -y --force-reinstall libsqlite``
 

--- a/README.rst
+++ b/README.rst
@@ -110,7 +110,7 @@ To install Cyclus and its dependencies onto a clean Ubuntu machine (tested on 18
 
 - ``conda create -n cyclus python=3.8``
 
-- ``conda activate cyclus
+- ``conda activate cyclus``
 
 - ``conda install -y openssh gxx_linux-64 gcc_linux-64 cmake make docker-pycreds git xo python-json-logger glib libxml2 libxmlpp libblas libcblas liblapack pkg-config coincbc boost-cpp hdf5 sqlite pcre gettext bzip2 xz setuptools pytest pytables pandas jinja2 "cython<3" websockets pprintpp``
 

--- a/README.rst
+++ b/README.rst
@@ -108,10 +108,13 @@ To install Cyclus and its dependencies onto a clean Ubuntu machine (tested on 18
 
 - ``conda config --add channels conda-forge``
 
-- ``conda install -y openssh gxx_linux-64 gcc_linux-64 cmake make docker-pycreds git xo
-  python-json-logger python=3.6 glibmm glib=2.56 libxml2 libxmlpp libblas libcblas
-  liblapack pkg-config coincbc=2.9 boost-cpp hdf5 sqlite pcre gettext bzip2 xz
-  setuptools nose pytables pandas jinja2 cython==0.26 websockets pprintpp``
+- ``conda create -n cyclus python=3.8``
+
+- ``conda activate cyclus
+
+- ``conda install -y openssh gxx_linux-64 gcc_linux-64 cmake make docker-pycreds git xo python-json-logger glib libxml2 libxmlpp libblas libcblas liblapack pkg-config coincbc boost-cpp hdf5 sqlite pcre gettext bzip2 xz setuptools pytest pytables pandas jinja2 "cython<3" websockets pprintpp``
+
+- ``conda install -y --force-reinstall libsqlite``
 
 - Use ``sudo apt install`` to install and configure git
 


### PR DESCRIPTION
Installation with Ubuntu 22.04 did not work because some conda packages were not compatible anymore.
Followed instructions on the docker installation, and tested it on a clean Ubuntu 22.04 system.