### PR TITLE
Build new docker images on all pushes to `main` not just with specifi…

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -9,12 +9,14 @@ on:
       - '.github/workflows/changelog_test.yml'
       - 'docker/**'
       - 'doc/**'
+      - 'CHANGELOG.rst'
   push:
     paths-ignore:
       - '.github/workflows/build_test_publish.yml'
       - '.github/workflows/changelog_test.yml'
       - 'docker/**'
       - 'doc/**'
+      - 'CHANGELOG.rst'
 
 jobs:
   build-and-test:

--- a/.github/workflows/build_test_publish.yml
+++ b/.github/workflows/build_test_publish.yml
@@ -10,9 +10,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - '.github/workflows/build_test_publish.yml'
-      - 'docker/**'
 
 jobs:
   build-dependency-and-test-img:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,7 @@ Since last release
   will fail unless update-alternatives has been used to point python at the 
   correct python3 version (#1558)
 * build and test are now fown on githubAction in place or CircleCI (#1569)
-* Have separate workflows for testing, publishing dependency images, and publishing release images (#1597, #1602, #1606, #1609)
+* Have separate workflows for testing, publishing dependency images, and publishing release images (#1597, #1602, #1606, #1609, #1629)
 * Add Ubuntu 20.04 to the list of supported platforms (#1605, #1608)
 * Add random number generator (Mersenne Twister 19937, from boost) and the ability to set the seed in the simulation control block (#1599)
 


### PR DESCRIPTION
Fixes #1628

We currently only pushed new docker images when pushes to `main` were caused by changes in specific files.  This means that there is no up-to-date image based on the most current state of `main` for downstream repos.

This fix causes all pushes to `main` to cause an update of the docker images tagged as `latest`.  In the future, once we have a working release, we can add to the images with a `stable` based on the latest release.