### PR TITLE
Move apt-update to <pkg_mgr>-deps build stage

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,7 +38,7 @@ Since last release
 **Changed:**
 
 * Moved to unified CHANGELOG Entry and check them with GithubAction (#1571)
-* Major update and modernization of build (#1587, #1632)
+* Major update and modernization of build (#1587, #1632, #1734)
 * Changed Json formatting for compatibility with current python standards (#1587)
 * Changed README.rst installation instructions, tested on fresh Ubuntu-22.04 system with Python 3.11 (#1617, #1644)
 * Resolved various compilation warnings due to use of deprecated APIs (#1671)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,11 +6,9 @@ FROM ubuntu:${ubuntu_version} as common-base
 ENV TZ=America/Chicago
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-RUN apt update --fix-missing
-
 FROM common-base as apt-deps
 
-RUN apt install -y \
+RUN apt update -y && install -y \
         libssh-dev \
         g++ \
         gcc \
@@ -48,7 +46,7 @@ RUN mkdir -p `python -m site --user-site`
 
 FROM common-base as conda-deps
 
-RUN apt install -y \
+RUN apt update -y && install -y \
         wget \
         bzip2 \
         ca-certificates \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 FROM common-base as apt-deps
 
-RUN apt update -y && install -y \
+RUN apt update -y && apt install -y \
         libssh-dev \
         g++ \
         gcc \
@@ -46,7 +46,7 @@ RUN mkdir -p `python -m site --user-site`
 
 FROM common-base as conda-deps
 
-RUN apt update -y && install -y \
+RUN apt update -y && apt install -y \
         wget \
         bzip2 \
         ca-certificates \

--- a/docker/Rocky.dockerfile
+++ b/docker/Rocky.dockerfile
@@ -18,7 +18,7 @@ RUN alternatives --install /usr/bin/python python /bin/python3.11 10 && \
     dnf config-manager --set-enabled crb
 
 FROM rocky-${rocky_version}-config as dnf-deps
-RUN dnf install -y \
+RUN dnf update -y && dnf install -y \
         wget \
         which \
         git \
@@ -43,7 +43,7 @@ RUN dnf install -y \
 RUN mkdir -p $(python -m site --user-site) && python -m pip install pandas tables cython jinja2
 
 FROM dnf-deps as libxmlpp
-RUN dnf install -y m4 doxygen perl-open perl-XML-Parser diffutils pcre-cpp pcre-devel  && \
+RUN dnf update -y && dnf install -y m4 doxygen perl-open perl-XML-Parser diffutils pcre-cpp pcre-devel  && \
     python -m pip install meson ninja packaging && \
     wget https://github.com/libxmlplusplus/libxmlplusplus/releases/download/4.0.3/libxml++-4.0.3.tar.xz && \
     tar xf libxml++-4.0.3.tar.xz && \


### PR DESCRIPTION
Closes #1733.  Whenever the dependency list changes the `RUN` step will have to re-run and `apt update` the package indexes. 