### PR TITLE
Add timestamp/SHA to PR comment

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -143,10 +143,13 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
+      - name: Checkout cyclus
+        uses: actions/checkout@v4
+
       - name: Save PR number and Commit hash to file
         run: |
           echo "${{ github.event.number }}" > pr_number
-          echo "${{ github.event.pull_request.head.sha }}" > commit_hash
+          echo "$(git show -s --format=%cd --date=format:'%m/%d/%Y %H:%M' ${{ github.event.pull_request.head.sha }}) - ${{ github.event.pull_request.head.sha }}" > commit_hash_timestamp
       
       - name: Upload PR number artifact
         uses: actions/upload-artifact@v4
@@ -157,8 +160,8 @@ jobs:
       - name: Upload Commit hash artifact
         uses: actions/upload-artifact@v4
         with:
-          name: commit_hash
-          path: commit_hash
+          name: commit_hash_timestamp
+          path: commit_hash_timestamp
 
   build-test-rocky:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -143,13 +143,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - name: Checkout Cyclus
-        uses: actions/checkout@v4
-        
       - name: Save PR number and Commit hash to file
         run: |
           echo "${{ github.event.number }}" > pr_number
-          echo "$(git rev-parse --short "{$GITHUB_SHA}")" > commit_hash
+          echo "${{ github.event.pull_request.head.sha }}" > commit_hash
       
       - name: Upload PR number artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -143,6 +143,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
+      - name: Checkout Cyclus
+        uses: actions/checkout@v4
+        
       - name: Save PR number and Commit hash to file
         run: |
           echo "${{ github.event.number }}" > pr_number

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -143,15 +143,22 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - name: Save PR number to file
+      - name: Save PR number and Commit hash to file
         run: |
           echo "${{ github.event.number }}" > pr_number
+          echo "${{ github.sha }}" > commit_hash
       
-      - name: Upload artifact
+      - name: Upload PR number artifact
         uses: actions/upload-artifact@v4
         with:
           name: pr_number
           path: pr_number
+      
+      - name: Upload Commit hash artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: commit_hash
+          path: commit_hash
 
   build-test-rocky:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Save PR number and Commit hash to file
         run: |
           echo "${{ github.event.number }}" > pr_number
-          echo "$(git show -s --format=%cd --date=format:'%m/%d/%Y %H:%M' ${{ github.event.pull_request.head.sha }}) - ${{ github.event.pull_request.head.sha }}" > commit_hash_timestamp
+          echo "${{ github.event.pull_request.head.sha }} - $(git log -1 --format=%ci)" > commit_hash_timestamp
       
       - name: Upload PR number artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Save PR number and Commit hash to file
         run: |
           echo "${{ github.event.number }}" > pr_number
-          echo "${{ github.sha }}" > commit_hash
+          echo "$(git rev-parse --short HEAD)" > commit_hash
       
       - name: Upload PR number artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -143,13 +143,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - name: Checkout Cyclus
-        uses: actions/checkout@v4
-        
       - name: Save PR number and Commit hash to file
         run: |
           echo "${{ github.event.number }}" > pr_number
-          echo "$(git rev-parse --short HEAD)" > commit_hash
+          echo "$(git rev-parse --short "{$GITHUB_SHA}")" > commit_hash
       
       - name: Upload PR number artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Merge artifacts and get PR number
         run: |
           echo "### Downstream Build Status Report" > artifacts_merged.md
-          echo "# $(echo "$(date +'%m/%d/%Y %H:%M')") ($(cat commit_hash))" > artifacts_merged.md
+          echo "# $(echo "$(date +'%m/%d/%Y %H:%M')") ($(cat commit_hash))" >> artifacts_merged.md
           cat ./*.txt >> artifacts_merged.md
           echo "PR_NUMBER=$(cat pr_number)" >> "$GITHUB_ENV"
 

--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Merge artifacts and get PR number
         run: |
-          echo "### Downstream Build Status Report - $(echo "$(date +'%m/%d/%Y %H:%M')") - $(cat commit_hash)" > artifacts_merged.md
+          echo "### Downstream Build Status Report - $(cat commit_hash)" > artifacts_merged.md
           cat ./*.txt >> artifacts_merged.md
           echo "PR_NUMBER=$(cat pr_number)" >> "$GITHUB_ENV"
 

--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Merge artifacts and get PR number
         run: |
-          echo "### Downstream Build Status Report - $(cat commit_hash)" > artifacts_merged.md
+          echo "### Downstream Build Status Report - $(echo "$(date +'%m/%d/%Y %H:%M')") - $(cat commit_hash)" > artifacts_merged.md
           cat ./*.txt >> artifacts_merged.md
           echo "PR_NUMBER=$(cat pr_number)" >> "$GITHUB_ENV"
 

--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -20,8 +20,7 @@ jobs:
 
       - name: Merge artifacts and get PR number
         run: |
-          echo "### Downstream Build Status Report" > artifacts_merged.md
-          echo "# $(echo "$(date +'%m/%d/%Y %H:%M')") ($(cat commit_hash))" >> artifacts_merged.md
+          echo "### Downstream Build Status Report - $(echo "$(date +'%m/%d/%Y %H:%M')") - $(cat commit_hash)" > artifacts_merged.md
           cat ./*.txt >> artifacts_merged.md
           echo "PR_NUMBER=$(cat pr_number)" >> "$GITHUB_ENV"
 

--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Merge artifacts and get PR number
         run: |
-          echo "### Downstream Build Status Report - $(echo "$(date +'%m/%d/%Y %H:%M')") - $(cat commit_hash)" > artifacts_merged.md
+          echo "### Downstream Build Status Report - $(cat commit_hash_timestamp)" > artifacts_merged.md
           cat ./*.txt >> artifacts_merged.md
           echo "PR_NUMBER=$(cat pr_number)" >> "$GITHUB_ENV"
 

--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -20,7 +20,8 @@ jobs:
 
       - name: Merge artifacts and get PR number
         run: |
-          echo "### Downstream Build Status Report ($(cat commit_hash))" > artifacts_merged.md
+          echo "### Downstream Build Status Report" > artifacts_merged.md
+          echo "# $(echo "$(date +'%m/%d/%Y %H:%M')") ($(cat commit_hash))" > artifacts_merged.md
           cat ./*.txt >> artifacts_merged.md
           echo "PR_NUMBER=$(cat pr_number)" >> "$GITHUB_ENV"
 

--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Merge artifacts and get PR number
         run: |
-          echo "### Downstream Build Status Report" > artifacts_merged.md
+          echo "### Downstream Build Status Report ($(cat commit_hash))" > artifacts_merged.md
           cat ./*.txt >> artifacts_merged.md
           echo "PR_NUMBER=$(cat pr_number)" >> "$GITHUB_ENV"
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,7 @@ Since last release
   will fail unless update-alternatives has been used to point python at the 
   correct python3 version (#1558)
 * build and test are now fown on githubAction in place or CircleCI (#1569)
-* Have separate workflows for testing, publishing dependency images, and publishing release images (#1597, #1602, #1606, #1609, #1629, #1633, #1637, #1668, #1672, #1676)
+* Have separate workflows for testing, publishing dependency images, and publishing release images (#1597, #1602, #1606, #1609, #1629, #1633, #1637, #1668, #1672, #1676, #1708)
 * Add Ubuntu 20.04 to the list of supported platforms (#1605, #1608)
 * Add random number generator (Mersenne Twister 19937, from boost) and the ability to set the seed in the simulation control block (#1599, #1677)
 * Added code coverage reporting to GitHub workflows (#1616, #1679)


### PR DESCRIPTION
Closes issue #1707.  Adds a timestamp and commit hash to the PR comment generated on downstream testing