### PR TITLE
force libxmlpp 4.0 in conda

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,7 +27,7 @@ Since last release
 **Changed:**
 
 * Moved to unified CHANGELOG Entry and check them with GithubAction (#1571)
-* Major update and modernization of build (#1587, #1632, #)
+* Major update and modernization of build (#1587, #1632, #1640)
 * Changed Json formatting for compatibility with current python standards (#1587)
 * Changed README.rst installation instructions, tested on fresh Ubuntu-22.04 system with Python 3.11 (#1617)
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,7 +27,7 @@ Since last release
 **Changed:**
 
 * Moved to unified CHANGELOG Entry and check them with GithubAction (#1571)
-* Major update and modernization of build (#1587, #1632)
+* Major update and modernization of build (#1587, #1632, #)
 * Changed Json formatting for compatibility with current python standards (#1587)
 * Changed README.rst installation instructions, tested on fresh Ubuntu-22.04 system with Python 3.11 (#1617)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -82,7 +82,7 @@ RUN conda update -y --all && \
                python-json-logger \
                glib \
                libxml2 \
-               libxmlpp \
+               libxmlpp-4.0 \
                libblas \
                libcblas \
                liblapack \


### PR DESCRIPTION
Some changes in the conda dependency tree have resulted in the `libxmlpp` resolving as version 2.40.x and then having an incompatibility with the newest `glibmm`.  This fixes it in local testing.