### PR TITLE
Small documentation fixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,8 @@ Since last release
 * Resolved various compilation warnings due to use of deprecated APIs (#1671)
 * Update version management in CMake build (#1696)
 * Changed dependency versions in README.rst, INSTALL.rst, and DEPENDENCIES.rst (#1703)
+* Updated minor documentation about updating CHNAGELOG.rst, fix formatting for rendering 
+  hyperlinks, and change branch name in README instructions on forking for development (#1715)
 
 **Removed:**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,7 +40,7 @@ Since last release
 * Resolved various compilation warnings due to use of deprecated APIs (#1671)
 * Update version management in CMake build (#1696)
 * Changed dependency versions in README.rst, INSTALL.rst, and DEPENDENCIES.rst (#1703)
-* Updated minor documentation about updating CHNAGELOG.rst, fix formatting for rendering 
+* Updated minor documentation about updating CHANGELOG.rst, fix formatting for rendering 
   hyperlinks, and change branch name in README instructions on forking for development (#1715)
 
 **Removed:**

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -30,7 +30,7 @@ Issuing a Pull Request
 ======================
 
 * Please make sure you describe the changes you made to the code in the 
-  `CHANGELOG.rst`_.
+  `CHANGELOG <CHANGELOG.rst>`_.
 
 * When you are ready to move changes from one of your topic branches into the
   "main" branch, it must be reviewed and accepted by another developer.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -30,8 +30,8 @@ Issuing a Pull Request
 ======================
 
 * Please make sure you describe the changes you made to the code in the 
-  `CHANGELOG`_ for |Cyclus|.
-   
+  `CHANGELOG.rst`_.
+
 * When you are ready to move changes from one of your topic branches into the
   "main" branch, it must be reviewed and accepted by another developer.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -29,6 +29,9 @@ General Notes
 Issuing a Pull Request
 ======================
 
+* Please make sure you describe the changes you made to the code in the 
+  `CHANGELOG`_ for |Cyclus|.
+   
 * When you are ready to move changes from one of your topic branches into the
   "main" branch, it must be reviewed and accepted by another developer.
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -12,7 +12,7 @@ provided with the source.
 Dependencies
 ************
 
-A full list of the Cyclus package dependencies is listed :doc:`here <DEPENDENCIES>`_:
+A full list of the Cyclus package dependencies is listed `here <DEPENDENCIES>`_:
 
 ************
 Installation
@@ -21,7 +21,7 @@ Installation
 
 Before going further with the installation procedure be sure you have installed
 all the required dependencies. We have provided detailed
-instructions for :doc:`installing dependencies <DEPENDENCIES.rst>_` for the major supported
+instructions for :doc:`installing dependencies <DEPENDENCIES.rst>` for the major supported
 systems.
 
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -12,7 +12,7 @@ provided with the source.
 Dependencies
 ************
 
-A full list of the Cyclus package dependencies is listed `DEPENDENCIES`_.
+A full list of the Cyclus package dependencies is listed `here <DEPENDENCIES.rst>`_.
 
 ************
 Installation
@@ -21,7 +21,7 @@ Installation
 
 Before going further with the installation procedure be sure you have installed
 all the required dependencies. We have provided detailed
-instructions for `installing dependencies <DEPENDENCIES.rst>_` for the major supported
+instructions for `DEPENDENCIES_` for the major supported
 systems.
 
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -12,7 +12,7 @@ provided with the source.
 Dependencies
 ************
 
-A full list of the Cyclus package dependencies is listed `here <DEPENDENCIES.rst>`_.
+A full list of the Cyclus package dependencies is listed `here`_.
 
 ************
 Installation
@@ -21,7 +21,7 @@ Installation
 
 Before going further with the installation procedure be sure you have installed
 all the required dependencies. We have provided detailed
-instructions for `DEPENDENCIES`_ for the major supported
+instructions `for installing those dependencies for the major supported systems`_ for the major supported
 systems.
 
 
@@ -196,4 +196,4 @@ proper functioning of Cyclus. You can run the tests yourself via:
 .. _`Cyclus repo`: https://github.com/cyclus/cyclus
 .. _`Cycamore Repo`: https://github.com/cyclus/cycamore
 .. _`for installing those dependencies for the major supported systems`: DEPENDENCIES.rst
-.. _`DEPENDENCIES`: DEPENDENCIES.rst
+.. _`here`: DEPENDENCIES.rst

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -21,7 +21,7 @@ Installation
 
 Before going further with the installation procedure be sure you have installed
 all the required dependencies. We have provided detailed
-instructions for `DEPENDENCIES_` for the major supported
+instructions for `DEPENDENCIES`_ for the major supported
 systems.
 
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -12,7 +12,7 @@ provided with the source.
 Dependencies
 ************
 
-A full list of the Cyclus package dependencies is listed `here <DEPENDENCIES>`_:
+A full list of the Cyclus package dependencies is listed `here <DEPENDENCIES.rst>`_:
 
 ************
 Installation

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -21,7 +21,7 @@ Installation
 
 Before going further with the installation procedure be sure you have installed
 all the required dependencies. We have provided detailed
-instructions for :doc:`installing dependencies <DEPENDENCIES>_` for the major supported
+instructions for :doc:`installing dependencies <DEPENDENCIES.rst>_` for the major supported
 systems.
 
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -12,7 +12,7 @@ provided with the source.
 Dependencies
 ************
 
-A full list of the Cyclus package dependencies is listed :doc:`here <DEPENDENCIES>`:
+A full list of the Cyclus package dependencies is listed :doc:`here <DEPENDENCIES>`_:
 
 ************
 Installation
@@ -21,7 +21,7 @@ Installation
 
 Before going further with the installation procedure be sure you have installed
 all the required dependencies. We have provided detailed
-instructions for :doc:`installing dependencies <DEPENDENCIES>` for the major supported
+instructions for :doc:`installing dependencies <DEPENDENCIES>_` for the major supported
 systems.
 
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -56,8 +56,8 @@ On MacOSX you also need to add ~/.local/lib/pythonX.Y/site-packages to your
 .. _`Cyclus User Guide`: http://fuelcycle.org/user/index.html
 .. _`Cyclus repo`: https://github.com/cyclus/cyclus
 .. _`Cycamore Repo`: https://github.com/cyclus/cycamore
-.. _`for installing those dependencies for the major supported systems`: https://github.com/cyclus/cyclus/blob/main/DEPENDENCIES.rst
-.. _`here`: https://github.com/cyclus/cyclus/blob/main/DEPENDENCIES.rst
+.. _`for installing those dependencies for the major supported systems`: https://fuelcycle.org/user/DEPENDENCIES.html
+.. _`here`: https://fuelcycle.org/user/DEPENDENCIES.html
 .. website_include_end
 
 .. website_custom_start

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -21,8 +21,7 @@ Installation
 
 Before going further with the installation procedure be sure you have installed
 all the required dependencies. We have provided detailed
-instructions `for installing those dependencies for the major supported systems`_ for the major supported
-systems.
+instructions `for installing those dependencies for the major supported systems`_.
 
 
 Default Installation
@@ -195,5 +194,5 @@ proper functioning of Cyclus. You can run the tests yourself via:
 .. _`Cyclus User Guide`: http://fuelcycle.org/user/index.html
 .. _`Cyclus repo`: https://github.com/cyclus/cyclus
 .. _`Cycamore Repo`: https://github.com/cyclus/cycamore
-.. _`for installing those dependencies for the major supported systems`: DEPENDENCIES.rst
-.. _`here`: DEPENDENCIES.rst
+.. _`for installing those dependencies for the major supported systems`: https://github.com/cyclus/cyclus/blob/main/DEPENDENCIES.rst
+.. _`here`: https://github.com/cyclus/cyclus/blob/main/DEPENDENCIES.rst

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -51,6 +51,13 @@ On MacOSX you also need to add ~/.local/lib/pythonX.Y/site-packages to your
   print(".".join(map(str, sys.version_info[:2])))'`/site-packages:\$PYTHONPATH\"" >> ~/.bashrc
   source ~/.bashrc
 
+
+.. _`Cyclus Homepage`: http://fuelcycle.org/
+.. _`Cyclus User Guide`: http://fuelcycle.org/user/index.html
+.. _`Cyclus repo`: https://github.com/cyclus/cyclus
+.. _`Cycamore Repo`: https://github.com/cyclus/cycamore
+.. _`for installing those dependencies for the major supported systems`: https://github.com/cyclus/cyclus/blob/main/DEPENDENCIES.rst
+.. _`here`: https://github.com/cyclus/cyclus/blob/main/DEPENDENCIES.rst
 .. website_include_end
 
 .. website_custom_start
@@ -190,9 +197,3 @@ proper functioning of Cyclus. You can run the tests yourself via:
     $ cyclus_unit_tests
 
 
-.. _`Cyclus Homepage`: http://fuelcycle.org/
-.. _`Cyclus User Guide`: http://fuelcycle.org/user/index.html
-.. _`Cyclus repo`: https://github.com/cyclus/cyclus
-.. _`Cycamore Repo`: https://github.com/cyclus/cycamore
-.. _`for installing those dependencies for the major supported systems`: https://github.com/cyclus/cyclus/blob/main/DEPENDENCIES.rst
-.. _`here`: https://github.com/cyclus/cyclus/blob/main/DEPENDENCIES.rst

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -196,3 +196,4 @@ proper functioning of Cyclus. You can run the tests yourself via:
 .. _`Cyclus repo`: https://github.com/cyclus/cyclus
 .. _`Cycamore Repo`: https://github.com/cyclus/cycamore
 .. _`for installing those dependencies for the major supported systems`: DEPENDENCIES.rst
+.. _`DEPENDENCIES`: DEPENDENCIES.rst

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -12,7 +12,7 @@ provided with the source.
 Dependencies
 ************
 
-A full list of the Cyclus package dependencies is listed `here <DEPENDENCIES.rst>`_:
+A full list of the Cyclus package dependencies is listed `here <DEPENDENCIES.rst>`_.
 
 ************
 Installation
@@ -21,7 +21,7 @@ Installation
 
 Before going further with the installation procedure be sure you have installed
 all the required dependencies. We have provided detailed
-instructions for :doc:`installing dependencies <DEPENDENCIES.rst>` for the major supported
+instructions for `installing dependencies <DEPENDENCIES.rst>_` for the major supported
 systems.
 
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -12,7 +12,7 @@ provided with the source.
 Dependencies
 ************
 
-A full list of the Cyclus package dependencies is listed `here <DEPENDENCIES.rst>`_.
+A full list of the Cyclus package dependencies is listed `DEPENDENCIES`_.
 
 ************
 Installation
@@ -174,7 +174,7 @@ dependencies through conda-forge.
 .. code-block:: bash
 
   conda config --add channels conda-forge
-  conda install cyclus-build-deps
+  conda install cyclus --only-deps
 
 
 *************

--- a/README.rst
+++ b/README.rst
@@ -165,11 +165,11 @@ to contribute into Cyclus, please follow this procedure:
 
 #. Fork Cyclus repository,
 
-#. Create a working branch on your fork from the ``develop`` branch,
+#. Create a working branch on your fork from the ``main`` branch,
 
 #. Implement your modification of the Cyclus source code,
 
-#. Submit a Pull request into ``Cyclus/develop`` branch,
+#. Submit a Pull request into ``Cyclus/main`` branch,
 
 #. Wait for reviews/merge (the proposer of a pull request cannot be the Merger).
 


### PR DESCRIPTION
This PR includes some small documentation fixes such as:
* a note in the `CONTRIBUTING` that tells developers to update the CHANGELOG, addressing what was started in #1561 
* fix the formatting for cross referencing in `INSTALL.rst` hat renders correctly on the website and when viewed on GitHub
* change conda package for dependencies to install only the dependencies for the cyclus package, allowing us to not have to maintain a core package and a dependencies package.
* Change the branch name for guiding new developers in the `README`