### PR TITLE
throw if invalid package id given

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,7 +27,7 @@ Since last release
 * Adds support for Cython3 (#1636)
 * Adds TotalInvTracker, which allows an inventory cap to be set for multiple resource buffers, and is now required for material buy policy (#1646)
 * AddMutalReqs and AddReciepe functions and exclusive bids in python API of DRE (#1584)
-* Created Package class and optional declaration of packages in input files (#1673), package id is a member of resources (materials/products) (#1675)
+* Created Package class and optional declaration of packages in input files (#1673, #1699), package id is a member of resources (materials/products) (#1675)
 * CI support for Rocky Linux (#1691)
 
 **Changed:**

--- a/src/context.cc
+++ b/src/context.cc
@@ -211,6 +211,9 @@ Package::Ptr Context::GetPackageByName(std::string name) {
 }
 
 Package::Ptr Context::GetPackageById(int id) {
+  if (id < 0) {
+    throw ValueError("Invalid package id " + std::to_string(id));
+  }
   // iterate through the list of packages to get the one package with the correct id
   std::map<std::string, Package::Ptr>::iterator it;
   for (it = packages_.begin(); it != packages_.end(); ++it) {
@@ -218,6 +221,7 @@ Package::Ptr Context::GetPackageById(int id) {
       return it->second;
     }
   }
+  throw ValueError("Invalid package id " + std::to_string(id));
 }
 
 void Context::InitSim(SimInfo si) {


### PR DESCRIPTION
Built errors into `GetPackageByName` but forgot to do so for `GetPackageById`. Throws for both `id` < 0 and unable to find matching `id`

Closes #1697 