### PR TITLE
More robust method for getting cyclus installation directory

### DIFF
--- a/src/env.cc.in
+++ b/src/env.cc.in
@@ -36,7 +36,7 @@ const std::string Env::GetInstallPath() {
     return instdir_;
   std::array<char, PATH_MAX> buffer;
   std::string instdir;
-  std::unique_ptr<FILE, decltype(&pclose)> pipe(popen("cyclus --install-path", "r"), pclose);
+  std::unique_ptr<FILE, decltype(&pclose)> pipe(popen("which cyclus", "r"), pclose);
   if (!pipe) {
       throw std::runtime_error("popen() failed!");
   }
@@ -45,6 +45,8 @@ const std::string Env::GetInstallPath() {
   }
   if (instdir.length() <= 0)
     instdir = "@cyclus_install_dir@";
+  else  // This should be the '/path/to/bin/cyclus/../..' (ie '/path/to')
+    instdir = fs::path(instdir).parent_path().parent_path().string();
   if (!fs::exists(instdir))
     instdir = "@cyclus_install_dir@";
   if (std::strlen(instdir.c_str()) < instdir.length()) {

--- a/src/env.cc.in
+++ b/src/env.cc.in
@@ -32,18 +32,20 @@ std::string Env::PathBase(std::string path) {
 }
 
 const std::string Env::GetInstallPath() {
-  // On some (most?) posix shells - notably BASH and ksh - the environment
-  // variable '_' is set to the absolute path of the currently executing
-  // program.  This allows us to have a somewhat platform independent way
-  // of figuring out the install directory. If this fails for any reason,
-  // we go back to the install directory specified at compile time.
+  std::array<char, PATH_MAX> buffer;
+  std::string instdir;
+  std::unique_ptr<FILE, decltype(&pclose)> pipe(popen("cyclus --install-path", "r"), pclose);
+  if (!pipe) {
+      throw std::runtime_error("popen() failed!");
+  }
+  while (fgets(buffer.data(), static_cast<int>(buffer.size()), pipe.get()) != nullptr) {
+      instdir += buffer.data();
+  }
   if (instdir_.length() > 0)
     return instdir_;
   std::string instdir = GetEnv("_");
-  if (instdir.length() > 0)
+  if (instdir.length() <= 0)
     instdir = "@cyclus_install_dir@";
-  else  // This should be the '/path/to/bin/cyclus/../..' (ie '/path/to')
-    instdir = fs::path(instdir).parent_path().parent_path().string();
   if (!fs::exists(instdir))
     instdir = "@cyclus_install_dir@";
   if (std::strlen(instdir.c_str()) < instdir.length()) {

--- a/src/env.cc.in
+++ b/src/env.cc.in
@@ -32,6 +32,8 @@ std::string Env::PathBase(std::string path) {
 }
 
 const std::string Env::GetInstallPath() {
+  if (instdir_.length() > 0)
+    return instdir_;
   std::array<char, PATH_MAX> buffer;
   std::string instdir;
   std::unique_ptr<FILE, decltype(&pclose)> pipe(popen("cyclus --install-path", "r"), pclose);
@@ -41,9 +43,6 @@ const std::string Env::GetInstallPath() {
   while (fgets(buffer.data(), static_cast<int>(buffer.size()), pipe.get()) != nullptr) {
       instdir += buffer.data();
   }
-  if (instdir_.length() > 0)
-    return instdir_;
-  std::string instdir = GetEnv("_");
   if (instdir.length() <= 0)
     instdir = "@cyclus_install_dir@";
   if (!fs::exists(instdir))


### PR DESCRIPTION
Closes #1688.

Instead of relying on the environment variable `_` to get the path of the running application (which returns the python installation directory when cyclus is called via python) this calls `which cyclus` to find the location of the cyclus binary.  

This assumes that the machine has the `which` utility and that the cyclus installation directory is in the `PATH`.   Not 100% robust but I think these are assumptions we can safely make (or enforce on our users).