### PR TITLE
Resolve Pytest warnings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -50,6 +50,7 @@ Since last release
 * Resolve deprecation warnings involving <boost/detail/sp_typeinfo.hpp> (#1611)
 * Resolve segmentation faults when calling Cbc (#1614)
 * Resolve segmentation faults when using cyclus via Python (#1666)
+* Resolve pytest warnings related to invalid escape sequences (#1684)
 
 
 

--- a/cli/cycpp.py
+++ b/cli/cycpp.py
@@ -73,8 +73,8 @@ elif sys.version_info[0] >= 3:
 sys_cpp = os.environ.get('CPP', 'cpp')
 
 # Non-capturing and must be used wit re.DOTALL, DO NOT COMPILE!
-RE_MULTILINE_COMMENT = "(?:\s*?/\*(?!\*/)*?\*/)"
-RE_SINGLE_LINE_COMMENT = "(?:\s*?//[^\n]*?\n\s*?)"
+RE_MULTILINE_COMMENT = r"(?:\s*?/\*(?!\*/)*?\*/)"
+RE_SINGLE_LINE_COMMENT = r"(?:\s*?//[^\n]*?\n\s*?)"
 RE_COMMENTS = "(?:" + RE_MULTILINE_COMMENT + "|" + RE_SINGLE_LINE_COMMENT + ")"
 
 # This might miss files which start with '#' - however, after canonization
@@ -277,7 +277,7 @@ class TypedefFilter(AliasFilter):
     """Filter for handling typedef as aliases. Note that in-line compound
     typedefs of structs and unions are not supported.
     """
-    regex = re.compile("\s*typedef\s+(.*?\s+.*)\s*$")
+    regex = re.compile(r"\s*typedef\s+(.*?\s+.*)\s*$")
 
     def transform(self, statement, sep):
         state = self.machine
@@ -290,7 +290,7 @@ class TypedefFilter(AliasFilter):
 
 class UsingFilter(AliasFilter):
     """Filter for accumumating using aliases."""
-    regex = re.compile("\s*using\s+(?!namespace\s+)([\w:]+)\s*")
+    regex = re.compile(r"\s*using\s+(?!namespace\s+)([\w:]+)\s*")
 
     def transform(self, statement, sep):
         state = self.machine
@@ -301,7 +301,7 @@ class UsingFilter(AliasFilter):
 class NamespaceFilter(Filter):
     """Filter for accumumating namespace encapsulations."""
     # handles anonymous namespaces as group(1) is None
-    regex = re.compile("\s*namespace(\s+\w*)?\s*[^=]*", re.DOTALL)
+    regex = re.compile(r"\s*namespace(\s+\w*)?\s*[^=]*", re.DOTALL)
 
     def transform(self, statement, sep):
         state = self.machine
@@ -320,7 +320,7 @@ class NamespaceFilter(Filter):
 
 class UsingNamespaceFilter(Filter):
     """Filter for accumumating using namespace statement."""
-    regex = re.compile("\s*using\s+namespace\s+([\w:]*)\s*")
+    regex = re.compile(r"\s*using\s+namespace\s+([\w:]*)\s*")
 
     def transform(self, statement, sep):
         state = self.machine
@@ -339,7 +339,7 @@ class UsingNamespaceFilter(Filter):
 
 class NamespaceAliasFilter(AliasFilter):
     """Filter for accumumating namespace renames."""
-    regex = re.compile("\s*namespace\s+(\w+)\s*=\s*([\w:]+)\s*")
+    regex = re.compile(r"\s*namespace\s+(\w+)\s*=\s*([\w:]+)\s*")
 
     def transform(self, statement, sep):
         state = self.machine
@@ -349,8 +349,8 @@ class NamespaceAliasFilter(AliasFilter):
 
 class ClassFilter(Filter):
     """Filter for picking out class names."""
-    regex = re.compile("(?:\s*template\s*<[\s\w,]*>)?"
-                       "\s*(?:class|struct)\s+(\w+)(\s*:[\n\s\w,:]+)?\s*", re.DOTALL)
+    regex = re.compile(r"(?:\s*template\s*<[\s\w,]*>)?"
+                       r"\s*(?:class|struct)\s+(\w+)(\s*:[\n\s\w,:]+)?\s*", re.DOTALL)
 
     def transform(self, statement, sep):
         state = self.machine
@@ -388,7 +388,7 @@ class ClassAndSuperclassFilter(ClassFilter):
 
 class AccessFilter(Filter):
     """Filter for setting the current access control flag."""
-    regex = re.compile('\s*(public|private|protected)\s*', re.DOTALL)
+    regex = re.compile(r'\s*(public|private|protected)\s*', re.DOTALL)
 
     def transform(self, statement, sep):
         access = self.match.group(1)
@@ -396,7 +396,7 @@ class AccessFilter(Filter):
 
 class PragmaCyclusErrorFilter(Filter):
     """Filter for handling invalid #pragma cyclus. This should be the last filter."""
-    regex = re.compile('\s*#\s*pragma\s+cyclus(.*)')
+    regex = re.compile(r'\s*#\s*pragma\s+cyclus(.*)')
 
     directives = frozenset(['var', 'note', 'exec', 'decl', 'def', 'impl'])
 
@@ -473,7 +473,7 @@ class VarDecorationFilter(DecorationFilter):
     This evals the contents of dict and puts them in state.var_annotations, to be
     consumed by the next match with VarDeclarationFilter.
     """
-    regex = re.compile("\s*#\s*pragma\s+cyclus\s+var\s+(.*)")
+    regex = re.compile(r"\s*#\s*pragma\s+cyclus\s+var\s+(.*)")
 
     def transform(self, statement, sep):
         state = self.machine
@@ -486,7 +486,7 @@ class VarDeclarationFilter(Filter):
     """State varible declaration.  Only operates if state.var_annotations is
     not None. Access for member variable must be public.
     """
-    regex = re.compile("(.*\w+.*?)\s+(\w+)")
+    regex = re.compile(r"(.*\w+.*?)\s+(\w+)")
 
     def transform_pass2(self, statement, sep):
         state = self.machine
@@ -615,7 +615,7 @@ class ExecFilter(Filter):
     Any Python statement(s) are valid as part of the code block. Be a little
     careful when using this pragma :).
     """
-    regex = re.compile("#\s*pragma\s+cyclus\s+exec\s+(.*)")
+    regex = re.compile(r"#\s*pragma\s+cyclus\s+exec\s+(.*)")
 
     def transform(self, statement, sep):
         execns = self.machine.execns
@@ -632,7 +632,7 @@ class NoteDecorationFilter(DecorationFilter):
     This evals the contents of dict and merges them in as the class-level
     annotations dict.
     """
-    regex = re.compile("\s*#\s*pragma\s+cyclus\s+note\s+(.*)")
+    regex = re.compile(r"\s*#\s*pragma\s+cyclus\s+note\s+(.*)")
 
     def transform(self, statement, sep):
         state = self.machine
@@ -920,9 +920,9 @@ def accumulate_state(canon):
 # pass 3
 #
 class CodeGeneratorFilter(Filter):
-    re_template = ("\s*#\s*pragma\s+cyclus\s*?"
-                   "(\s+def\s+|\s+decl\s+|\s+impl\s+|\s*?)?"
-                   "(?:\s*?{0}\s*?)(\s+?(?:[\w:\.]+)?)?")
+    re_template = (r"\s*#\s*pragma\s+cyclus\s*?"
+                   r"(\s+def\s+|\s+decl\s+|\s+impl\s+|\s*?)?"
+                   r"(?:\s*?{0}\s*?)(\s+?(?:[\w:\.]+)?)?")
 
     def_template = "\n{ind}{virt}{rtn} {ns}{methodname}({args}){sep}\n"
 
@@ -2010,7 +2010,7 @@ class DefaultPragmaFilter(Filter):
     """Filter for handling default pragma code generation:
         #pragma cyclus [def|decl|impl]
     """
-    regex = re.compile("\s*#\s*pragma\s+cyclus(\s+def|\s+decl|\s+impl)?\s*$",
+    regex = re.compile(r"\s*#\s*pragma\s+cyclus(\s+def|\s+decl|\s+impl)?\s*$",
                        re.DOTALL)
 
     def transform(self, statement, sep):

--- a/tests/cycpp_test.py
+++ b/tests/cycpp_test.py
@@ -1140,6 +1140,7 @@ def test_internal_infiletodb():
         if want != impl:
             pprint.pprint(impl)
             assert msg == False
+            
 def test_nuclide_uitype():
     m = MockCodeGenMachine()
     m.context = {"MyFactory": OrderedDict([('vars', OrderedDict([

--- a/tests/cycpp_test.py
+++ b/tests/cycpp_test.py
@@ -1049,7 +1049,7 @@ def test_internal_schema():
         msg = 'case {0} failed\n    ---- got ----\n    {1}\n    ---- want ----\n    {2}'.format(i + 1, impl.replace('\n', '\n    '), want.replace('\n', '\n    '))
         if want != impl:
             pprint.pprint(impl)
-            assert msg == False
+            assert False, msg
 
 def test_internal_infiletodb():
     # the expected output (i.e. 'want':...) is set as 'throw' if the

--- a/tests/cycpp_test.py
+++ b/tests/cycpp_test.py
@@ -1049,7 +1049,7 @@ def test_internal_schema():
         msg = 'case {0} failed\n    ---- got ----\n    {1}\n    ---- want ----\n    {2}'.format(i + 1, impl.replace('\n', '\n    '), want.replace('\n', '\n    '))
         if want != impl:
             pprint.pprint(impl)
-            assert(False, msg)
+            assert msg == False
 
 def test_internal_infiletodb():
     # the expected output (i.e. 'want':...) is set as 'throw' if the
@@ -1131,7 +1131,7 @@ def test_internal_infiletodb():
             except:
                 haderr = True
             msg = 'case {0} failed: expected raised exception, got none.'
-            assert(haderr, msg)
+            assert haderr == msg
             continue
         else:
             impl = f.impl()
@@ -1139,8 +1139,7 @@ def test_internal_infiletodb():
         msg = 'case {0} failed\n    ---- got ----\n    {1}\n    ---- want ----\n    {2}'.format(i + 1, impl.replace('\n', '\n    '), want.replace('\n', '\n    '))
         if want != impl:
             pprint.pprint(impl)
-            assert(False, msg)
-
+            assert msg == False
 def test_nuclide_uitype():
     m = MockCodeGenMachine()
     m.context = {"MyFactory": OrderedDict([('vars', OrderedDict([

--- a/tests/cycpp_test.py
+++ b/tests/cycpp_test.py
@@ -1131,7 +1131,7 @@ def test_internal_infiletodb():
             except:
                 haderr = True
             msg = 'case {0} failed: expected raised exception, got none.'
-            assert haderr == msg
+            assert haderr, msg
             continue
         else:
             impl = f.impl()
@@ -1139,8 +1139,8 @@ def test_internal_infiletodb():
         msg = 'case {0} failed\n    ---- got ----\n    {1}\n    ---- want ----\n    {2}'.format(i + 1, impl.replace('\n', '\n    '), want.replace('\n', '\n    '))
         if want != impl:
             pprint.pprint(impl)
-            assert msg == False
-            
+            assert False, msg
+
 def test_nuclide_uitype():
     m = MockCodeGenMachine()
     m.context = {"MyFactory": OrderedDict([('vars', OrderedDict([

--- a/tests/test_bear_deploy.py
+++ b/tests/test_bear_deploy.py
@@ -56,7 +56,7 @@ def test_bear_deploy():
     # test that the institution deploys a BearStore
     assert ("New fac: BearStore" in  s)
     # test that the first agents exist with right minimum production.
-    agents = re.compile('Agent \d+ 8\.0')
+    agents = re.compile(r'Agent \d+ 8\.0')
     all_agents = set(agents.findall(s))
     assert (len(all_agents) >=  9)
     if os.path.exists('bears.json'):


### PR DESCRIPTION
There are many instances in `cycpp.py` where a standard string is used instead of a raw string literal leading to incorrect escaping.  This led to a failing test mentioned in #1683.  This PR resolves the regex warnings along with a handful of other pytest warnings.  Pytest should run cleanly now with no warnings.