### PR TITLE
Update Dependency tables in DEPENDENCIES.rst

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,13 +306,16 @@ IF(NOT CYCLUS_DOC_ONLY)
     # Cython & Python Bindings
     #
     # Use new Python library finder
-    find_package (Python3 COMPONENTS Interpreter Development NumPy)
+    find_package (Python3 REQUIRED COMPONENTS Interpreter Development)
 
     execute_process(COMMAND "${Python3_EXECUTABLE}" -m site --user-site
                     OUTPUT_VARIABLE PYTHON_SITE_PACKAGES
                     OUTPUT_STRIP_TRAILING_WHITESPACE)
     message("-- PYTHON_EXECUTABLE: ${Python3_EXECUTABLE}")
     message("-- PYTHON_SITE_PACKAGES: ${PYTHON_SITE_PACKAGES}")
+    IF (NOT APPLE)
+        set(LIBS ${LIBS} ${Python3_LIBRARIES})
+    ENDIF (NOT APPLE)
 
     # Include the CMake script UseCython.cmake.  This defines add_cython_module().
     # Instruction for use can be found at the top of cmake/UseCython.cmake.
@@ -325,7 +328,7 @@ IF(NOT CYCLUS_DOC_ONLY)
           message(FATAL_ERROR "Cython version is too old, must be 0.25+.")
         endif()
         include(UseCython)
-
+        find_package (Python3 REQUIRED COMPONENTS NumPy)
         find_package(Jinja2 REQUIRED)
         find_package(Pandas REQUIRED)
 
@@ -341,9 +344,6 @@ IF(NOT CYCLUS_DOC_ONLY)
 
         # make sure we know about having python
         add_definitions(-DCYCLUS_WITH_PYTHON)
-        IF (NOT APPLE)
-            set(LIBS ${LIBS} ${Python3_LIBRARIES})
-        ENDIF (NOT APPLE)
         INCLUDE_DIRECTORIES("${CMAKE_CURRENT_BINARY_DIR}/cyclus")
     else(Cython_FOUND)
         # If we don't have Python bindings, we may try to find tcmalloc.
@@ -365,6 +365,7 @@ IF(NOT CYCLUS_DOC_ONLY)
     # NOTE: for some reason, adding quotes around
     # ${Glibmm_INCLUDE_DIRS} breaks Ubuntu 12.04
     set(inc_dirs
+        "${Python3_INCLUDE_DIRS}"
         "${LIBXML2_INCLUDE_DIR}"
         "${LIBXMLXX_INCLUDE_DIRS}"
         "${Glibmm_INCLUDE_DIRS}"
@@ -377,7 +378,6 @@ IF(NOT CYCLUS_DOC_ONLY)
       INCLUDE_DIRECTORIES(${inc_dirs})
     ENDIF()
     message("-- Include Directories: ${inc_dirs}")
-
 
     if(Cython_FOUND)
         INCLUDE_DIRECTORIES(AFTER "${Python3_INCLUDE_DIRS}" "${_Python3_NumPy_INCLUDE_DIR}")

--- a/DEPENDENCIES.rst
+++ b/DEPENDENCIES.rst
@@ -22,20 +22,19 @@ In order to facilitate future compatibility with multiple platforms,
 Cyclus is built using ``CMake``. A full list of the Cyclus package
 dependencies is shown below:
 
-====================   ==================
-Package                Minimum Version
-====================   ==================
-``CMake``                3.16.3
-``boost``                1.71.0
-``libxml2``              2.9.10+
-``libxml++``             2.40.1
-``python``               3.8.10
-``sqlite3``              3.31.1
-``HDF5``                 1.10.4+
-``Coin-Cbc``             2.10.3
-``Coin-Clp``             1.17.5
-``zlib``                 1.2.11
-====================   ==================
+====================      ==================
+Package                   Minimum Version
+====================      ==================
+``CMake``                   3.16.3
+``pkg-config``              0.29.1
+``boost``                   1.71.0
+``libxml2``                 2.9.10
+``libxml++``                2.40.1
+``python`` (dev version)    3.8.10
+``sqlite3``                 3.31.1
+``HDF5``                    1.10.4
+``LAPACK``                  3.9.0
+====================      ==================
 
 .. website_include_end
 
@@ -43,23 +42,22 @@ Package                Minimum Version
 
 And a few optional dependencies:
 
-====================   ==================
-Package                Minimum Version
-====================   ==================
-doxygen (for docs)     1.7.6.1
-tcmalloc (for speed)   any
-Cython                 0.29+
-Python (dev version)   3.8+
-Jinja2                 any
-NumPy                  1.9+
-Pandas                 any
-====================   ==================
+====================   ==================  =============================================  ==================        
+Package                Minimum Version     Purpose                                        Notes
+====================   ==================  =============================================  ==================  
+``Coin-Cbc``             2.10.3             Enables use of Branch-and-Cut solver          Cyclus must be built with ``--allow-milps`` flag
+``Coin-Clp``             1.17.5             Enables use of Linear Programming solver      Cyclus must be built with ``--allow-milps`` flag
+``doxygen``              1.7.6.1            Building documentation
+``TCMmalloc``            any                Improves performance                          Only used if Cython is not present
+``Cython``               0.29               Enables use of Python agents and input files  
+``Jinja2``               2.10.1             Enables use of Python agents and input files  Only needed if Cython is installed
+``NumPy``                1.9                Enables use of Python agents and input files  Only needed if Cython is installed
+``pandas``               0.25.3             Enables use of Python agents and input files  Only needed if Cython is installed
+``pip``                  20.0.2             Enables use of Python agents and input files  Only needed if Cython is installed
+====================   ==================  =============================================  ==================
 
 *Note that the Debian/Ubuntu package ``libtcmalloc`` is NOT discovered correctly
 by our build system.  Instead use ``libgoogle-perftools-dev``.*
-
-*Also note that the development version of Python, Jinja2, NumPy, and Pandas are
-only needed if Cython is installed.*
 
 ***********************
 Installing Dependencies
@@ -88,31 +86,30 @@ required library package names is:
 
 #. make
 #. cmake
+#. pkg-config
 #. libboost-all-dev (see note below)
 #. libxml2-dev
 #. libxml++2.6-dev
+#. python3-dev
 #. libsqlite3-dev
-#. libhdf5-serial-dev
-#. libbz2-dev
-#. coinor-libcbc-dev
-#. coinor-libcoinutils-dev
-#. coinor-libosi-dev
-#. coinor-libclp-dev
-#. coinor-libcgl-dev
+#. libhdf5-dev
+#. liblapack-dev
+
 
 and (optionally):
 
 #. doxygen
-#. g++
-#. libblas-dev
-#. liblapack-dev
 #. libgoogle-perftools-dev
-#. python3-dev
+#. coinor-libcbc-dev
+#. coinor-libcoinutils-dev
+#. coinor-libosi-dev
+#. coinor-libclp-dev
 #. python3-tables
 #. python3-pandas
 #. python3-numpy
-#. python3-nose
+#. python3-pytest
 #. python3-jinja2
+#. python3-pip
 #. cython3       (see note below)
 
 For example, in order to install libxml++ (and libxml2) on your system, type:
@@ -126,19 +123,17 @@ If you'd prefer to copy/paste, the following line will install all **required**
 
 .. code-block:: bash
 
-   sudo apt-get install -y cmake make libboost-all-dev libxml2-dev libxml++2.6-dev \
-   libsqlite3-dev libhdf5-serial-dev libbz2-dev coinor-libcbc-dev coinor-libcoinutils-dev \
-   coinor-libosi-dev coinor-libclp-dev coinor-libcgl-dev
+   sudo apt-get install -y cmake make pkg-config libboost-all-dev libxml2-dev libxml++2.6-dev \
+   python3 libsqlite3-dev libhdf5-dev liblapack-dev
 
 And to install all *Cyclus* dependencies (**required and optional**):
 
 .. code-block:: bash
 
-   sudo apt-get install -y cmake make libboost-all-dev libxml2-dev libxml++2.6-dev \
-   libsqlite3-dev libhdf5-serial-dev libbz2-dev coinor-libcbc-dev coinor-libcoinutils-dev \
-   coinor-libosi-dev coinor-libclp-dev coinor-libcgl-dev libblas-dev liblapack-dev g++ \
-   libgoogle-perftools-dev python3-dev python3-tables python3-pandas python3-numpy python3-nose \
-   python3-jinja2 cython3
+   sudo apt-get install -y cmake make pkg-config libboost-all-dev libxml2-dev libxml++2.6-dev \
+   python3 libsqlite3-dev libhdf5-dev liblapack-dev coinor-libcbc-dev coinor-libcoinutils-dev \
+   coinor-libosi-dev coinor-libclp-dev coinor-libcgl-dev doxygen libgoogle-perftools-dev python3-tables \
+   python3-pandas python3-numpy python3-pytest python3-jinja2 cython3
 
 To determine which version of Python is already installed on your computer, run:
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,7 +42,7 @@ RUN mkdir -p `python -m site --user-site`
 
 FROM common-base as conda-deps
 
-RUN apt update -y && install -y \
+RUN apt update -y && apt install -y \
         wget \
         bzip2 \
         ca-certificates \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,14 +11,12 @@ RUN apt update --fix-missing
 FROM common-base as apt-deps
 
 RUN apt install -y \
-        libssh-dev \
         g++ \
         gcc \
         cmake \
         make \
         libxml2-dev \
         libxml++2.6-dev \
-        libblas-dev \
         liblapack-dev \
         pkg-config \
         coinor-libcbc-dev \
@@ -29,8 +27,6 @@ RUN apt install -y \
         libhdf5-dev \
         libsqlite3-dev \
         libpcre2-dev \
-        gettext-base \
-        xz-utils \
         python3-setuptools \
         python3-pytest \ 
         python3-tables \
@@ -70,20 +66,14 @@ RUN conda uninstall -y conda-libmamba-solver
 RUN conda config --set solver classic
 RUN conda update -y --all && \
     mamba install -y \
-               openssh \
                gxx_linux-64 \
                gcc_linux-64 \
                cmake \
                make \
-               docker-pycreds \
                git \
-               xo \
-               python-json-logger \
                glib \
                libxml2 \
                libxmlpp-4.0 \
-               libblas \
-               libcblas \
                liblapack \
                pkg-config \
                coincbc \
@@ -91,9 +81,6 @@ RUN conda update -y --all && \
                hdf5 \
                sqlite \
                pcre \
-               gettext \
-               bzip2 \
-               xz \
                setuptools \
                pytest \
                pytables \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,11 +6,9 @@ FROM ubuntu:${ubuntu_version} as common-base
 ENV TZ=America/Chicago
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-RUN apt update --fix-missing
-
 FROM common-base as apt-deps
 
-RUN apt install -y \
+RUN apt update -y && apt install -y \
         g++ \
         gcc \
         cmake \
@@ -44,7 +42,7 @@ RUN mkdir -p `python -m site --user-site`
 
 FROM common-base as conda-deps
 
-RUN apt install -y \
+RUN apt update -y && install -y \
         wget \
         bzip2 \
         ca-certificates \

--- a/docker/Rocky.dockerfile
+++ b/docker/Rocky.dockerfile
@@ -18,7 +18,7 @@ RUN alternatives --install /usr/bin/python python /bin/python3.11 10 && \
     dnf config-manager --set-enabled crb
 
 FROM rocky-${rocky_version}-config as dnf-deps
-RUN dnf install -y \
+RUN dnf update -y && dnf install -y \
         wget \
         which \
         git \
@@ -29,10 +29,8 @@ RUN dnf install -y \
         hdf5-devel \
         libxml2-devel \
         boost-devel \
-        blas-devel \
         lapack-devel \
         sqlite-devel \
-        gettext \
         xz \
         python3.11-devel \
         python3.11-setuptools \
@@ -43,7 +41,7 @@ RUN dnf install -y \
 RUN mkdir -p $(python -m site --user-site) && python -m pip install pandas tables cython jinja2
 
 FROM dnf-deps as libxmlpp
-RUN dnf install -y m4 doxygen perl-open perl-XML-Parser diffutils pcre-cpp pcre-devel  && \
+RUN dnf update -y && dnf install -y m4 doxygen perl-open perl-XML-Parser diffutils pcre-cpp pcre-devel  && \
     python -m pip install meson ninja packaging && \
     wget https://github.com/libxmlplusplus/libxmlplusplus/releases/download/4.0.3/libxml++-4.0.3.tar.xz && \
     tar xf libxml++-4.0.3.tar.xz && \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -201,7 +201,7 @@ list(REMOVE_ITEM cc_files ${CMAKE_CURRENT_SOURCE_DIR}/coin_helpers.cc)
 list(REMOVE_ITEM cc_files ${CMAKE_CURRENT_SOURCE_DIR}/prog_translator.cc)
 # The cython modules are built as their own shared libraries
 # We don't want them to be included in libcyclus.so
-if(CYCLUS_WITH_PYTHON)
+if(Cython_FOUND)
   list(REMOVE_ITEM cc_files ${CythonModuleSrc})
 endif()
 SET(CYCLUS_CORE_SRC ${CYCLUS_CORE_SRC} ${cc_files})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -201,8 +201,9 @@ list(REMOVE_ITEM cc_files ${CMAKE_CURRENT_SOURCE_DIR}/coin_helpers.cc)
 list(REMOVE_ITEM cc_files ${CMAKE_CURRENT_SOURCE_DIR}/prog_translator.cc)
 # The cython modules are built as their own shared libraries
 # We don't want them to be included in libcyclus.so
-list(REMOVE_ITEM cc_files ${CythonModuleSrc})
-
+if(CYCLUS_WITH_PYTHON)
+  list(REMOVE_ITEM cc_files ${CythonModuleSrc})
+endif()
 SET(CYCLUS_CORE_SRC ${CYCLUS_CORE_SRC} ${cc_files})
 
 # Add Cyclus source files that use COIN, if we have COIN

--- a/tests/toolkit/infile_converters_tests.cc
+++ b/tests/toolkit/infile_converters_tests.cc
@@ -2,6 +2,8 @@
 
 #include "cyclus.h"
 
+#ifdef CYCLUS_WITH_PYTHON
+
 std::string MakeInput() {
   return std::string(
           "<simulation>"
@@ -109,3 +111,5 @@ TEST(InfileConverters, PyXmlRoundTrip) {
   EXPECT_STREQ(p1.c_str(), p2.c_str());
   EXPECT_STREQ(x1.c_str(), x2.c_str());
 }
+
+#endif // CYCLUS_WITH_PYTHON


### PR DESCRIPTION
Closes #1710. This PR updates the dependency tables with correct lists of **required** and **optional** dependencies, along with notes about the optional dependencies.  

It also contains some minor build changes that allow users to build without Cython present on their machine.