### PR TITLE
Fix Python segmentation fault behavior

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Cyclus Python Tests
         run: |
-          cd tests && python -m pytest --ignore test_main.py
+          cd tests && python -m pytest
 
       - name: Unit Test Coverage Report
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -62,14 +62,12 @@ Debug/
 # generated cython ignores
 *.cc.gen
 *.cc.h
-*.cpp.gen
-*.cpp.h
 *.h.gen
-src/eventhooks.cpp
+src/eventhooks.cc
 src/eventhooks.h
-src/pyinfile.cpp
+src/pyinfile.cc
 src/pyinfile.h
-src/pymodule.cpp
+src/pymodule.cc
 src/pymodule.h
 
 # this is copied over by the installer

--- a/.gitignore
+++ b/.gitignore
@@ -62,12 +62,14 @@ Debug/
 # generated cython ignores
 *.cc.gen
 *.cc.h
+*.cpp.gen
+*.cpp.h
 *.h.gen
-src/eventhooks.cc
+src/eventhooks.cpp
 src/eventhooks.h
-src/pyinfile.cc
+src/pyinfile.cpp
 src/pyinfile.h
-src/pymodule.cc
+src/pymodule.cpp
 src/pymodule.h
 
 # this is copied over by the installer

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,7 +45,7 @@ Since last release
   quantize, bids that one was not able to fullfill and caused cyclus to crash. (#1552)
 * Resolve deprecation warnings involving <boost/detail/sp_typeinfo.hpp> (#1611)
 * Resolve segmentation faults when calling Cbc (#1614)
-* Resolve segmentation faults wehn using cyclus via Python (#1666)
+* Resolve segmentation faults when using cyclus via Python (#1666)
 
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,6 +45,7 @@ Since last release
   quantize, bids that one was not able to fullfill and caused cyclus to crash. (#1552)
 * Resolve deprecation warnings involving <boost/detail/sp_typeinfo.hpp> (#1611)
 * Resolve segmentation faults when calling Cbc (#1614)
+* Resolve segmentation faults wehn using cyclus via Python (#1666)
 
 
 

--- a/cyclus/__init__.py
+++ b/cyclus/__init__.py
@@ -1,7 +1,3 @@
-from __future__ import print_function, unicode_literals
-
 __version__ = '1.5.5'
-
-from cyclus.lib import py_import_call_init
-
-py_import_call_init()
+# from cyclus.lib import py_import_call_init, py_import_init
+import pymodule, eventhooks, pyinfile

--- a/cyclus/__init__.py
+++ b/cyclus/__init__.py
@@ -1,3 +1,2 @@
 __version__ = '1.5.5'
-# from cyclus.lib import py_import_call_init, py_import_init
 import pymodule, eventhooks, pyinfile

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -134,5 +134,4 @@ RUN cyclus_unit_tests
 
 FROM cyclus-test as cyclus-pytest
 
-RUN cd tests && python -m pytest --ignore test_main.py
-
+RUN cd tests && python -m pytest

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -130,22 +130,23 @@ if(Cython_FOUND)
     foreach(file ${CYCLUS_CORE_CYTHON_FILES})
         message(STATUS "Cython Compiling ${file}")
         get_filename_component(name ${file} NAME_WE)
-        set(_generated_h "${CMAKE_CURRENT_SOURCE_DIR}/${name}.cpp.h")
-        set(_generated_cpp "${CMAKE_CURRENT_SOURCE_DIR}/${name}.cpp.gen")
+        set(_generated_h "${CMAKE_CURRENT_SOURCE_DIR}/${name}.cc.h")
+        set(_generated_cc "${CMAKE_CURRENT_SOURCE_DIR}/${name}.cc.gen")
         set(_h_file "${CMAKE_CURRENT_SOURCE_DIR}/${name}.h")
-        set(_cpp_file "${CMAKE_CURRENT_SOURCE_DIR}/${name}.cpp")
+        set(_cc_file "${CMAKE_CURRENT_SOURCE_DIR}/${name}.cc")
         set_source_files_properties(${_cc_file} PROPERTIES GENERATED TRUE)
 
         EXECUTE_PROCESS(COMMAND ${CYTHON_EXECUTABLE} --cplus
             ${include_directory_arg} ${version_arg}
             ${cython_debug_arg} ${CYTHON_FLAGS}
-            --output-file  ${_generated_cpp} ${file}
+            --output-file  ${_generated_cc} ${file}
             RESULT_VARIABLE res_var_c)
         IF(NOT "${res_var_c}" STREQUAL "0")
             message(FATAL_ERROR "Cython compilation of ${file} failed!")
         ENDIF()
 
-        ADD_LIBRARY(${name} ${_cpp_file})
+        ADD_LIBRARY(${name} ${_cc_file})
+        SET(CythonModuleSrc ${CythonModuleSrc} ${_cc_file})
         SET_TARGET_PROPERTIES(${name} PROPERTIES 
           OUTPUT_NAME "${name}"
           PREFIX ""
@@ -166,7 +167,7 @@ if(Cython_FOUND)
           )
 
         copy_when_diff(${_generated_h} ${_h_file})
-        copy_when_diff(${_generated_cpp} ${_cpp_file})
+        copy_when_diff(${_generated_cc} ${_cc_file})
     endforeach()
 endif(Cython_FOUND)
 ###########################################################
@@ -197,6 +198,7 @@ foreach(ccfile ${CYCLUS_COIN_SRC})
 endforeach()
 list(REMOVE_ITEM cc_files ${CMAKE_CURRENT_SOURCE_DIR}/coin_helpers.cc)
 list(REMOVE_ITEM cc_files ${CMAKE_CURRENT_SOURCE_DIR}/prog_translator.cc)
+list(REMOVE_ITEM cc_files ${CythonModuleSrc})
 
 SET(CYCLUS_CORE_SRC ${CYCLUS_CORE_SRC} ${cc_files})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,8 +98,7 @@ copy_when_diff(
 ###########################################################
 ############# cython configuration ########################
 ###########################################################
-
-SET(PreCythonLibs ${LIBS})
+SET(NoCythonLibs ${LIBS})
 if(Cython_FOUND)
     # some setup
     set(cython_include_directories "")
@@ -155,7 +154,7 @@ if(Cython_FOUND)
           )
         SET(LIBS ${LIBS} ${name})
 
-        TARGET_LINK_LIBRARIES(${name} dl ${PreCythonLibs})
+        TARGET_LINK_LIBRARIES(${name} dl ${NoCythonLibs})
 
         INSTALL(
           TARGETS ${name}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -198,6 +198,8 @@ foreach(ccfile ${CYCLUS_COIN_SRC})
 endforeach()
 list(REMOVE_ITEM cc_files ${CMAKE_CURRENT_SOURCE_DIR}/coin_helpers.cc)
 list(REMOVE_ITEM cc_files ${CMAKE_CURRENT_SOURCE_DIR}/prog_translator.cc)
+# The cython modules are built as their own shared libraries
+# We don't want them to be included in libcyclus.so
 list(REMOVE_ITEM cc_files ${CythonModuleSrc})
 
 SET(CYCLUS_CORE_SRC ${CYCLUS_CORE_SRC} ${cc_files})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,6 +98,8 @@ copy_when_diff(
 ###########################################################
 ############# cython configuration ########################
 ###########################################################
+
+SET(PreCythonLibs ${LIBS})
 if(Cython_FOUND)
     # some setup
     set(cython_include_directories "")
@@ -132,7 +134,7 @@ if(Cython_FOUND)
         set(_generated_h "${CMAKE_CURRENT_SOURCE_DIR}/${name}.cc.h")
         set(_generated_cc "${CMAKE_CURRENT_SOURCE_DIR}/${name}.cc.gen")
         set(_h_file "${CMAKE_CURRENT_SOURCE_DIR}/${name}.h")
-        set(_cc_file "${CMAKE_CURRENT_SOURCE_DIR}/${name}.cc")
+        set(_cc_file "${CMAKE_CURRENT_SOURCE_DIR}/${name}.cpp")
         set_source_files_properties(${_cc_file} PROPERTIES GENERATED TRUE)
 
         EXECUTE_PROCESS(COMMAND ${CYTHON_EXECUTABLE} --cplus
@@ -143,6 +145,23 @@ if(Cython_FOUND)
         IF(NOT "${res_var_c}" STREQUAL "0")
             message(FATAL_ERROR "Cython compilation of ${file} failed!")
         ENDIF()
+
+        ADD_LIBRARY(${name} ${_cc_file})
+        SET_TARGET_PROPERTIES(${name} PROPERTIES 
+          OUTPUT_NAME "${name}"
+          PREFIX ""
+          INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib"
+          INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib"
+          )
+        SET(LIBS ${LIBS} ${name})
+
+        TARGET_LINK_LIBRARIES(${name} dl ${PreCythonLibs})
+
+        INSTALL(
+          TARGETS ${name}
+          LIBRARY DESTINATION lib
+          )
+
         copy_when_diff(${_generated_h} ${_h_file})
         copy_when_diff(${_generated_cc} ${_cc_file})
     endforeach()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -131,22 +131,22 @@ if(Cython_FOUND)
     foreach(file ${CYCLUS_CORE_CYTHON_FILES})
         message(STATUS "Cython Compiling ${file}")
         get_filename_component(name ${file} NAME_WE)
-        set(_generated_h "${CMAKE_CURRENT_SOURCE_DIR}/${name}.cc.h")
-        set(_generated_cc "${CMAKE_CURRENT_SOURCE_DIR}/${name}.cc.gen")
+        set(_generated_h "${CMAKE_CURRENT_SOURCE_DIR}/${name}.cpp.h")
+        set(_generated_cpp "${CMAKE_CURRENT_SOURCE_DIR}/${name}.cpp.gen")
         set(_h_file "${CMAKE_CURRENT_SOURCE_DIR}/${name}.h")
-        set(_cc_file "${CMAKE_CURRENT_SOURCE_DIR}/${name}.cpp")
+        set(_cpp_file "${CMAKE_CURRENT_SOURCE_DIR}/${name}.cpp")
         set_source_files_properties(${_cc_file} PROPERTIES GENERATED TRUE)
 
         EXECUTE_PROCESS(COMMAND ${CYTHON_EXECUTABLE} --cplus
             ${include_directory_arg} ${version_arg}
             ${cython_debug_arg} ${CYTHON_FLAGS}
-            --output-file  ${_generated_cc} ${file}
+            --output-file  ${_generated_cpp} ${file}
             RESULT_VARIABLE res_var_c)
         IF(NOT "${res_var_c}" STREQUAL "0")
             message(FATAL_ERROR "Cython compilation of ${file} failed!")
         ENDIF()
 
-        ADD_LIBRARY(${name} ${_cc_file})
+        ADD_LIBRARY(${name} ${_cpp_file})
         SET_TARGET_PROPERTIES(${name} PROPERTIES 
           OUTPUT_NAME "${name}"
           PREFIX ""
@@ -161,9 +161,13 @@ if(Cython_FOUND)
           TARGETS ${name}
           LIBRARY DESTINATION lib
           )
+        INSTALL(
+          TARGETS ${name}
+          LIBRARY DESTINATION ${PYTHON_SITE_PACKAGES}
+          )
 
         copy_when_diff(${_generated_h} ${_h_file})
-        copy_when_diff(${_generated_cc} ${_cc_file})
+        copy_when_diff(${_generated_cpp} ${_cpp_file})
     endforeach()
 endif(Cython_FOUND)
 ###########################################################

--- a/src/pyhooks.cc
+++ b/src/pyhooks.cc
@@ -1,9 +1,8 @@
+#include "Python.h"
 #include "pyhooks.h"
 
 #ifdef CYCLUS_WITH_PYTHON
 #include <stdlib.h>
-
-#include "Python.h"
 
 extern "C" {
 #include "eventhooks.h"
@@ -17,39 +16,58 @@ bool PY_INTERP_INIT = false;
 
 
 void PyAppendInitTab(void) {
-#if PY_MAJOR_VERSION < 3
-  // Not used before Python 3
-#else
-  PyImport_AppendInittab("_cyclus_eventhooks", PyInit_eventhooks);
-  PyImport_AppendInittab("_cyclus_pyinfile", PyInit_pyinfile);
-  PyImport_AppendInittab("_cyclus_pymodule", PyInit_pymodule);
-#endif
+  if (PyImport_AppendInittab("eventhooks", PyInit_eventhooks) == -1) {
+    fprintf(stderr, "Error appending 'eventhooks' to the initialization table\n");
+  }
+
+  if (PyImport_AppendInittab("pyinfile", PyInit_pyinfile) == -1) {
+    fprintf(stderr, "Error appending 'pyinfile' to the initialization table\n");
+  }
+
+  if (PyImport_AppendInittab("pymodule", PyInit_pymodule) == -1) {
+    fprintf(stderr, "Error appending 'pymodule' to the initialization table\n");
+  }
 }
 
 void PyImportInit(void) {
-#if PY_MAJOR_VERSION < 3
-  initeventhooks();
-  initpyinfile();
-  initpymodule();
-#else
-  PyImport_ImportModule("_cyclus_eventhooks");
-  PyImport_ImportModule("_cyclus_pyinfile");
-  PyImport_ImportModule("_cyclus_pymodule");
-#endif
-};
+  PyObject* module_eventhooks = PyImport_ImportModule("eventhooks");
+  if (module_eventhooks == NULL) {
+    PyErr_Print(); // Print Python error information
+    fprintf(stderr, "Error importing 'eventhooks' module\n");
+  }
 
+  PyObject* module_pyinfile = PyImport_ImportModule("pyinfile");
+  if (module_pyinfile == NULL) {
+    PyErr_Print();
+    fprintf(stderr, "Error importing 'pyinfile' module\n");
+  }
+
+  PyObject* module_pymodule = PyImport_ImportModule("pymodule");
+  if (module_pymodule == NULL) {
+    PyErr_Print();
+    fprintf(stderr, "Error importing 'pymodule' module\n");
+  }
+}
 
 void PyImportCallInit(void) {
-#if PY_MAJOR_VERSION < 3
-  initeventhooks();
-  initpyinfile();
-  initpymodule();
-#else
-  PyInit_eventhooks();
-  PyInit_pyinfile();
-  PyInit_pymodule();
-#endif
-};
+  PyObject* init_eventhooks = PyInit_eventhooks();
+  if (init_eventhooks == NULL) {
+    PyErr_Print();
+    fprintf(stderr, "Error calling PyInit_eventhooks()\n");
+  }
+
+  PyObject* init_pyinfile = PyInit_pyinfile();
+  if (init_pyinfile == NULL) {
+    PyErr_Print();
+    fprintf(stderr, "Error calling PyInit_pyinfile()\n");
+  }
+
+  PyObject* init_pymodule = PyInit_pymodule();
+  if (init_pymodule == NULL) {
+    PyErr_Print();
+    fprintf(stderr, "Error calling PyInit_pymodule()\n");
+  }
+}
 
 
 void PyStart(void) {


### PR DESCRIPTION
This prevents segmentation faults described in #1589 and removes the `--ignore test_main.py` flag from the python tests in the Dockerfile.  

There are three cython modules in the cython core code - `pymodule.pyx`, `eventhooks.pyx`, and `pyinfile.pyx`.  There is functionality in `pyhooks.cc` that manages the python module initialization.  When cyclus is called from python, the python interpreter is already initialized so these three modules must be imported explicitly (previously "handled" by `py_import_call_init()` in `cyclus/__init__.py`).  This wasn't working correctly, so the cython modules are not appropriately initialized and this is where the segmentation faults occur.  

The current fix builds these three cython modules as their own shared libraries so that python can import them.  I modified `cyclus/__init__.py` to import these modules explicitly instead of using `py_import_call_init()`.  I was able to fix my dummy repo by calling `py_import_call_init()` followed by `py_import_init()` to actually import the modules, but have struggled to get this working in cyclus (I think it is the "best practice" fix, I can continue to work at implementing this in cyclus).

Another significant change to the CMake build (that can be up for debate) is that these three shared libraries are installed to both `/root/.local/lib` and python site packages.  This is so cyclus can find the shared libraries on LD_LIBRARY_PATH and python can find the modules in its path.  This was a design choice I made, but we can choose to install them to one location and modify our environment variables accordingly.