### PR TITLE
CI Updates

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -68,6 +68,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: cyclus/cycamore
+          ref: ci-updates
           path: ${{ github.workspace }}/cycamore
 
       - name: Build and Test Cycamore
@@ -92,6 +93,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: cyclus/cymetric
+          ref: ci-updates
           path: ${{ github.workspace }}/cymetric
 
       - name: Build and Test Cymetric

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -23,10 +23,7 @@ on:
 jobs:
   build-test-cyclus:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      pull-requests: write
+
     strategy:
       fail-fast: false
       matrix:
@@ -39,16 +36,17 @@ jobs:
           conda,
         ]
 
-    steps:
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
 
+    steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: network=host
 
       - name: Checkout Cyclus
         uses: actions/checkout@v4
@@ -59,8 +57,7 @@ jobs:
         with:
           file: docker/Dockerfile
           cache-from: type=registry,ref=ghcr.io/cyclus/cyclus_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cyclus:ci-layer-cache
-          cache-to: type=registry,ref=ghcr.io/cyclus/cyclus_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cyclus:ci-layer-cache,mode=max
-          tags: ghcr.io/cyclus/cyclus_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cyclus:ci-image-cache
+          tags: localhost:5000/cyclus:local
           push: true
           build-args: |
             pkg_mgr=${{ matrix.pkg_mgr }}
@@ -81,14 +78,14 @@ jobs:
         with:
           context: ${{ github.workspace }}/cycamore
           file: ${{ github.workspace }}/cycamore/docker/Dockerfile
+          build-contexts: |
+            ghcr.io/cyclus/cyclus_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cyclus=docker-image://localhost:5000/cyclus:local
           cache-from: type=registry,ref=ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache
-          cache-to: type=registry,ref=ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache,mode=max
-          tags: ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-image-cache
+          tags: localhost:5000/cycamore:local
           push: true
           build-args: |
             pkg_mgr=${{ matrix.pkg_mgr }}
             ubuntu_version=${{ matrix.ubuntu_versions }}
-            cyclus_tag=ci-image-cache@${{ steps.build-cyclus.outputs.digest }}
 
       - name: Checkout Cymetric
         if: ${{ github.event_name == 'pull_request' && steps.build-cycamore.outcome == 'success' }}
@@ -105,25 +102,51 @@ jobs:
         with:
           context: ${{ github.workspace }}/cymetric
           file: ${{ github.workspace }}/cymetric/docker/Dockerfile
+          build-contexts: |
+            ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore=docker-image://localhost:5000/cycamore:local
           cache-from: type=registry,ref=ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache
-          cache-to: type=registry,ref=ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache,mode=max
-          tags: ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-image-cache
-          push: true
           build-args: |
             pkg_mgr=${{ matrix.pkg_mgr }}
             ubuntu_version=${{ matrix.ubuntu_versions }}
-            cycamore_tag=ci-image-cache@${{ steps.build-cycamore.outputs.digest }}
   
-      - name: PR Comment
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: thollander/actions-comment-pull-request@v2
+      - name: Export Environment Variables
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "CYCAMORE_BUILD_STATUS=${{steps.build-cycamore.outcome == 'success' && '**Success** :white_check_mark:' || 
+          steps.build-cycamore.outcome == 'failure' && '**Failure** :x:' || 
+          '**Skipped due to upstream failure** :warning:'}}" >> "$GITHUB_ENV"
+
+          echo "CYMETRIC_BUILD_STATUS=${{steps.build-cymetric.outcome == 'success' && '**Success** :white_check_mark:' || 
+          steps.build-cymetric.outcome == 'failure' && '**Failure** :x:' || 
+          '**Skipped due to upstream failure** :warning:'}}" >> "$GITHUB_ENV"
+
+          echo "ARTIFACT_NAME=${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}" >> "$GITHUB_ENV"
+
+      - name: Construct Artifact
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "
+          ##### Build \`FROM cyclus_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cyclus\`
+            - Cycamore: ${{ env.CYCAMORE_BUILD_STATUS }}
+            - Cymetric: ${{ env.CYMETRIC_BUILD_STATUS }}" > ${{ env.ARTIFACT_NAME }}.txt
+      
+      - name: Upload Artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
         with:
-          comment_tag: ${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}
-          message: |
-            ## Downstream build statuses using cyclus_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}
-            - Cycamore: ${{steps.build-cycamore.outcome == 'success' && '*Success* :white_check_mark:' || 
-                steps.build-cycamore.outcome == 'failure' && '**Failure** :x:' || 
-                '**Skipped due to upstream failure** :warning:'}}
-            - Cymetric: ${{steps.build-cymetric.outcome == 'success' && '*Success* :white_check_mark:' || 
-                steps.build-cymetric.outcome == 'failure' && '**Failure** :x:' || 
-                '**Skipped due to upstream failure** :warning:'}}
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.ARTIFACT_NAME }}.txt
+
+  upload-pr-number:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Save PR number to file
+        run: |
+          echo "${{ github.event.number }}" > pr_number
+      
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr_number
+          path: pr_number

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -68,7 +68,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: cyclus/cycamore
-          ref: ci-updates
           path: ${{ github.workspace }}/cycamore
 
       - name: Build and Test Cycamore
@@ -93,7 +92,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: cyclus/cymetric
-          ref: ci-updates
           path: ${{ github.workspace }}/cymetric
 
       - name: Build and Test Cymetric

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -11,6 +11,9 @@ on:
       - '.github/workflows/changelog_test.yml'
       - 'doc/**'
       - 'CHANGELOG.rst'
+  push:
+    branches:
+      - main
 
 jobs:
   build-and-test:
@@ -35,7 +38,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout Cyclus
@@ -48,7 +51,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           cache-from: type=registry,ref=ghcr.io/cyclus/cyclus_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cyclus-coverage:ci-layer-cache
-          cache-to: type=registry,ref=ghcr.io/cyclus/cyclus_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cyclus-coverage:ci-layer-cache,mode=max
+          cache-to: type=registry,ref=ghcr.io/cyclus/cyclus_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cyclus-coverage:ci-layer-cache,mode=max,ignore-error=true
           file: docker/Dockerfile
           target: coverage-report
           outputs: type=local,dest=.

--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -1,0 +1,32 @@
+name: Comment on PR
+
+on:
+  workflow_run:
+    workflows: ["Build/Test Cyclus"]
+    types:
+      - completed
+
+jobs:
+  pr-comment:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+          merge-multiple: true
+
+      - name: Merge artifacts and get PR number
+        run: |
+          echo "### Downstream Build Status Report" > artifacts_merged.md
+          cat ./*.txt >> artifacts_merged.md
+          echo "PR_NUMBER=$(cat pr_number)" >> "$GITHUB_ENV"
+
+      - name: PR Comment
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          pr_number: ${{ env.PR_NUMBER }}
+          comment_tag: build_status_report
+          filePath: artifacts_merged.md

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -68,7 +68,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: cyclus/cycamore
-          ref: ci-updates
           path: ${{ github.workspace }}/cycamore
     
       - name: Build, Test, and Push Cycamore
@@ -90,7 +89,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: cyclus/cymetric
-          ref: ci-updates
           path: ${{ github.workspace }}/cymetric
 
       - name: Build, Test, and Push Cymetric

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -90,6 +90,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: cyclus/cymetric
+          ref: ci-updates
           path: ${{ github.workspace }}/cymetric
 
       - name: Build, Test, and Push Cymetric

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -43,7 +43,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout Cyclus
@@ -53,10 +53,10 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build, Test, and Push Cyclus
+        id: build-cyclus
         uses: docker/build-push-action@v5
         with:
           cache-from: type=registry,ref=ghcr.io/cyclus/cyclus_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cyclus:ci-layer-cache
-          cache-to: type=registry,ref=ghcr.io/cyclus/cyclus_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cyclus:ci-layer-cache,mode=max
           file: docker/Dockerfile
           push: true
           tags: ghcr.io/cyclus/cyclus_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cyclus:${{ env.tag }}
@@ -68,6 +68,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: cyclus/cycamore
+          ref: ci-updates
           path: ${{ github.workspace }}/cycamore
     
       - name: Build, Test, and Push Cycamore
@@ -78,7 +79,6 @@ jobs:
           context: ${{ github.workspace }}/cycamore
           file: ${{ github.workspace }}/cycamore/docker/Dockerfile
           cache-from: type=registry,ref=ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache
-          cache-to: type=registry,ref=ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:ci-layer-cache,mode=max
           tags: ghcr.io/cyclus/cycamore_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cycamore:${{ env.tag }}
           push: true
           build-args: |
@@ -99,7 +99,6 @@ jobs:
           context: ${{ github.workspace }}/cymetric
           file: ${{ github.workspace }}/cymetric/docker/Dockerfile
           cache-from: type=registry,ref=ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache
-          cache-to: type=registry,ref=ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:ci-layer-cache,mode=max
           tags: ghcr.io/cyclus/cymetric_${{ matrix.ubuntu_versions }}_${{ matrix.pkg_mgr }}/cymetric:${{ env.tag }}
           push: true
           build-args: |

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,7 @@ Since last release
   will fail unless update-alternatives has been used to point python at the 
   correct python3 version (#1558)
 * build and test are now fown on githubAction in place or CircleCI (#1569)
-* Have separate workflows for testing, publishing dependency images, and publishing release images (#1597, #1602, #1606, #1609, #1629, #1633, #1637)
+* Have separate workflows for testing, publishing dependency images, and publishing release images (#1597, #1602, #1606, #1609, #1629, #1633, #1637, #1668)
 * Add Ubuntu 20.04 to the list of supported platforms (#1605, #1608)
 * Add random number generator (Mersenne Twister 19937, from boost) and the ability to set the seed in the simulation control block (#1599)
 * Added code coverage reporting to GitHub workflows (#1616)


### PR DESCRIPTION
This fixes the CI permissions problems we're seeing (along with cymetric [#195](https://github.com/cyclus/cymetric/pull/195) and cycamore [#583](https://github.com/cyclus/cycamore/pull/583)).  Sorry that this hasn't gone as smoothly as possible, hopefully this is the last major refactor.

Changes are as follows:
- `build_test.yml` does not push any images to the cyclus GHCR.  Instead it uses a local docker registry on the GitHub runner.  This way we don't experience permissions errors with PRs from forks.  This adds a tiny bit of complexity that I wanted to avoid, but honestly I think the workflow might be more intuitive now than in previous iterations.  I tried implementing this without a local registry service but docker automatically tries to pull metadata so I was seeing lots of permission errors.
  - we still use build-contexts to "redefine" the cyclus image being used in downstream testing but now it references the image in our local registry
- `publish_latest.yml` is the only workflow that updates the layer cache.  This way all workflows essentially pull the layers that build the dependency image in `cyclus:latest`.  Most workflows pull from this cache
- `code_coverage.yml` has its own cache since its dependencies are slightly different, but I've included the `ignore-error` option so that cache-to won't stop a workflow from passing in a PR
- all workflows that publish images (`publish_latest.yml` and `publish_release.yml`) need to be updated from a branch on the upstream repository.  This is similar to our previous strategy
- in the cycamore and cymetric PRs I changed the cyclus_tag/cycamore_tag in the Dockerfile to `latest`.  This is to eliminate some verbosity in the workflow files and ensure users are using the latest versions when building from the Dockerfile

Once again I've reference branches in cycamore and cymetric corresponding to their respective PRs with these changes