### PR TITLE
Remove compare-ref param

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -64,7 +64,6 @@ jobs:
         with:
           file: ${{ github.workspace }}/total_coverage.info
           format: lcov
-          compare-ref: main
 
       - name: Upload Coverage HTML Artifact
         uses: actions/upload-pages-artifact@v2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,7 @@ Since last release
 * Have separate workflows for testing, publishing dependency images, and publishing release images (#1597, #1602, #1606, #1609, #1629, #1633, #1637, #1668, #1672)
 * Add Ubuntu 20.04 to the list of supported platforms (#1605, #1608)
 * Add random number generator (Mersenne Twister 19937, from boost) and the ability to set the seed in the simulation control block (#1599)
-* Added code coverage reporting to GitHub workflows (#1616)
+* Added code coverage reporting to GitHub workflows (#1616, #1679)
 * Adds active and dormant buying cycles in buy policy (#1596)
 * Add random number generator (Mersenne Twister 19937, from boost) and the ability to set the seed in the simulation control block (#1599, #1639)
 * Allow randomness in request frequency and size through buy policy (#1634)


### PR DESCRIPTION
I think this will solve the base branch problem we've see with code coverage and PRs.  It seemed to work on my [fork](https://github.com/bennibbelink/cyclus/pull/16).  For some reason coveralls is referencing an [old build](https://coveralls.io/builds/64235833) on `main` which you can see in the coveralls UI.  Removing the explicit reference in the coveralls GitHub action seems to alleviate this issue