### PR TITLE
Update README conda installation instructions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ Since last release
 
 **Changed:**
 
+* Changed README.rst installation instructions, tested on fresh Ubuntu-22.04 system with Python3.11
+
 **Removed:**
 
 **Fixed:**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ Since last release
 
 **Changed:**
 
-* Changed README.rst installation instructions, tested on fresh Ubuntu-22.04 system with Python3.11
+* Changed README.rst installation instructions, tested on fresh Ubuntu-22.04 system with Python3.11 (#1744)
 
 **Removed:**
 

--- a/README.rst
+++ b/README.rst
@@ -78,38 +78,28 @@ Cyclus is built using ``CMake``. For detailed instructions on Cyclus dependencie
 Quick Cyclus Installation
 *************************
 The quickest way to install Cyclus and its dependencies relies on using the `conda-forge` channel and the `conda` package manager within the Anaconda python environment.  The following instructions guide you through that approach.
-To install Cyclus and its dependencies onto a clean Ubuntu machine (tested on 18.04 LTS):
+To install Cyclus and its dependencies onto a clean Ubuntu machine (tested on 22.04 LTS):
 
-- Download the latest Anaconda installer for Linux at
-  ``https://www.anaconda.com/distribution/#download-section``
+- Download the latest Miniconda installer for Linux at
+  ``https://docs.anaconda.com/free/miniconda/miniconda-other-installer-links/``
 
 - Move the ``.sh`` to your Home directory
 
 - In Terminal, execute the following commands:
 
-- ``bash Anaconda3-2019.03-Linux-x86_64.sh``
+- ``bash ~/miniconda.sh -b -u -p ~/miniconda3``
 
-- ``echo 'export PATH="~/anaconda/bin:$PATH"' >> ~/.bashrc``
+- ``echo 'export PATH="~/miniconda3/bin:$PATH"' >> ~/.bashrc``
 
-- ``source .bashrc``
+- ``source ~/.bashrc``
 
 - ``conda config --add channels conda-forge``
 
-- ``conda create -n cyclus python=3.11``
+- ``conda create -n cyclus``
 
 - ``conda activate cyclus``
 
-- ``conda install -y gxx_linux-64 gcc_linux-64 cmake make git glib libxml2 libxmlpp-4.0 liblapack pkg-config coincbc boost-cpp hdf5 sqlite pcre setuptools pytest pytables pandas jinja2 cython websockets pprintpp pip``
-
-- ``conda install -y --force-reinstall libsqlite``
-
-- Use ``sudo apt install`` to install and configure git
-
-- Clone the Cyclus repository by running ``git clone https://github.com/cyclus/cyclus.git``
-
-- Navigate to the folder containing Cyclus
-
-- Run the command ``python install.py``
+- ``conda install -y cyclus``
 
 For more detailed installation procedure, and/or custom installation please
 refer to the `INSTALLATION guide <INSTALL.rst>`_.

--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,7 @@ To install Cyclus and its dependencies onto a clean Ubuntu machine (tested on 22
 
 .. code-block:: bash
 
-  echo 'export PATH="~/miniconda3/bin:$PATH"' >> ~/.bashrc
+  ~/miniconda3/bin/conda init bash
   source ~/.bashrc
 
 - Create a new environment and install the Cyclus package

--- a/README.rst
+++ b/README.rst
@@ -80,26 +80,31 @@ Quick Cyclus Installation
 The quickest way to install Cyclus and its dependencies relies on using the `conda-forge` channel and the `conda` package manager within the Anaconda python environment.  The following instructions guide you through that approach.
 To install Cyclus and its dependencies onto a clean Ubuntu machine (tested on 22.04 LTS):
 
-- Download the latest Miniconda installer for Linux at
-  ``https://docs.anaconda.com/free/miniconda/miniconda-other-installer-links/``
+- Download and install Miniconda for Linux
 
-- Move the ``.sh`` to your Home directory
 
-- In Terminal, execute the following commands:
+.. code-block:: python
 
-- ``bash ~/miniconda.sh -b -u -p ~/miniconda3``
+  mkdir -p ~/miniconda3
+  wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda3/miniconda.sh
+  bash ~/miniconda3/miniconda.sh -b -u -p ~/miniconda3
+  rm -rf ~/miniconda3/miniconda.sh
 
-- ``echo 'export PATH="~/miniconda3/bin:$PATH"' >> ~/.bashrc``
+- Execute the following commands to initialize Miniconda:
 
-- ``source ~/.bashrc``
+.. code-block:: python
 
-- ``conda config --add channels conda-forge``
+  echo 'export PATH="~/miniconda3/bin:$PATH"' >> ~/.bashrc
+  source ~/.bashrc
 
-- ``conda create -n cyclus``
+- Create a new environment and install the Cyclus package
 
-- ``conda activate cyclus``
+.. code-block:: python
 
-- ``conda install -y cyclus``
+  conda config --add channels conda-forge
+  conda create -n cyclus python=3.11
+  conda activate cyclus
+  conda install -y cyclus
 
 For more detailed installation procedure, and/or custom installation please
 refer to the `INSTALLATION guide <INSTALL.rst>`_.

--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,7 @@ To install Cyclus and its dependencies onto a clean Ubuntu machine (tested on 22
 - Download and install Miniconda for Linux
 
 
-.. code-block:: python
+.. code-block:: bash
 
   mkdir -p ~/miniconda3
   wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda3/miniconda.sh
@@ -92,14 +92,14 @@ To install Cyclus and its dependencies onto a clean Ubuntu machine (tested on 22
 
 - Execute the following commands to initialize Miniconda:
 
-.. code-block:: python
+.. code-block:: bash
 
   echo 'export PATH="~/miniconda3/bin:$PATH"' >> ~/.bashrc
   source ~/.bashrc
 
 - Create a new environment and install the Cyclus package
 
-.. code-block:: python
+.. code-block:: bash
 
   conda config --add channels conda-forge
   conda create -n cyclus python=3.11
@@ -118,7 +118,7 @@ our tests). You can run the tests yourself via:
 
 .. code-block:: bash
 
-    $ cyclus_unit_tests
+    cyclus_unit_tests
 
 
 *******************
@@ -147,7 +147,7 @@ file ``input.xml``, you can run Cyclus via:
 
 .. code-block:: bash
 
-    $ cyclus path/to/input.xml
+    cyclus path/to/input.xml
 
 For a more detailed explanation, check out the `Cyclus User Guide`_.
 

--- a/README.rst
+++ b/README.rst
@@ -102,7 +102,7 @@ To install Cyclus and its dependencies onto a clean Ubuntu machine (tested on 22
 .. code-block:: bash
 
   conda config --add channels conda-forge
-  conda create -n cyclus python=3.11
+  conda create -n cyclus
   conda activate cyclus
   conda install -y cyclus
 


### PR DESCRIPTION
Closes #1736.  The current instructions in our README say the quickest way to install cyclus is by installing all conda dependencies then build from source.  This changes those instructions to simply `conda install -y cyclus`.