### PR TITLE
Resolve compilation warnings in Cyclus build

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,7 @@ Since last release
 * Major update and modernization of build (#1587, #1632)
 * Changed Json formatting for compatibility with current python standards (#1587)
 * Changed README.rst installation instructions, tested on fresh Ubuntu-22.04 system with Python 3.11 (#1617, #1644)
+* Resolved various compilation warnings due to use of deprecated APIs (#1671)
 
 **Removed:**
 

--- a/cyclus/cpp_cyclus.pxd
+++ b/cyclus/cpp_cyclus.pxd
@@ -276,7 +276,6 @@ cdef extern from "pyhooks.h" namespace "cyclus":
 
    cdef void PyAppendInitTab() except +
    cdef void PyImportInit() except +
-   cdef void PyImportCallInit() except +
 
 
 cdef extern from "pyhooks.h" namespace "cyclus::toolkit":

--- a/cyclus/lib.pyx
+++ b/cyclus/lib.pyx
@@ -816,14 +816,6 @@ def py_import_init():
     """
     cpp_cyclus.PyImportInit()
 
-
-def py_import_call_init():
-    """Calls Cyclus-internal Python imports. This is called
-    automatically when cyclus is imported. Users should not need to call
-    this function.
-    """
-    cpp_cyclus.PyImportCallInit()
-
 #
 # XML
 #

--- a/src/cyc_std.h
+++ b/src/cyc_std.h
@@ -8,10 +8,11 @@
 namespace cyclus {
 
 /// @brief a less-than comparison for pairs
-template<class T> struct SecondLT : std::binary_function<T, T, bool> {
-  bool operator()(const T& x, const T& y) const {
-    return x.second < y.second;
-  }
+template <class T>
+struct SecondLT {
+    bool operator()(const T& x, const T& y) const {
+        return x.second < y.second;
+    }
 };
 
 // taken from

--- a/src/discovery.cc
+++ b/src/discovery.cc
@@ -91,7 +91,7 @@ std::set<std::string> DiscoverSpecsInDir(std::string d) {
   fs::recursive_directory_iterator last;
   for (; it != last; it.increment(errc)) {
     if (errc != no_err) {
-      if (it.level() > 0) {
+      if (it.depth() > 0) {
         it.pop();
       }
       continue;
@@ -100,8 +100,8 @@ std::set<std::string> DiscoverSpecsInDir(std::string d) {
     string pthstr = pth.string();
     bool irf = fs::is_regular_file(pth, errc);
     if (errc != no_err || !irf) {
-      it.no_push();
-      if (it.level() > 0) {
+      it.disable_recursion_pending();
+      if (it.depth() > 0) {
         it.pop();
       }
       continue;

--- a/src/greedy_solver.cc
+++ b/src/greedy_solver.cc
@@ -46,15 +46,17 @@ void GreedySolver::Condition() {
 void GreedySolver::Init() {
  std::for_each(graph_->request_groups().begin(),
                 graph_->request_groups().end(),
-                std::bind1st(
-                    std::mem_fun(&GreedySolver::GetCaps),
-                    this));
+                std::bind(
+                    &GreedySolver::GetCaps,
+                    this,
+                    std::placeholders::_1));
 
   std::for_each(graph_->supply_groups().begin(),
                 graph_->supply_groups().end(),
-                std::bind1st(
-                    std::mem_fun(&GreedySolver::GetCaps),
-                    this));
+                std::bind(
+                    &GreedySolver::GetCaps,
+                    this,
+                    std::placeholders::_1));
 }
 
 double GreedySolver::SolveGraph() {
@@ -68,9 +70,10 @@ double GreedySolver::SolveGraph() {
 
   std::for_each(graph_->request_groups().begin(),
                 graph_->request_groups().end(),
-                std::bind1st(
-                    std::mem_fun(&GreedySolver::GreedilySatisfySet),
-                    this));
+                std::bind(
+                    &GreedySolver::GreedilySatisfySet,
+                    this,
+                    std::placeholders::_1));
 
   obj_ += unmatched_ * pseudo_cost;
   return obj_;

--- a/src/pyhooks.cc
+++ b/src/pyhooks.cc
@@ -49,27 +49,6 @@ void PyImportInit(void) {
   }
 }
 
-void PyImportCallInit(void) {
-  PyObject* init_eventhooks = PyInit_eventhooks();
-  if (init_eventhooks == NULL) {
-    PyErr_Print();
-    fprintf(stderr, "Error calling PyInit_eventhooks()\n");
-  }
-
-  PyObject* init_pyinfile = PyInit_pyinfile();
-  if (init_pyinfile == NULL) {
-    PyErr_Print();
-    fprintf(stderr, "Error calling PyInit_pyinfile()\n");
-  }
-
-  PyObject* init_pymodule = PyInit_pymodule();
-  if (init_pymodule == NULL) {
-    PyErr_Print();
-    fprintf(stderr, "Error calling PyInit_pymodule()\n");
-  }
-}
-
-
 void PyStart(void) {
   if (!PY_INTERP_INIT) {
     PyAppendInitTab();
@@ -127,8 +106,6 @@ bool PY_INTERP_INIT = false;
 void PyAppendInitTab(void) {};
 
 void PyImportInit(void) {};
-
-void PyImportCallInit(void) {};
 
 void PyStart(void) {};
 

--- a/src/pyhooks.h
+++ b/src/pyhooks.h
@@ -22,9 +22,6 @@ void PyAppendInitTab(void);
 /// Convience function for import initialization
 void PyImportInit(void);
 
-/// Convience function for imports when Python has already been started
-void PyImportCallInit(void);
-
 /// Initialize Python functionality, this is a no-op if Python was not
 /// installed along with Cyclus. This may be called many times and safely
 /// initializes the Python interpreter only once.

--- a/src/resource_exchange.h
+++ b/src/resource_exchange.h
@@ -77,8 +77,9 @@ class ResourceExchange {
     std::for_each(
         traders_.begin(),
         traders_.end(),
-        std::bind1st(std::mem_fun(&cyclus::ResourceExchange<T>::AddRequests_),
-                     this));
+        std::bind(&cyclus::ResourceExchange<T>::AddRequests_,
+                     this,
+                     std::placeholders::_1));
   }
 
   /// @brief queries traders and collects all responses to requests for bids
@@ -87,8 +88,9 @@ class ResourceExchange {
     std::for_each(
         traders_.begin(),
         traders_.end(),
-        std::bind1st(std::mem_fun(&cyclus::ResourceExchange<T>::AddBids_),
-                     this));
+        std::bind(&cyclus::ResourceExchange<T>::AddBids_,
+                     this,
+                     std::placeholders::_1));
   }
 
   /// @brief adjust preferences for requests given bid responses
@@ -98,9 +100,10 @@ class ResourceExchange {
     std::for_each(
         traders.begin(),
         traders.end(),
-        std::bind1st(
-            std::mem_fun(&cyclus::ResourceExchange<T>::AdjustPrefs_),
-            this));
+        std::bind(
+            &cyclus::ResourceExchange<T>::AdjustPrefs_,
+            this,
+            std::placeholders::_1));
   }
 
   /// return true if this is an empty exchange (i.e., no requests exist,


### PR DESCRIPTION
Summary of the changes:

- `src/any.hpp` I found resolution from [newer boost version](https://www.boost.org/doc/libs/1_84_0/boost/spirit/home/support/detail/hold_any.hpp)
- `src/cyc_std.h std::binary_function` is deprecated.  We can just use `std::function` now - https://stackoverflow.com/questions/33114656/replacement-for-stdbinary-function
- `src/greedy_solver.cc` and `src/resource_exchange.h` - `std::bind1st` is deprecated. We can just use `std::bind` now https://stackoverflow.com/questions/52769059/replacement-for-removed-bind1st-in-c17
- `src/discovery.cc` a couple deprecated methods - I followed the suggestions that the warnings listed
- `src/pyhooks.[cc,h]`, `cyclus/cpp_cyclus.pxd`, `cyclus/lib.pyx` - removed a function from pyhooks that we no longer use (and was bad practice given the warnings)