### PR TITLE
Resolve more regex invalid escape sequences

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,7 +51,7 @@ Since last release
 * Resolve deprecation warnings involving <boost/detail/sp_typeinfo.hpp> (#1611)
 * Resolve segmentation faults when calling Cbc (#1614)
 * Resolve segmentation faults when using cyclus via Python (#1666)
-* Resolve pytest warnings related to invalid escape sequences (#1684)
+* Resolve pytest and compilation warnings related to invalid escape sequences (#1684, #1698)
 * Fix how Env::GetInstallPath() finds the location of the cyclus installation (#1689)
 * Fix Debian package generation (#1676)
 

--- a/cli/post-process-cython.py
+++ b/cli/post-process-cython.py
@@ -2,10 +2,10 @@
 from __future__ import print_function, unicode_literals
 import re
 
-RE_LAST_WORD = re.compile('.*?(\w+)[^\w]*$')
-RE_SQUARE_BRACKETS = re.compile('(\[[^\[\]]+?\])')
-RE_ANGLE_BRACKETS = re.compile('(<[^<>]+?>)')
-RE_VERSION = re.compile('.*?(\d+)\.(\d+)(\.\d+)?')
+RE_LAST_WORD = re.compile(r'.*?(\w+)[^\w]*$')
+RE_SQUARE_BRACKETS = re.compile(r'(\[[^\[\]]+?\])')
+RE_ANGLE_BRACKETS = re.compile(r'(<[^<>]+?>)')
+RE_VERSION = re.compile(r'.*?(\d+)\.(\d+)(\.\d+)?')
 
 
 def parse_version(src):

--- a/share/dbtypes_gen.py
+++ b/share/dbtypes_gen.py
@@ -35,7 +35,7 @@ SUPPORTED_INDEX = 6
 CANON_INDEX = 7
 VL_INDEX = 8
 
-RE_ENUM_ENTRY = re.compile('\s*\w+\s*?(=\s*?\d+)?,\s*?//.*')
+RE_ENUM_ENTRY = re.compile(r'\s*\w+\s*?(=\s*?\d+)?,\s*?//.*')
 
 
 def main():


### PR DESCRIPTION
Closes #1695 .

Converts a handful of strings uses by `re` to raw string literals to avoid invalid escape sequences.