### PR TITLE
Allow ResBuf to be a bulk storage facility by forcing a squash of all incoming resources

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Since last release
 * AddMutalReqs and AddReciepe functions and exclusive bids in python API of DRE (#1584)
 * Created Package class and optional declaration of packages in input files (#1673, #1699), package id is a member of resources (materials/products) (#1675)
 * CI support for Rocky Linux (#1691)
+* Added support for a ResBuf to behave as a single bulk storage with mixing & extraction of resources (#1687)
 
 **Changed:**
 

--- a/src/material.h
+++ b/src/material.h
@@ -136,7 +136,9 @@ class Material: public Resource {
   /// not result in an updated material composition.  Does nothing if the
   /// simulation decay mode is set to "never" or none of the nuclides' decay
   /// constants are significant with respect to the time delta.
-  void Decay(int curr_time);
+  /// @param curr_time current time to use for the decay calculation 
+  ///        (default: -1 forces the decay to the context's current time)
+  virtual void Decay(int curr_time = -1);
 
   /// Returns the last time step on which a decay calculation was performed
   /// for the material.  This is not necessarily synonymous with the last time

--- a/src/material.h
+++ b/src/material.h
@@ -121,7 +121,7 @@ class Material: public Resource {
                   double threshold = eps_rsrc());
 
   /// Combines material mat with this one.  mat's quantity becomes zero.
-  void Absorb(Ptr mat);
+  virtual void Absorb(Ptr mat);
 
   /// Changes the material's composition to c without changing its mass.  Use
   /// this method for things like converting fresh to spent fuel via burning in

--- a/src/resource.h
+++ b/src/resource.h
@@ -80,9 +80,14 @@ class Resource {
   virtual Ptr ExtractRes(double quantity) = 0;
 
   /// To enable the Decay method to be called on any child resource, define
-  /// the a null op decay method here.
+  /// a null op Decay method here.
   /// @param curr_time the current time for the decay oepration
   virtual void Decay(int curr_time) { return; };
+
+  /// To enable the Absorb method to be called on any child resource, define
+  /// a null op Absorb method here.
+  /// @param res pointer to a resource to be absorbed by this resource
+  virtual void Absorb(Ptr res) { return; };
 
  protected:
   const static int default_package_id_ = 1;

--- a/src/resource.h
+++ b/src/resource.h
@@ -5,6 +5,8 @@
 #include <vector>
 #include <boost/shared_ptr.hpp>
 
+#include "error.h"
+
 class SimInitTest;
 
 namespace cyclus {
@@ -82,12 +84,12 @@ class Resource {
   /// To enable the Decay method to be called on any child resource, define
   /// a null op Decay method here.
   /// @param curr_time the current time for the decay oepration
-  virtual void Decay(int curr_time) { return; };
+  virtual void Decay(int curr_time) { throw Error("cannot decay resource type " + this->type()); };
 
   /// To enable the Absorb method to be called on any child resource, define
   /// a null op Absorb method here.
   /// @param res pointer to a resource to be absorbed by this resource
-  virtual void Absorb(Ptr res) { return; };
+  virtual void Absorb(Ptr res) { throw Error("cannot absorb resource type " + this->type()); };
 
  protected:
   const static int default_package_id_ = 1;

--- a/src/resource.h
+++ b/src/resource.h
@@ -79,6 +79,11 @@ class Resource {
   /// @return a new resource object with same state id and quantity == quantity
   virtual Ptr ExtractRes(double quantity) = 0;
 
+  /// To enable the Decay method to be called on any child resource, define
+  /// the a null op decay method here.
+  /// @param curr_time the current time for the decay oepration
+  virtual void Decay(int curr_time) { return; };
+
  protected:
   const static int default_package_id_ = 1;
  private:

--- a/src/toolkit/res_buf.h
+++ b/src/toolkit/res_buf.h
@@ -338,6 +338,7 @@ class ResBuf {
   /// Maximum quantity of resources this buffer can hold
   double cap_;
 
+  /// Whether materials should be stored as a single squashed item or as individual resource objects
   bool is_bulk_;
 
   /// List of constituent resource objects forming the buffer's inventory

--- a/src/toolkit/res_buf.h
+++ b/src/toolkit/res_buf.h
@@ -255,7 +255,7 @@ class ResBuf {
     } else if (rs_present_.count(m) == 1) {
       throw KeyError("duplicate resource push attempted");
     }
-    if (!is_bulk_) {
+    if (!is_bulk_  || rs_.size() == 0) {
       rs_.push_back(m);
       rs_present_.insert(m);
     } else {
@@ -304,7 +304,7 @@ class ResBuf {
     }
 
     for (int i = 0; i < rss.size(); i++) {
-      if (!is_bulk_) {
+      if (!is_bulk_ || rs_.size() == 0) {
         rs_.push_back(rss[i]);
         rs_present_.insert(rss[i]);
       } else {

--- a/tests/toolkit/res_buf_tests.cc
+++ b/tests/toolkit/res_buf_tests.cc
@@ -12,20 +12,20 @@ namespace toolkit {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // - - - - - - Getters, Setters, and Property changers - - - - - - - - - - - -
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(ResBufTest, set_capacity_ExceptionsEmpty) {
+TEST_F(ProductBufTest, set_capacity_ExceptionsEmpty) {
   EXPECT_THROW(store_.capacity(neg_cap), ValueError);
   EXPECT_NO_THROW(store_.capacity(zero_cap));
   EXPECT_NO_THROW(store_.capacity(cap));
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(ResBufTest, set_capacity_ExceptionsFilled) {
+TEST_F(ProductBufTest, set_capacity_ExceptionsFilled) {
   EXPECT_THROW(filled_store_.capacity(low_cap), ValueError);
   EXPECT_NO_THROW(filled_store_.capacity(cap));
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(ResBufTest, GetCapacity_ExceptionsEmpty) {
+TEST_F(ProductBufTest, GetCapacity_ExceptionsEmpty) {
   ASSERT_NO_THROW(store_.capacity());
   store_.capacity(zero_cap);
   ASSERT_NO_THROW(store_.capacity());
@@ -34,12 +34,12 @@ TEST_F(ResBufTest, GetCapacity_ExceptionsEmpty) {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(ResBufTest, GetCapacity_InitialEmpty) {
+TEST_F(ProductBufTest, GetCapacity_InitialEmpty) {
   EXPECT_DOUBLE_EQ(store_.capacity(), INFINITY);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(ResBufTest, Getset_capacityEmpty) {
+TEST_F(ProductBufTest, Getset_capacityEmpty) {
   store_.capacity(zero_cap);
   EXPECT_DOUBLE_EQ(store_.capacity(), zero_cap);
 
@@ -48,7 +48,7 @@ TEST_F(ResBufTest, Getset_capacityEmpty) {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(ResBufTest, GetSpace_Empty) {
+TEST_F(ProductBufTest, GetSpace_Empty) {
   ASSERT_NO_THROW(store_.space());
   EXPECT_DOUBLE_EQ(store_.space(), INFINITY);
 
@@ -62,33 +62,33 @@ TEST_F(ResBufTest, GetSpace_Empty) {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(ResBufTest, GetSpace_Filled) {
+TEST_F(ProductBufTest, GetSpace_Filled) {
   double space = cap - (mat1_->quantity() + mat2_->quantity());
   ASSERT_NO_THROW(filled_store_.space());
   EXPECT_DOUBLE_EQ(filled_store_.space(), space);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(ResBufTest, GetQuantity_Empty) {
+TEST_F(ProductBufTest, GetQuantity_Empty) {
   ASSERT_NO_THROW(store_.quantity());
   EXPECT_DOUBLE_EQ(store_.quantity(), 0.0);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(ResBufTest, GetQuantity_Filled) {
+TEST_F(ProductBufTest, GetQuantity_Filled) {
   ASSERT_NO_THROW(filled_store_.quantity());
   double quantity = mat1_->quantity() + mat2_->quantity();
   EXPECT_DOUBLE_EQ(filled_store_.quantity(), quantity);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(ResBufTest, GetCount_Empty) {
+TEST_F(ProductBufTest, GetCount_Empty) {
   ASSERT_NO_THROW(store_.count());
   EXPECT_EQ(store_.count(), 0);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(ResBufTest, GetCount_Filled) {
+TEST_F(ProductBufTest, GetCount_Filled) {
   ASSERT_NO_THROW(filled_store_.count());
   EXPECT_DOUBLE_EQ(filled_store_.count(), 2);
 }
@@ -96,21 +96,21 @@ TEST_F(ResBufTest, GetCount_Filled) {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // - - - - - Removing from buffer  - - - - - - - - - - - - - - - - - - - - - -
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(ResBufTest, RemoveQty_ExceptionsEmpty) {
+TEST_F(ProductBufTest, RemoveQty_ExceptionsEmpty) {
   Product::Ptr p;
   double qty = cap + overeps;
   ASSERT_THROW(p = filled_store_.Pop(qty), ValueError);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(ResBufTest, RemoveQty_ExceptionsFilled) {
+TEST_F(ProductBufTest, RemoveQty_ExceptionsFilled) {
   Product::Ptr p;
   double qty = cap + overeps;
   ASSERT_THROW(p = store_.Pop(qty), ValueError);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(ResBufTest, RemoveQty_SingleNoSplit) {
+TEST_F(ProductBufTest, RemoveQty_SingleNoSplit) {
   // pop one no splitting leaving one mat in the store
   Product::Ptr p;
 
@@ -121,7 +121,7 @@ TEST_F(ResBufTest, RemoveQty_SingleNoSplit) {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(ResBufTest, RemoveQty_SingleWithSplit) {
+TEST_F(ProductBufTest, RemoveQty_SingleWithSplit) {
   // pop one no splitting leaving one mat in the store
 
   Product::Ptr p;
@@ -134,7 +134,7 @@ TEST_F(ResBufTest, RemoveQty_SingleWithSplit) {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(ResBufTest, RemoveQty_DoubleWithSplit) {
+TEST_F(ProductBufTest, RemoveQty_DoubleWithSplit) {
   // pop one no splitting leaving one mat in the store
 
   Product::Ptr p;
@@ -147,14 +147,14 @@ TEST_F(ResBufTest, RemoveQty_DoubleWithSplit) {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(ResBufTest, RemoveNum_ExceptionsFilled) {
+TEST_F(ProductBufTest, RemoveNum_ExceptionsFilled) {
   ProdVec manifest;
   ASSERT_THROW(manifest = filled_store_.PopN(3), ValueError);
   ASSERT_THROW(manifest = filled_store_.PopN(-1), ValueError);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(ResBufTest, RemoveNum_ZeroFilled) {
+TEST_F(ProductBufTest, RemoveNum_ZeroFilled) {
   ProdVec manifest;
   double tot_qty = filled_store_.quantity();
 
@@ -165,7 +165,7 @@ TEST_F(ResBufTest, RemoveNum_ZeroFilled) {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(ResBufTest, RemoveNum_OneFilled) {
+TEST_F(ProductBufTest, RemoveNum_OneFilled) {
   ProdVec manifest;
 
   ASSERT_NO_THROW(manifest = filled_store_.PopN(1));
@@ -177,7 +177,7 @@ TEST_F(ResBufTest, RemoveNum_OneFilled) {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(ResBufTest, RemoveNum_TwoFilled) {
+TEST_F(ProductBufTest, RemoveNum_TwoFilled) {
   ProdVec manifest;
 
   ASSERT_NO_THROW(manifest = filled_store_.PopN(2));
@@ -191,7 +191,7 @@ TEST_F(ResBufTest, RemoveNum_TwoFilled) {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(ResBufTest, RemoveOne_Filled) {
+TEST_F(ProductBufTest, RemoveOne_Filled) {
   Product::Ptr mat;
 
   ASSERT_NO_THROW(mat = filled_store_.Pop());
@@ -210,7 +210,7 @@ TEST_F(ResBufTest, RemoveOne_Filled) {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(ResBufTest, PopBack) {
+TEST_F(ProductBufTest, PopBack) {
   Product::Ptr mat;
 
   ASSERT_NO_THROW(mat = filled_store_.PopBack());
@@ -231,7 +231,7 @@ TEST_F(ResBufTest, PopBack) {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // - - - - - Pushing into buffer - - - - - - - - - - - - - - - - - - - - - - -
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(ResBufTest, Push_Empty) {
+TEST_F(ProductBufTest, Push_Empty) {
   ASSERT_NO_THROW(store_.capacity(cap));
 
   ASSERT_NO_THROW(store_.Push(mat1_));
@@ -244,7 +244,7 @@ TEST_F(ResBufTest, Push_Empty) {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(ResBufTest, Push_OverCapacityEmpty) {
+TEST_F(ProductBufTest, Push_OverCapacityEmpty) {
   ASSERT_NO_THROW(store_.capacity(cap));
 
   ASSERT_NO_THROW(store_.Push(mat1_));
@@ -266,7 +266,7 @@ TEST_F(ResBufTest, Push_OverCapacityEmpty) {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(ResBufTest, Push_DuplicateEmpty) {
+TEST_F(ProductBufTest, Push_DuplicateEmpty) {
   ASSERT_NO_THROW(store_.capacity(cap));
 
   ASSERT_NO_THROW(store_.Push(mat1_));
@@ -277,7 +277,7 @@ TEST_F(ResBufTest, Push_DuplicateEmpty) {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(ResBufTest, PushAll_Empty) {
+TEST_F(ProductBufTest, PushAll_Empty) {
   ASSERT_NO_THROW(store_.capacity(cap));
   ASSERT_NO_THROW(store_.Push(mats));
   ASSERT_EQ(store_.count(), 2);
@@ -285,7 +285,7 @@ TEST_F(ResBufTest, PushAll_Empty) {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(ResBufTest, PushAll_ResCast) {
+TEST_F(ProductBufTest, PushAll_ResCast) {
   ResVec rs;
   for (int i = 0; i < mats.size(); ++i) {
     rs.push_back(mats[i]);
@@ -297,7 +297,7 @@ TEST_F(ResBufTest, PushAll_ResCast) {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(ResBufTest, PushAll_NoneEmpty) {
+TEST_F(ProductBufTest, PushAll_NoneEmpty) {
   ProdVec manifest;
   ASSERT_NO_THROW(store_.capacity(cap));
   ASSERT_NO_THROW(store_.Push(manifest));
@@ -306,7 +306,7 @@ TEST_F(ResBufTest, PushAll_NoneEmpty) {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(ResBufTest, PushAll_RetrieveOrderEmpty) {
+TEST_F(ProductBufTest, PushAll_RetrieveOrderEmpty) {
   Product::Ptr mat;
 
   ASSERT_NO_THROW(store_.capacity(cap));
@@ -318,7 +318,7 @@ TEST_F(ResBufTest, PushAll_RetrieveOrderEmpty) {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(ResBufTest, PushAll_OverCapacityEmpty) {
+TEST_F(ProductBufTest, PushAll_OverCapacityEmpty) {
   ASSERT_NO_THROW(store_.capacity(cap));
   ASSERT_NO_THROW(store_.Push(mats));
 
@@ -343,7 +343,7 @@ TEST_F(ResBufTest, PushAll_OverCapacityEmpty) {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-TEST_F(ResBufTest, PushAll_DuplicateEmpty) {
+TEST_F(ProductBufTest, PushAll_DuplicateEmpty) {
   ASSERT_NO_THROW(store_.capacity(2 * cap));
 
   ASSERT_NO_THROW(store_.Push(mats));
@@ -353,6 +353,21 @@ TEST_F(ResBufTest, PushAll_DuplicateEmpty) {
 
   ASSERT_EQ(store_.count(), 2);
   EXPECT_DOUBLE_EQ(store_.quantity(), mat1_->quantity() + mat2_->quantity());
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// Special tests for material buffers
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+TEST_F(MaterialBufTest, NonBulkTest) {
+
+  ASSERT_EQ(mat_store_.count(), 2);
+  ASSERT_EQ(mat_store_.capacity(), cap_);
+  double qty_exp = 2 * mat1_->quantity();
+  double space_exp = cap_ - qty_exp;
+  ASSERT_EQ(mat_store_.space(), space_exp);
+  ASSERT_EQ(mat_store_.quantity(), qty_exp);
+
 }
 
 }  // namespace toolkit

--- a/tests/toolkit/res_buf_tests.cc
+++ b/tests/toolkit/res_buf_tests.cc
@@ -1,4 +1,5 @@
 #include "res_buf_tests.h"
+#include "toolkit/mat_query.h"
 
 #include <gtest/gtest.h>
 
@@ -368,7 +369,33 @@ TEST_F(MaterialBufTest, NonBulkTest) {
   ASSERT_EQ(mat_store_.space(), space_exp);
   ASSERT_EQ(mat_store_.quantity(), qty_exp);
 
+  Material::Ptr pop1_ = mat_store_.Pop();
+  ASSERT_EQ(pop1_->comp(), test_comp1_);
+  Material::Ptr pop2_ = mat_store_.Pop();
+  ASSERT_EQ(pop2_->comp(), test_comp2_);
+
 }
+
+TEST_F(MaterialBufTest, BulkTest) {
+
+  ASSERT_EQ(bulk_store_.count(), 1);
+  ASSERT_EQ(bulk_store_.capacity(), cap_);
+  double qty_exp = 2 * mat1_->quantity();
+  double space_exp = cap_ - qty_exp;
+  ASSERT_EQ(bulk_store_.space(), space_exp);
+  ASSERT_EQ(bulk_store_.quantity(), qty_exp);
+
+  Material::Ptr pop1_ = mat_store_.Pop();
+  cyclus::toolkit::MatQuery mq1(pop1_);
+  double sr89_qty = mq1.mass(sr89_);
+  double fe59_qty = mq1.mass(fe59_);
+
+  ASSERT_EQ(sr89_qty, 5.0 * units::g);  
+  ASSERT_EQ(fe59_qty, 5.0 * units::g);  
+
+
+}
+
 
 }  // namespace toolkit
 }  // namespace cyclus

--- a/tests/toolkit/res_buf_tests.h
+++ b/tests/toolkit/res_buf_tests.h
@@ -73,7 +73,7 @@ class MaterialBufTest : public ::testing::Test {
 
   Nuc sr89_, fe59_;
   Material::Ptr mat1_, mat2_, mat3_;
-  Composition::Ptr test_comp1_, test_comp2_;
+  Composition::Ptr test_comp1_, test_comp2_, test_comp3_;
 
   double cap_;
 
@@ -89,6 +89,9 @@ class MaterialBufTest : public ::testing::Test {
 
       w[fe59_] = 2;
       test_comp2_ = Composition::CreateFromMass(w);
+
+      w[sr89_] = 1;
+      test_comp3_ = Composition::CreateFromMass(w);
 
       mat1_ = Material::CreateUntracked(5 * units::g, test_comp1_);
       mat2_ = Material::CreateUntracked(5 * units::g, test_comp2_);

--- a/tests/toolkit/res_buf_tests.h
+++ b/tests/toolkit/res_buf_tests.h
@@ -72,7 +72,7 @@ class MaterialBufTest : public ::testing::Test {
   ResBuf<Material> bulk_store_ = ResBuf<Material>(true);
 
   Nuc sr89_, fe59_;
-  Material::Ptr mat1_, mat2_, mat3_;
+  Material::Ptr mat1a_, mat1b_, mat2a_, mat2b_, mat3_;
   Composition::Ptr test_comp1_, test_comp2_, test_comp3_;
 
   double cap_;
@@ -93,20 +93,18 @@ class MaterialBufTest : public ::testing::Test {
       w[sr89_] = 1;
       test_comp3_ = Composition::CreateFromMass(w);
 
-      mat1_ = Material::CreateUntracked(5 * units::g, test_comp1_);
-      mat2_ = Material::CreateUntracked(5 * units::g, test_comp2_);
-      mat3_ = Material::CreateUntracked(5 * units::g, test_comp1_);
+      double mat_size = 5 * units::g;
 
-      cap_ = 10 * mat1_->quantity();
+      mat1a_ = Material::CreateUntracked(mat_size, test_comp1_);
+      mat1b_ = Material::CreateUntracked(mat_size, test_comp1_);
+      mat2a_ = Material::CreateUntracked(mat_size, test_comp2_);
+      mat2b_ = Material::CreateUntracked(mat_size, test_comp2_);
+      mat3_ = Material::CreateUntracked(mat_size, test_comp3_);
+
+      cap_ = 10 * mat_size;
 
       mat_store_.capacity(cap_);
       bulk_store_.capacity(cap_);
-
-      mat_store_.Push(mat1_);
-      mat_store_.Push(mat2_);
-
-      bulk_store_.Push(mat3_);
-      bulk_store_.Push(mat2_);
 
     } catch (std::exception err) {
       FAIL() << "An exception was thrown in the fixture SetUp.";

--- a/tests/toolkit/res_buf_tests.h
+++ b/tests/toolkit/res_buf_tests.h
@@ -7,13 +7,15 @@
 #include "error.h"
 #include "logger.h"
 #include "product.h"
+#include "composition.h"
+#include "material.h"
 #include "toolkit/res_buf.h"
 
 namespace cyclus {
 namespace toolkit {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-class ResBufTest : public ::testing::Test {
+class ProductBufTest : public ::testing::Test {
  protected:
   Product::Ptr mat1_, mat2_;
   double mass1, mass2;
@@ -62,6 +64,53 @@ class ResBufTest : public ::testing::Test {
     }
   }
 };
+
+class MaterialBufTest : public ::testing::Test {
+ protected:
+
+  ResBuf<Material> mat_store_;  // default constructed mat store
+  ResBuf<Material> bulk_store_ = ResBuf<Material>(true);
+
+  Nuc sr89_, fe59_;
+  Material::Ptr mat1_, mat2_, mat3_;
+  Composition::Ptr test_comp1_, test_comp2_;
+
+  double cap_;
+
+  virtual void SetUp() {
+    try {
+
+      sr89_ = 380890000;
+      fe59_ = 260590000;
+
+      CompMap v, w;
+      v[sr89_] = 1;
+      test_comp1_ = Composition::CreateFromMass(v);
+
+      w[fe59_] = 2;
+      test_comp2_ = Composition::CreateFromMass(w);
+
+      mat1_ = Material::CreateUntracked(5 * units::g, test_comp1_);
+      mat2_ = Material::CreateUntracked(5 * units::g, test_comp2_);
+      mat3_ = Material::CreateUntracked(5 * units::g, test_comp1_);
+
+      cap_ = 10 * mat1_->quantity();
+
+      mat_store_.capacity(cap_);
+      bulk_store_.capacity(cap_);
+
+      mat_store_.Push(mat1_);
+      mat_store_.Push(mat2_);
+
+      bulk_store_.Push(mat3_);
+      bulk_store_.Push(mat2_);
+
+    } catch (std::exception err) {
+      FAIL() << "An exception was thrown in the fixture SetUp.";
+    }
+  }
+};
+
 
 }  // namespace toolkit
 }  // namespace cyclus


### PR DESCRIPTION
Add a state variable to `ResBuf` to declare it as bulk storage with default `false`.  All items that are `Push`ed are automatically `Absorb`ed into the first item in the `ResBuf`.

Also add `Decay` method that will force every item in a `ResBuf` to decay.