### PR TITLE
Transport units

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Since last release
 ====================
 
 **Added:**
+* Added TransportUnits (#1570)
 
 **Changed:**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Since last release
 ====================
 
 **Added:**
-* Added TransportUnits (#1570)
+* Added TransportUnits (#1750)
 
 **Changed:**
 
@@ -16,7 +16,6 @@ Since last release
 * Consistently use hyphens in ``install.py`` flags (#1748)
 * Material sell policy can package materials (#1749)
 * Use miniforge for conda CI builds instead of miniconda (#1763)
-* Added TransportUnits (#1570)
 
 **Removed:**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Since last release
 * Consistently use hyphens in ``install.py`` flags (#1748)
 * Material sell policy can package materials (#1749)
 * Use miniforge for conda CI builds instead of miniconda (#1763)
+* Added TransportUnits (#1570)
 
 **Removed:**
 

--- a/share/cyclus-flat.rng.in
+++ b/share/cyclus-flat.rng.in
@@ -147,12 +147,23 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
     </element>
   </zeroOrMore>
 
-    <zeroOrMore>
+  <zeroOrMore>
     <element name="package">
       <interleave>
         <element name="name"><text/></element>
         <element name="fill_min"><data type="double"/></element>
         <element name="fill_max"><data type="double"/></element>
+        <element name="strategy"><text/></element>
+      </interleave>
+    </element>
+  </zeroOrMore>
+
+  <zeroOrMore>
+    <element name="transportunit">
+      <interleave>
+        <element name="name"><text/></element>
+        <element name="fill_min"><data type="nonNegativeInteger"/></element>
+        <element name="fill_max"><data type="nonNegativeInteger"/></element>
         <element name="strategy"><text/></element>
       </interleave>
     </element>

--- a/share/cyclus.rng.in
+++ b/share/cyclus.rng.in
@@ -190,6 +190,17 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
     </element>
   </zeroOrMore>
 
+  <zeroOrMore>
+    <element name="transportunit">
+      <interleave>
+        <element name="name"><text/></element>
+        <element name="fill_min"><data type="nonNegativeInteger"/></element>
+        <element name="fill_max"><data type="nonNegativeInteger"/></element>
+        <element name="strategy"><text/></element>
+      </interleave>
+    </element>
+  </zeroOrMore>
+
 </interleave> </element>
 
 </start>

--- a/src/context.cc
+++ b/src/context.cc
@@ -224,6 +224,40 @@ Package::Ptr Context::GetPackage(std::string name) {
   return packages_[name];
 }
 
+Package::Ptr Context::GetPackageById(int id) {
+  if (id == Package::unpackaged_id()) {
+    return Package::unpackaged();
+  }
+  if (id < 0) {
+    throw ValueError("Invalid package id " + std::to_string(id));
+  }
+  // iterate through the list of packages to get the one package with the correct id
+  std::map<std::string, Package::Ptr>::iterator it;
+  for (it = packages_.begin(); it != packages_.end(); ++it) {
+    if (it->second->id() == id) {
+      return it->second;
+    }
+  }
+  throw ValueError("Invalid package id " + std::to_string(id));
+}
+
+  void AddTransportUnit(std::string name, int fill_min, int fill_max, 
+                        std::string strategy) {
+    transport_units_[name] = TransportUnit::Create(name, fill_min, fill_max, strategy);
+    NewDatum("TransportUnit")
+      ->AddVal("TransportUnit", name)
+      ->AddVal("FillMin", fill_min)
+      ->AddVal("FillMax", fill_max)
+      ->AddVal("Strategy", strategy)
+      ->AddVal("Id", transport_units_[name]->id())
+      ->Record();
+  }
+
+  /// Retrieve a registered transport unit
+  TransportUnit::Ptr GetTransportUnitByName(std::string name);
+
+  TransportUnit::Ptr GetTransportUnitById(int id);
+
 void Context::InitSim(SimInfo si) {
   NewDatum("Info")
       ->AddVal("Handle", si.handle)
@@ -277,7 +311,7 @@ void Context::InitSim(SimInfo si) {
 int Context::time() {
   return ti_->time();
 }
-
+LoadPacka
 int Context::random() {
   return rng_->random();
 }

--- a/src/context.h
+++ b/src/context.h
@@ -356,6 +356,7 @@ class Context {
   std::map<std::string, Agent*> protos_;
   std::map<std::string, Composition::Ptr> recipes_;
   std::map<std::string, Package::Ptr> packages_;
+  std::map<std::string, TransportUnit::Ptr> transport_units_;
   std::set<Agent*> agent_list_;
   std::set<Trader*> traders_;
   std::map<std::string, int> n_prototypes_;

--- a/src/context.h
+++ b/src/context.h
@@ -262,6 +262,19 @@ class Context {
   /// Retrieve a registered package. 
   Package::Ptr GetPackage(std::string name);
 
+  /// Adds a transport unit type to a simulation-wide accessible list.
+  /// Agents should NOT add their own transport units.
+  void AddTransportUnit(std::string name, int fill_min = 0,
+                  int fill_max = std::numeric_limits<int>::max(),
+                  std::string strategy = "first");
+
+  /// Records transport unit information. Should be used first on unrestricted,
+  /// then to record user-declared transport units
+  void RecordTransportUnit(TransportUnit::Ptr);
+
+  /// Retrieve a registered transport unit. 
+  TransportUnit::Ptr GetTransportUnit(std::string name);
+
   int random();
 
   /// Generates a random number on the range [0,1)]

--- a/src/package.cc
+++ b/src/package.cc
@@ -79,8 +79,7 @@ TransportUnit::Ptr TransportUnit::Create(std::string name, int fill_min, int fil
 // if the static member is not yet set, create a new object
 // otherwise return the object that already exists
 TransportUnit::Ptr& TransportUnit::unrestricted() {
-
-  if (!unrestricted) {
+  if (!unrestricted_) {
     unrestricted_ = Ptr(new TransportUnit(unrestricted_name_));
   }
   return unrestricted_;
@@ -102,28 +101,26 @@ int TransportUnit::GetTransportUnitFill(int qty) {
 
     if (num_at_min_fill >= num_at_max_fill) {
       // all material *might* fit transport units. However, this is more
-      // challenging than packages because transport units are discrete. check:
-
+      // challenging than packages because transport units are discrete. 
       double dbl_fill_mass = (double)qty / (double)num_at_max_fill;
-        return std::floor(dbl_fill_mass);
+      return std::floor(dbl_fill_mass);
     }
     // some material will remain unrestricted, fill up as many transport
     // units as possible. Or, perfect fill is possible but not with integer
-    // fill (see above). Should also start filling to max until last partial
-    // filled transport unit
-    return fill_max_;
+    // fill (see above). 
   }
+  return fill_max_;
 }
 
 int TransportUnit::MaxShippablePackages(int pkgs) {
   int TU_fill;
   int shippable = 0;
-  
+
   if (pkgs == 0 && pkgs < fill_min_) {
     return 0;
   }
 
-  while (pkgs > 0 && pkgs >= fill_min_) {
+  while ((pkgs > 0) && (pkgs >= fill_min_)) {
     TU_fill = GetTransportUnitFill(pkgs);
     shippable += TU_fill;
     pkgs -= TU_fill;
@@ -134,7 +131,9 @@ int TransportUnit::MaxShippablePackages(int pkgs) {
 TransportUnit::TransportUnit(std::string name, int fill_min, int fill_max, std::string strategy) : 
   name_(name), fill_min_(fill_min), fill_max_(fill_max), strategy_(strategy) {
     if (name == unrestricted_name_) {
-      throw ValueError("can't create a new transport unit with name 'unrestricted'");
+      if (unrestricted_) {
+        throw ValueError("can't create a new transport unit with name 'unrestricted'");
+      }
   }
 }
 

--- a/src/package.cc
+++ b/src/package.cc
@@ -62,4 +62,65 @@ Package::Package(std::string name, double fill_min, double fill_max,
   }
 }
 
+// unrestricted id is 1, so start the user-declared transport id at 2
+int TransportUnit::next_package_id_ = 2;
+TransportUnit::Ptr TransportUnit::unrestricted_ = NULL;
+
+TransportUnit::Ptr TransportUnit::Create(std::string name, int fill_min, int fill_max, std::string strategy) {
+  if (fill_min < 0 || fill_max < 0) {
+    throw ValueError("fill_min and fill_max must be non-negative");
+  }
+  else if (fill_min > fill_max) {
+    throw ValueError("fill_min must be less than or equal to fill_max");
+  }
+  Ptr p(new TransportUnit(name, fill_min, fill_max, strategy));
+  return p;
+}
+
+// singleton pattern: 
+// if the static member is not yet set, create a new object
+// otherwise return the object that already exists
+TransportUnit::Ptr& TransportUnit::unrestricted() {
+
+  if (!unrestricted) {
+    unrestricted_ = Ptr(new TransportUnit(unrestricted_name_));
+  }
+  return unrestricted_;
+}
+
+int TransportUnit::GetFillMass(double qty) {
+  if (qty < fill_min_) {
+    // less than one pkg of material available
+    return 0;
+  }
+
+  int fill_mass;
+  if (strategy_ == "first") {
+    fill_mass = fill_max_;
+  } else if (strategy_ == "equal") {
+    int num_min_fill = std::floor(qty / fill_min_);
+    int num_max_fill = std::ceil(qty / fill_max_);
+    if (num_min_fill >= num_max_fill) {
+      // all material can fit in a package
+      int fill_mass = qty / num_max_fill;
+    } else {
+      // some material will remain unrestricted, fill up as many max packages as possible
+      fill_mass = fill_max_;
+    }
+  }
+  return fill_mass;
+}
+  
+TransportUnit::TransportUnit(std::string name, int fill_min, int fill_max, std::string strategy) : 
+  name_(name), fill_min_(fill_min), fill_max_(fill_max), strategy_(strategy) {
+    if (name == unrestricted_name_) {
+      if (unrestricted_) {
+        throw ValueError("can't create a new transport unit with name 'unrestricted'");
+      }
+      id_ = unrestricted_id_;
+    } else {
+      id_ = next_transport_unit_id_++;
+    }
+  }
+
 } // namespace cyclus

--- a/src/package.cc
+++ b/src/package.cc
@@ -73,8 +73,8 @@ TransportUnit::Ptr TransportUnit::Create(std::string name, int fill_min, int fil
   else if (fill_min > fill_max) {
     throw ValueError("fill_min must be less than or equal to fill_max");
   }
-  Ptr p(new TransportUnit(name, fill_min, fill_max, strategy));
-  return p;
+  Ptr t(new TransportUnit(name, fill_min, fill_max, strategy));
+  return t;
 }
 
 // singleton pattern: 
@@ -88,7 +88,7 @@ TransportUnit::Ptr& TransportUnit::unrestricted() {
   return unrestricted_;
 }
 
-int TransportUnit::GetFillMass(double qty) {
+int TransportUnit::GetTransportUnitFill(int qty) {
   if (qty < fill_min_) {
     // less than one pkg of material available
     return 0;
@@ -104,11 +104,23 @@ int TransportUnit::GetFillMass(double qty) {
       // all material can fit in a package
       int fill_mass = qty / num_max_fill;
     } else {
-      // some material will remain unrestricted, fill up as many max packages as possible
+      // some material will remain unrestricted, fill up as many transport
+      // units as possible
       fill_mass = fill_max_;
     }
   }
   return fill_mass;
+}
+
+int TransportUnit:TotalShippablePackages(int pkgs) {
+  int fill = GetTransportUnitFill(pkgs);
+  int shippable = std::floor(pkgs / fill) * fill;
+  
+  int remainder = pkgs % fill;
+  if (remainder > 0 && remainder >= fill_min_) {
+    shippable += remainder;
+  }
+  return shippable;
 }
   
 TransportUnit::TransportUnit(std::string name, int fill_min, int fill_max, std::string strategy) : 

--- a/src/package.cc
+++ b/src/package.cc
@@ -87,7 +87,7 @@ TransportUnit::Ptr& TransportUnit::unrestricted() {
 
 int TransportUnit::GetTransportUnitFill(int qty) {
   if (qty < fill_min_) {
-    // less than one pkg of material available
+    // less than one TransportUnit of material available
     return 0;
   }
 

--- a/src/package.h
+++ b/src/package.h
@@ -68,6 +68,72 @@ class Package {
     std::string strategy_;
 };
 
+class TransportUnit {
+  public:
+    typedef boost::shared_ptr<TransportUnit> Ptr;
+
+    // create a new package type. Should be called by the context only
+    // (see Context::AddPackage), unless you want an untracked package
+    //  type (which you probably don't)
+    static Ptr Create(std::string name, int fill_min = 0,
+                      int fill_max = std::numeric_limits<int>::max(),
+                      std::string strategy = "first");
+
+    /// Returns optimal fill mass for a resource to be packaged. Can be used
+    /// to determine how to respond to requests for material, and to actually
+    /// package and send off trades.
+    /// Packaging strategy "first" simply fills the packages one by one to the
+    /// maximum fill. Therefore, it should always try to max fill.
+    /// Packaging strategy "equal" tries to fill all packages to the same mass.
+    /// This tries to find the optimal number and fill mass of packages given
+    /// the packaging limitations. It does this by calculating bounding fills, 
+    /// floor(quantity/fill_min) and ceiling(quantity/fill_max). 
+    /// There might be a scenario where there is no solution, i.e. an integer
+    /// number of packages cannot be filled with no remainder. In this case,
+    /// the most effective fill strategy is to fill to the max. Numeric example:
+    /// quantity = 5, fill_min = 3, fill_max = 4. num_min_fill = floor(5/3) = 1,
+    /// num_max_fill = ceil(5/4) = 2. num_min_fill < num_max_fill, so fill to
+    /// the max.
+    int GetShippableTransportUnits(int qty);
+
+    // returns package id
+    int id() const { return id_; }
+    // returns package name
+    std::string name() const { return name_; }
+    // returns package fill min
+    int fill_min() const { return fill_min_; }
+    // returns package fill max
+    int fill_max() const { return fill_max_; }
+    // returns package strategy
+    std::string strategy() const { return strategy_; }
+
+    // returns the unrestricted id (1)
+    static int unrestricted_id() { return unrestricted_id_; }
+
+    // returns the unrestricted transport unit name
+    static std::string unrestricted_name() { return unrestricted_name_; }
+
+    // returns the unrestricted singleton object
+    static Ptr& unrestricted();
+
+  private:
+    Package(std::string name, 
+            int fill_min = 0, 
+            int fill_max = std::numeric_limits<int>::max(), 
+            std::string strategy = "first");
+
+    static const int unrestricted_id_ = 1;
+    static constexpr char unrestricted_name_[11] = "unrestricted";
+    static Ptr unrestricted_;
+    static int next_tranport_unit_id_;
+
+    std::string name_;
+    int id_;
+    int fill_min_;
+    int fill_max_;
+    std::string strategy_;
+};
+
 }  // namespace cyclus
 
 #endif  // CYCLUS_SRC_PACKAGE_H_

--- a/src/package.h
+++ b/src/package.h
@@ -86,7 +86,7 @@ class TransportUnit {
     int GetTransportUnitFill(int qty);
 
     /// Returns the max number of packages that can be shipped
-    int TotalShippablePackages(int pkgs);
+    int MaxShippablePackages(int pkgs);
 
     // returns package id
     int id() const { return id_; }
@@ -115,7 +115,7 @@ class TransportUnit {
             std::string strategy = "first");
 
     static const int unrestricted_id_ = 1;
-    static constexpr char unrestricted_name_[11] = "unrestricted";
+    static constexpr char unrestricted_name_[13] = "unrestricted";
     static Ptr unrestricted_;
     static int next_tranport_unit_id_;
 

--- a/src/package.h
+++ b/src/package.h
@@ -72,29 +72,21 @@ class TransportUnit {
   public:
     typedef boost::shared_ptr<TransportUnit> Ptr;
 
-    // create a new package type. Should be called by the context only
-    // (see Context::AddPackage), unless you want an untracked package
-    //  type (which you probably don't)
+    // create a new transport unit type. Should be called by the context only
+    // (see Context::AddTransportUnit), unless you want an untracked package
+    // type (which you probably don't)
     static Ptr Create(std::string name, int fill_min = 0,
                       int fill_max = std::numeric_limits<int>::max(),
                       std::string strategy = "first");
 
-    /// Returns optimal fill mass for a resource to be packaged. Can be used
-    /// to determine how to respond to requests for material, and to actually
-    /// package and send off trades.
-    /// Packaging strategy "first" simply fills the packages one by one to the
-    /// maximum fill. Therefore, it should always try to max fill.
-    /// Packaging strategy "equal" tries to fill all packages to the same mass.
-    /// This tries to find the optimal number and fill mass of packages given
-    /// the packaging limitations. It does this by calculating bounding fills, 
-    /// floor(quantity/fill_min) and ceiling(quantity/fill_max). 
-    /// There might be a scenario where there is no solution, i.e. an integer
-    /// number of packages cannot be filled with no remainder. In this case,
-    /// the most effective fill strategy is to fill to the max. Numeric example:
-    /// quantity = 5, fill_min = 3, fill_max = 4. num_min_fill = floor(5/3) = 1,
-    /// num_max_fill = ceil(5/4) = 2. num_min_fill < num_max_fill, so fill to
-    /// the max.
-    int GetShippableTransportUnits(int qty);
+    /// Returns number of packages for 
+    /// Strategy "first" simply fill transport units one by one to max fill
+    /// Strategy "equal" tries to fill all transport units with the
+    /// same number of packages
+    int GetTransportUnitFill(int qty);
+
+    /// Returns the max number of packages that can be shipped
+    int TotalShippablePackages(int pkgs);
 
     // returns package id
     int id() const { return id_; }
@@ -117,7 +109,7 @@ class TransportUnit {
     static Ptr& unrestricted();
 
   private:
-    Package(std::string name, 
+    TransportUnit(std::string name, 
             int fill_min = 0, 
             int fill_max = std::numeric_limits<int>::max(), 
             std::string strategy = "first");

--- a/src/package.h
+++ b/src/package.h
@@ -9,7 +9,9 @@
 
 namespace cyclus {
 
-/// Packager is a class that packages materials into discrete items in ways that mimic realistic nuclear material handling. Packages will eventually be a required parameter of resources.
+/// Packager is a class that packages materials into discrete items in ways 
+// that mimic realistic nuclear material handling. Package is a parameter
+// of materials and products, with default unpackaged
 class Package {
   public:
     typedef boost::shared_ptr<Package> Ptr;
@@ -68,35 +70,40 @@ class Package {
     std::string strategy_;
 };
 
+/// TransportUnit is a class that can be used in conjunction with packages to
+/// restrict the amount of material that can be traded between facilities.
+/// Unlike Packages, TransportUnits are not a property of resources. They are
+/// simply applied at the response to request for bids phase and then the trade
+/// execution to determine whether the available number of packages is 
+/// allowable given the TransportUnit parameters. Default is unrestricted
 class TransportUnit {
   public:
     typedef boost::shared_ptr<TransportUnit> Ptr;
 
-    // create a new transport unit type. Should be called by the context only
-    // (see Context::AddTransportUnit), unless you want an untracked package
-    // type (which you probably don't)
+    /// create a new transport unit type. Should be called by the context only
+    /// (see Context::AddTransportUnit), unless you want an untracked transport
+    /// unit type (which you probably don't)
     static Ptr Create(std::string name, int fill_min = 0,
                       int fill_max = std::numeric_limits<int>::max(),
                       std::string strategy = "first");
 
-    /// Returns number of packages for 
+    /// Returns number of packages for each transport unit.
     /// Strategy "first" simply fill transport units one by one to max fill
     /// Strategy "equal" tries to fill all transport units with the
     /// same number of packages
     int GetTransportUnitFill(int qty);
 
-    /// Returns the max number of packages that can be shipped
+    /// Returns the max number of transport units that can be shipped from the 
+    /// available quantity
     int MaxShippablePackages(int pkgs);
 
-    // returns package id
-    int id() const { return id_; }
-    // returns package name
+    // returns transport unit name
     std::string name() const { return name_; }
-    // returns package fill min
+    // returns transport unit fill min
     int fill_min() const { return fill_min_; }
-    // returns package fill max
+    // returns transport unit fill max
     int fill_max() const { return fill_max_; }
-    // returns package strategy
+    // returns transport unit strategy
     std::string strategy() const { return strategy_; }
 
     // returns the unrestricted id (1)

--- a/src/package.h
+++ b/src/package.h
@@ -9,7 +9,7 @@
 
 namespace cyclus {
 
-/// Packager is a class that packages materials into discrete items in ways 
+/// Package is a class that packages materials into discrete items in ways 
 // that mimic realistic nuclear material handling. Package is a parameter
 // of materials and products, with default unpackaged
 class Package {

--- a/src/package.h
+++ b/src/package.h
@@ -76,6 +76,11 @@ class Package {
 /// simply applied at the response to request for bids phase and then the trade
 /// execution to determine whether the available number of packages is 
 /// allowable given the TransportUnit parameters. Default is unrestricted
+/// Strategy "first" simply fill transport units one by one to max fill
+/// Strategy "equal" tries to fill all transport units with the
+/// Strategy "hybrid" is iterative, recursively filling transport units
+/// with the max fill until the remaining quantity can be filled with the
+/// at least the min fill. This is the most efficient strategy
 class TransportUnit {
   public:
     typedef boost::shared_ptr<TransportUnit> Ptr;
@@ -88,8 +93,6 @@ class TransportUnit {
                       std::string strategy = "first");
 
     /// Returns number of packages for each transport unit.
-    /// Strategy "first" simply fill transport units one by one to max fill
-    /// Strategy "equal" tries to fill all transport units with the
     /// same number of packages
     int GetTransportUnitFill(int qty);
 
@@ -119,7 +122,7 @@ class TransportUnit {
     TransportUnit(std::string name, 
             int fill_min = 0, 
             int fill_max = std::numeric_limits<int>::max(), 
-            std::string strategy = "first");
+            std::string strategy = "hybrid");
 
     static const int unrestricted_id_ = 1;
     static constexpr char unrestricted_name_[13] = "unrestricted";

--- a/src/toolkit/matl_sell_policy.cc
+++ b/src/toolkit/matl_sell_policy.cc
@@ -66,7 +66,7 @@ void MatlSellPolicy::set_transport_unit(std::string x) {
     int max_shippable = tu->MaxShippablePackages(num_pkgs);
 
     if ((tu->name() != TransportUnit::unrestricted_name()) && quantize_ > 0 &&
-    (max_shippable != num_pkgs))  {
+        (max_shippable != num_pkgs))  {
       std::stringstream ss;
       ss << "Quantize " << quantize_ << " packages cannot be shipped according to transport unit fill min/max values (" << tu->fill_min() << ", "
        << tu->fill_max() << ")";
@@ -202,8 +202,8 @@ std::set<BidPortfolio<Material>::Ptr> MatlSellPolicy::GetMatlBids(
         bids.assign(n_full_bids, bid_qty);
 
         remaining_qty = fmod(qty, bid_qty);
-        if (!excl && (remaining_qty > 0) && 
-        (remaining_qty >= package_->fill_min())) {
+        if ((!excl) && (remaining_qty > 0) && 
+            (remaining_qty >= package_->fill_min())) {
           // leftover material is enough to fill one more partial package. Add
           // to bids
           bids.push_back(remaining_qty);

--- a/src/toolkit/matl_sell_policy.cc
+++ b/src/toolkit/matl_sell_policy.cc
@@ -213,9 +213,7 @@ std::set<BidPortfolio<Material>::Ptr> MatlSellPolicy::GetMatlBids(
       int shippable_pkgs = transport_unit_->MaxShippablePackages(bids.size());
       if (shippable_pkgs < bids.size()) {
         // can't ship all bids. Pop the extras.
-        for (int i=0; i<(bids.size() - shippable_pkgs); i++) {
-          bids.pop_back();
-        }
+        bids.erase(bids.begin() + shippable_pkgs, bids.end())
       }
 
       // Peek at resbuf to get current composition

--- a/src/toolkit/matl_sell_policy.cc
+++ b/src/toolkit/matl_sell_policy.cc
@@ -48,10 +48,10 @@ void MatlSellPolicy::set_package(std::string x) {
     Package::Ptr pkg = manager()->context()->GetPackage(x);
     double pkg_fill = pkg->GetFillMass(quantize_);
     if ((pkg->name() != Package::unpackaged_name()) && (quantize_ > 0) &&
-    (std::fmod(quantize_, pkg_fill) > 0)) { 
+        (std::fmod(quantize_, pkg_fill) > 0)) { 
       std::stringstream ss;
       ss << "Quantize " << quantize_ << " is not fully packagable based on fill min/max values (" 
-        << pkg->fill_min() << ", " << pkg->fill_max() << ")";
+         << pkg->fill_min() << ", " << pkg->fill_max() << ")";
       throw ValueError(ss.str());
     }
     package_ = pkg;

--- a/src/toolkit/matl_sell_policy.h
+++ b/src/toolkit/matl_sell_policy.h
@@ -85,7 +85,8 @@ class MatlSellPolicy : public Trader {
   MatlSellPolicy& Init(Agent* manager, ResBuf<Material>* buf, std::string name,
                        double throughput, bool ignore_comp,
                        double quantize,
-                       std::string package_name = Package::unpackaged_name());
+                       std::string package_name = Package::unpackaged_name(),
+                       std::string transport_unit_name = TransportUnit::unrestricted_name());
   /// @}
 
   /// Instructs the policy to empty its buffer with offers on the given
@@ -127,6 +128,7 @@ class MatlSellPolicy : public Trader {
   void set_throughput(double x);
   void set_ignore_comp(bool x);
   void set_package(std::string x);
+  void set_transport_unit(std::string x);
 
   ResBuf<Material>* buf_;
   std::set<std::string> commods_;
@@ -135,6 +137,7 @@ class MatlSellPolicy : public Trader {
   std::string name_;
   bool ignore_comp_;
   Package::Ptr package_;
+  TransportUnit::Ptr transport_unit_;
 };
 
 }  // namespace toolkit

--- a/src/xml_file_loader.cc
+++ b/src/xml_file_loader.cc
@@ -197,6 +197,7 @@ void XMLFileLoader::LoadSim() {
   LoadSolver();
   LoadRecipes();
   LoadPackages();
+  LoadTransportUnits();
   LoadSpecs();
   LoadInitialAgents();  // must be last
   SimInit::Snapshot(ctx_);
@@ -346,6 +347,24 @@ void XMLFileLoader::LoadPackages() {
 
     ctx_->AddPackage(name, fill_min, fill_max, strategy);
   }
+}
+
+void XMLFileLoader::LoadTransportUnits() {
+  InfileTree xqe(*parser_);
+
+  std::string query = "/*/transportunit";
+  int num_transport_units = xqe.NMatches(query);
+  for (int i = 0; i < num_transport_units; i++) {
+    InfileTree* qe = xqe.SubTree(query, i);
+    std::string name = cyclus::OptionalQuery<std::string>(qe, "name", "default");
+    CLOG(LEV_DEBUG3) << "loading transport unit: " << name;
+    
+    double fill_min = cyclus::OptionalQuery<double>(qe, "fill_min", eps());
+    double fill_max = cyclus::OptionalQuery<double>(qe, "fill_max", std::numeric_limits<double>::max());
+    
+    std::string strategy = cyclus::OptionalQuery<std::string>(qe, "strategy", "first");
+
+    ctx_->AddTransportUnit(name, fill_min, fill_max, strategy);
 }
 
 void XMLFileLoader::LoadSpecs() {

--- a/src/xml_file_loader.cc
+++ b/src/xml_file_loader.cc
@@ -365,6 +365,7 @@ void XMLFileLoader::LoadTransportUnits() {
     std::string strategy = cyclus::OptionalQuery<std::string>(qe, "strategy", "first");
 
     ctx_->AddTransportUnit(name, fill_min, fill_max, strategy);
+  }
 }
 
 void XMLFileLoader::LoadSpecs() {

--- a/src/xml_file_loader.h
+++ b/src/xml_file_loader.h
@@ -85,6 +85,9 @@ class XMLFileLoader {
   /// Loads packages
   void LoadPackages();
 
+  /// Loads Transport Units
+  void LoadTransportUnits();
+
   /// Creates all initial agent instances from the input file.
   virtual void LoadInitialAgents();
 

--- a/tests/context_tests.cc
+++ b/tests/context_tests.cc
@@ -136,3 +136,15 @@ TEST_F(ContextTests, DoublePackageNameThrow) {
   
   delete ctx;
   }
+
+TEST_F(ContextTests, DoubleTransportUnitNameThrow) {
+  Timer ti;
+  Recorder rec;
+  Context* ctx = new Context(&ti, &rec);
+
+  ctx->AddTransportUnit("foo");
+
+  ASSERT_THROW(ctx->AddTransportUnit("foo"), cyclus::KeyError);
+  
+  delete ctx;
+  }

--- a/tests/package_tests.cc
+++ b/tests/package_tests.cc
@@ -159,35 +159,58 @@ TEST(PackageTests, GetTransportUnitFillMass) {
 }
 
 TEST(PackageTests, MaxShippablePackages) {
-    int pq_min = 3;
-    int pq_max = 4;
-    int r_min = 6;
-    int r_max = 8;
-    TransportUnit::Ptr p = TransportUnit::Create("foo", pq_min, pq_max, "first");
-    TransportUnit::Ptr q = TransportUnit::Create("bar", pq_min, pq_max, "equal");
-    TransportUnit::Ptr r = TransportUnit::Create("baz", r_min, r_max, "equal");
+    int p_min = 3;
+    int p_max = 4;
+    int q_min = 6;
+    int q_max = 8;
+    TransportUnit::Ptr p_first = TransportUnit::Create("foo", p_min, p_max, "first");
+    TransportUnit::Ptr p_equal = TransportUnit::Create("bar", p_min, p_max, "equal");
+    TransportUnit::Ptr p_hybrid = TransportUnit::Create("baz", p_min, p_max, "hybrid");
 
+    TransportUnit::Ptr q_first = TransportUnit::Create("foobar", q_min, q_max, "first");
+    TransportUnit::Ptr q_equal = TransportUnit::Create("foobaz", q_min, q_max, "equal");
+    TransportUnit::Ptr q_hybrid = TransportUnit::Create("foobaz", q_min, q_max, "hybrid");
+    
     int exp;
 
     int none_fit = 2;
-    EXPECT_EQ(0, p->MaxShippablePackages(none_fit));
-    EXPECT_EQ(0, q->MaxShippablePackages(none_fit));
-    EXPECT_EQ(0, r->MaxShippablePackages(none_fit));
+    EXPECT_EQ(0, p_first->MaxShippablePackages(none_fit));
+    EXPECT_EQ(0, p_equal->MaxShippablePackages(none_fit));
+    EXPECT_EQ(0, p_hybrid->MaxShippablePackages(none_fit));
+    EXPECT_EQ(0, q_first->MaxShippablePackages(none_fit));
+    EXPECT_EQ(0, q_equal->MaxShippablePackages(none_fit));
+    EXPECT_EQ(0, q_hybrid->MaxShippablePackages(none_fit));
 
     int all_fit = 8;
-    EXPECT_EQ(all_fit, p->MaxShippablePackages(all_fit));
-    EXPECT_EQ(all_fit, q->MaxShippablePackages(all_fit));
-    EXPECT_EQ(all_fit, r->MaxShippablePackages(all_fit));
+    EXPECT_EQ(all_fit, p_first->MaxShippablePackages(all_fit));
+    EXPECT_EQ(all_fit, p_equal->MaxShippablePackages(all_fit));
+    EXPECT_EQ(all_fit, q_first->MaxShippablePackages(all_fit));
+    EXPECT_EQ(all_fit, q_equal->MaxShippablePackages(all_fit));
+    EXPECT_EQ(all_fit, q_hybrid->MaxShippablePackages(all_fit));
 
-    // all can ship for p/q, but will go 4-3-3, only 8 ship for r
+    // all can ship for p_hybrid, but will go 4-3-3. Only 8 ship for other
     int partial = 10; 
-    EXPECT_EQ(pq_max * 2, p->MaxShippablePackages(partial));
-    EXPECT_EQ(partial, q->MaxShippablePackages(partial));
-    EXPECT_EQ(r_max, r->MaxShippablePackages(partial));
+    EXPECT_EQ(p_max * 2, p_first->MaxShippablePackages(partial));
+    EXPECT_EQ(p_min * 3, p_equal->MaxShippablePackages(partial));
+    EXPECT_EQ(partial, p_hybrid->MaxShippablePackages(partial));
+    EXPECT_EQ(q_max, q_first->MaxShippablePackages(partial));
+    EXPECT_EQ(q_max, q_equal->MaxShippablePackages(partial));
+    EXPECT_EQ(q_max, q_hybrid->MaxShippablePackages(partial));
 
-    int partial2 = 14;
-    EXPECT_EQ(pq_max * 3, p->MaxShippablePackages(partial2));
-    EXPECT_EQ(partial2, q->MaxShippablePackages(partial2));
-    EXPECT_EQ(partial2, r->MaxShippablePackages(partial2));
+    int partial2 = 14; // all ship p_hybrid. q, others ship 12. q_equal and 
+    // q_hybrid can ship all
+    EXPECT_EQ(p_max * 3, p_first->MaxShippablePackages(partial2));
+    EXPECT_EQ(p_max * 3, p_equal->MaxShippablePackages(partial2));
+    EXPECT_EQ(partial2, p_hybrid->MaxShippablePackages(partial2));
+    EXPECT_EQ(q_max, q_first->MaxShippablePackages(partial2));
+    EXPECT_EQ(partial2, q_equal->MaxShippablePackages(partial2));
+    EXPECT_EQ(partial2, q_hybrid->MaxShippablePackages(partial2));
 
+    int partial3 = 15; // all ship in hybrid and p_equal
+    EXPECT_EQ(p_max * 3, p_first->MaxShippablePackages(partial3));
+    EXPECT_EQ(partial3, p_equal->MaxShippablePackages(partial3));
+    EXPECT_EQ(partial3, p_hybrid->MaxShippablePackages(partial3));
+    EXPECT_EQ(q_max, q_first->MaxShippablePackages(partial3));
+    EXPECT_EQ((q_max-1) * 2, q_equal->MaxShippablePackages(partial3));
+    EXPECT_EQ(partial3, q_hybrid->MaxShippablePackages(partial3));
 }

--- a/tests/package_tests.cc
+++ b/tests/package_tests.cc
@@ -8,8 +8,9 @@
 #include "test_agents/test_facility.h"
 
 using cyclus::Package;
+using cyclus::TransportUnit;
 
-TEST(PackageTests, Create) {
+TEST(PackageTests, CreatePackage) {
 
     std::string p_exp_name = "foo";
     double exp_min = 0.1;
@@ -32,7 +33,7 @@ TEST(PackageTests, Create) {
 
 }
 
-TEST(PackageTests, UnpackagedID) {
+TEST(PackageTests, Unpackaged) {
     EXPECT_EQ("unpackaged", Package::unpackaged_name());
 }
 
@@ -46,14 +47,14 @@ TEST(PackageTests, InvalidPackage) {
     EXPECT_THROW(Package::Create("foo", 100, 1, "first"), cyclus::ValueError);
 }
 
-TEST(PackageTests, GetFillMass) {
+TEST(PackageTests, GetPackageFillMass) {
     double min = 0.3;
     double max = 0.9;
     double tight_min = 0.85;
 
     Package::Ptr p = Package::Create("foo", min, max, "first");
     Package::Ptr q = Package::Create("bar", min, max, "equal");
-    Package::Ptr r = Package::Create("bar", tight_min, max, "equal");
+    Package::Ptr r = Package::Create("baz", tight_min, max, "equal");
 
     double exp;
 
@@ -75,4 +76,118 @@ TEST(PackageTests, GetFillMass) {
     EXPECT_EQ(max, p->GetFillMass(two_packages));
     exp = two_packages / 2;
     EXPECT_EQ(exp, q->GetFillMass(two_packages));
+}
+
+TEST(PackageTests, CreateTransportUnit) {
+
+    std::string p_exp_name = "foo";
+    int exp_min = 0.1;
+    int exp_max = 0.9;
+    std::string exp_strat = "first";
+
+    TransportUnit::Ptr p = TransportUnit::Create(p_exp_name, exp_min, exp_max,
+                                                 exp_strat);
+
+    EXPECT_EQ(p_exp_name, p->name());
+    EXPECT_EQ(exp_min, p->fill_min());
+    EXPECT_EQ(exp_max, p->fill_max());
+    EXPECT_EQ(exp_strat, p->strategy());
+
+    EXPECT_NE(TransportUnit::unrestricted_name(), p->name());
+
+    std::string q_exp_name = "bar";
+    TransportUnit::Ptr q = TransportUnit::Create(q_exp_name, exp_min, exp_max,
+                                                 exp_strat);
+    EXPECT_NE(TransportUnit::unrestricted_name(), q->name());
+    EXPECT_NE(q->name(), p->name());
+}
+
+TEST(PackageTests, Unrestricted) {
+    EXPECT_EQ("unrestricted", TransportUnit::unrestricted_name());
+}
+
+TEST(PackageTests, InvalidTransportUnit) {
+    // can't create package with name "unrestricted"
+    EXPECT_THROW(TransportUnit::Create("unrestricted", 0, 1, "first"),
+                 cyclus::ValueError);
+    // can't have negative min/max
+    EXPECT_THROW(TransportUnit::Create("foo", -1, 1, "first"),
+                 cyclus::ValueError);
+    EXPECT_THROW(TransportUnit::Create("foo", 0, -1, "first"),
+                 cyclus::ValueError);
+    // can't have min bigger than max
+    EXPECT_THROW(TransportUnit::Create("foo", 100, 1, "first"),
+                 cyclus::ValueError);
+}
+
+TEST(PackageTests, GetTransportUnitFillMass) {
+    int min = 3;
+    int max = 9;
+    int tight_min = 8;
+
+    TransportUnit::Ptr p = TransportUnit::Create("foo", min, max, "first");
+    TransportUnit::Ptr q = TransportUnit::Create("bar", min, max, "equal");
+    TransportUnit::Ptr r = TransportUnit::Create("baz", tight_min, max, "equal");
+
+    double exp;
+
+    int no_fit = 1;
+    EXPECT_EQ(0, p->GetTransportUnitFill(no_fit));
+    EXPECT_EQ(0, q->GetTransportUnitFill(no_fit));
+    EXPECT_EQ(0, r->GetTransportUnitFill(no_fit));
+
+    int perfect_fit = 9;
+    EXPECT_EQ(perfect_fit, p->GetTransportUnitFill(perfect_fit));
+    EXPECT_EQ(perfect_fit, q->GetTransportUnitFill(perfect_fit));
+    EXPECT_EQ(perfect_fit, r->GetTransportUnitFill(perfect_fit));
+
+    int two_full_packages = 18;
+    EXPECT_EQ(max, p->GetTransportUnitFill(perfect_fit));
+    EXPECT_EQ(max, q->GetTransportUnitFill(perfect_fit));
+    EXPECT_EQ(max, r->GetTransportUnitFill(perfect_fit));
+
+    int partial_fit = 11;
+    EXPECT_EQ(max, p->GetTransportUnitFill(partial_fit));
+    exp = std::floor(partial_fit / 2);
+    EXPECT_EQ(exp, q->GetTransportUnitFill(partial_fit));
+    EXPECT_EQ(max, r->GetTransportUnitFill(partial_fit));
+
+    int two_partial_packages = 17;
+    EXPECT_EQ(max, p->GetTransportUnitFill(two_partial_packages));
+    exp = std::floor(two_partial_packages / 2);
+    EXPECT_EQ(exp, q->GetTransportUnitFill(two_partial_packages));
+}
+
+TEST(PackageTests, MaxShippablePackages) {
+    int pq_min = 3;
+    int pq_max = 4;
+    int r_min = 6;
+    int r_max = 8;
+    TransportUnit::Ptr p = TransportUnit::Create("foo", pq_min, pq_max, "first");
+    TransportUnit::Ptr q = TransportUnit::Create("bar", pq_min, pq_max, "equal");
+    TransportUnit::Ptr r = TransportUnit::Create("baz", r_min, r_max, "equal");
+
+    int exp;
+
+    int none_fit = 2;
+    EXPECT_EQ(0, p->MaxShippablePackages(none_fit));
+    EXPECT_EQ(0, q->MaxShippablePackages(none_fit));
+    EXPECT_EQ(0, r->MaxShippablePackages(none_fit));
+
+    int all_fit = 8;
+    EXPECT_EQ(all_fit, p->MaxShippablePackages(all_fit));
+    EXPECT_EQ(all_fit, q->MaxShippablePackages(all_fit));
+    EXPECT_EQ(all_fit, r->MaxShippablePackages(all_fit));
+
+    // all can ship for p/q, but will go 4-3-3, only 8 ship for r
+    int partial = 10; 
+    EXPECT_EQ(pq_max * 2, p->MaxShippablePackages(partial));
+    EXPECT_EQ(partial, q->MaxShippablePackages(partial));
+    EXPECT_EQ(r_max, r->MaxShippablePackages(partial));
+
+    int partial2 = 14;
+    EXPECT_EQ(pq_max * 3, p->MaxShippablePackages(partial2));
+    EXPECT_EQ(partial2, q->MaxShippablePackages(partial2));
+    EXPECT_EQ(partial2, r->MaxShippablePackages(partial2));
+
 }

--- a/tests/toolkit/matl_sell_policy_tests.cc
+++ b/tests/toolkit/matl_sell_policy_tests.cc
@@ -186,7 +186,6 @@ TEST_F(MatlSellPolicyTests, Package) {
   EXPECT_NO_THROW(sim.Run());
 
   QueryResult qr_trans = sim.db().Query("Transactions", NULL);
-  QueryResult qr_res = sim.db().Query("Resources", NULL);
   EXPECT_EQ(3, qr_trans.rows.size());
 
   EXPECT_EQ(0, qr_trans.GetVal<int>("Time", 0));
@@ -232,11 +231,11 @@ TEST_F(MatlSellPolicyTests, TransportUnit) {
 
   sim.context()->AddPackage("foo", 1, 2, "first");
   Package::Ptr p = sim.context()->GetPackage("foo");
-  sim.context()->AddTransportUnit("bar", 1, 2, "first");
+  sim.context()->AddTransportUnit("foo", 3, 3, "first");
   TransportUnit::Ptr tu = sim.context()->GetTransportUnit("foo");
 
   cyclus::toolkit::MatlSellPolicy sellpol;
-  sellpol.Init(fac, &buf, "buf", 4, false, 0, p->name(), tu->name())
+  sellpol.Init(fac, &buf, "buf", 10, false, 0, p->name(), tu->name())
           .Set("commod").Start();
 
   EXPECT_NO_THROW(sim.Run());

--- a/tests/toolkit/matl_sell_policy_tests.cc
+++ b/tests/toolkit/matl_sell_policy_tests.cc
@@ -242,8 +242,8 @@ TEST_F(MatlSellPolicyTests, TransportUnit) {
 
   sim.context()->AddPackage("foo", 1, 2, "first");
   Package::Ptr p = sim.context()->GetPackage("foo");
-  sim.context()->AddTransportUnit("foo", 3, 3, "first");
-  TransportUnit::Ptr tu = sim.context()->GetTransportUnit("foo");
+  sim.context()->AddTransportUnit("foo-truck", 3, 3, "first");
+  TransportUnit::Ptr tu = sim.context()->GetTransportUnit("foo-truck");
 
   cyclus::toolkit::MatlSellPolicy sellpol;
   sellpol.Init(fac, &buf, "buf", 10, false, 0, p->name(), tu->name())

--- a/tests/toolkit/matl_sell_policy_tests.cc
+++ b/tests/toolkit/matl_sell_policy_tests.cc
@@ -192,6 +192,7 @@ TEST_F(MatlSellPolicyTests, Package) {
   EXPECT_EQ(1, qr_trans.GetVal<int>("Time", 1));
   EXPECT_EQ(2, qr_trans.GetVal<int>("Time", 2));
 
+<<<<<<< Updated upstream
   std::vector<cyclus::Cond> conds;
   conds.push_back(cyclus::Cond("PackageName", "==", std::string("foo")));
   QueryResult qr_res = sim.db().Query("Resources", &conds);
@@ -199,6 +200,28 @@ TEST_F(MatlSellPolicyTests, Package) {
   EXPECT_EQ(2, qr_res.GetVal<double>("Quantity", 0));
   EXPECT_EQ(2, qr_res.GetVal<double>("Quantity", 1));
   EXPECT_EQ(1, qr_res.GetVal<double>("Quantity", 2));
+=======
+  // Resource 0 is the material of 5 that we first created. The first resource 
+  // is split into 3 and 2, then split again into 1 and 2
+  // the first resource split into 3 and 2. Resource 3/4 is split into 1 and 2
+  EXPECT_EQ(5, qr_res.GetVal<double>("Quantity", 0));
+
+  std::vector<double> pkg_first_split = {qr_res.GetVal<double>("Quantity", 1),
+                                         qr_res.GetVal<double>("Quantity", 2),
+  std::sort(pkg_first_split.begin(), pkg_first_split.end(),
+            std::greater<double>());
+  std::vector<double> exp_first = {3, 2};
+  
+  EXPECT_EQ(exp_first, pkgng_split);
+
+  std::vector<double> pkg_second_split = {qr_res.GetVal<double>("Quantity", 3),
+                                          qr_res.GetVal<double>("Quantity", 4)};
+  std::sort(pkg_second_split.begin(), pkg_second_split.end(), 
+            std::greater<double>());
+  std::vector<double> exp_second = {2, 1};
+
+  EXPECT_EQ(exp_second, pkg_second_split);
+>>>>>>> Stashed changes
 
   // All material should have been transacted, including the resource of size 1
   EXPECT_EQ(0, buf.quantity());

--- a/tests/toolkit/matl_sell_policy_tests.cc
+++ b/tests/toolkit/matl_sell_policy_tests.cc
@@ -162,7 +162,7 @@ TEST_F(MatlSellPolicyTests, Package) {
   
   sim.context()->AddPrototype(a->prototype(), a);
   sim.agent = sim.context()->CreateAgent<cyclus::Agent>(a->prototype());
-  sim.AddSink("commod").Finalize();
+  sim.AddSink("commod").capacity(2).Finalize();
   TestFacility* fac = dynamic_cast<TestFacility*>(sim.agent);
 
   cyclus::toolkit::ResBuf<cyclus::Material> buf;
@@ -190,16 +190,81 @@ TEST_F(MatlSellPolicyTests, Package) {
   EXPECT_EQ(3, qr_trans.rows.size());
 
   EXPECT_EQ(0, qr_trans.GetVal<int>("Time", 0));
-  EXPECT_EQ(0, qr_trans.GetVal<int>("Time", 1));
-  EXPECT_EQ(1, qr_trans.GetVal<int>("Time", 2));
+  EXPECT_EQ(1, qr_trans.GetVal<int>("Time", 1));
+  EXPECT_EQ(2, qr_trans.GetVal<int>("Time", 2));
 
-  // Resource 0 is the material of 5 that we first created. Resource 1/2 is 
-  // the first resource split into 3 and 2. Resource 3/4 is split into 1 and 2
-  EXPECT_NEAR(2, qr_res.GetVal<double>("Quantity", 2), 0.00001);
-  EXPECT_NEAR(2, qr_res.GetVal<double>("Quantity", 4), 0.00001);
+  std::vector<cyclus::Cond> conds;
+  conds.push_back(cyclus::Cond("PackageName", "==", std::string("foo")));
+  QueryResult qr_res = sim.db().Query("Resources", &conds);
+  EXPECT_EQ(qr_res.rows.size(), 3);
+  EXPECT_EQ(2, qr_res.GetVal<double>("Quantity", 0));
+  EXPECT_EQ(2, qr_res.GetVal<double>("Quantity", 1));
+  EXPECT_EQ(1, qr_res.GetVal<double>("Quantity", 2));
 
   // All material should have been transacted, including the resource of size 1
   EXPECT_EQ(0, buf.quantity());
 }
+
+TEST_F(MatlSellPolicyTests, TransportUnit) {
+  using cyclus::QueryResult;
+
+  int dur = 5;
+  double throughput = 1;
+
+  cyclus::MockSim sim(dur);
+  cyclus::Agent* a = new TestFacility(sim.context());
+  
+  sim.context()->AddPrototype(a->prototype(), a);
+  sim.agent = sim.context()->CreateAgent<cyclus::Agent>(a->prototype());
+  sim.AddSink("commod").Finalize();
+  TestFacility* fac = dynamic_cast<TestFacility*>(sim.agent);
+
+  cyclus::toolkit::ResBuf<cyclus::Material> buf;
+
+  double qty = 5;
+  CompMap cm;
+  cm[922350000] = 0.05;
+  cm[922380000] = 0.95;
+  Composition::Ptr comp = Composition::CreateFromMass(cm);
+  mat = Material::Create(a, qty, comp, Package::unpackaged_name());
+
+  buf.Push(mat);
+
+  sim.context()->AddPackage("foo", 1, 2, "first");
+  Package::Ptr p = sim.context()->GetPackage("foo");
+  sim.context()->AddTransportUnit("bar", 1, 2, "first");
+  TransportUnit::Ptr tu = sim.context()->GetTransportUnit("foo");
+
+  cyclus::toolkit::MatlSellPolicy sellpol;
+  sellpol.Init(fac, &buf, "buf", 4, false, 0, p->name(), tu->name())
+          .Set("commod").Start();
+
+  EXPECT_NO_THROW(sim.Run());
+
+  QueryResult qr_trans = sim.db().Query("Transactions", NULL);
+  EXPECT_EQ(3, qr_trans.rows.size());
+
+  EXPECT_EQ(0, qr_trans.GetVal<int>("Time", 0));
+  EXPECT_EQ(0, qr_trans.GetVal<int>("Time", 1));
+  EXPECT_EQ(0, qr_trans.GetVal<int>("Time", 2));
+
+  // the order of trades that happen in the same time step is not guaranteed,
+  // so we can't use database order to confirm which resource (sizes 2, 2, 1)
+  // will appear in which order. Thus make a set, sort high-low, then compare
+  std::vector<cyclus::Cond> conds;
+  conds.push_back(cyclus::Cond("PackageName", "==", std::string("foo")));
+  QueryResult qr_res = sim.db().Query("Resources", &conds);
+  std::vector<double> pkgd_trades = {qr_res.GetVal<double>("Quantity", 0),
+                                     qr_res.GetVal<double>("Quantity", 1),
+                                     qr_res.GetVal<double>("Quantity", 2)};
+
+  std::sort(pkgd_trades.begin(), pkgd_trades.end(), std::greater<double>());
+  std::vector<double> exp = {2, 2, 1};
+  EXPECT_EQ(exp, pkgd_trades);
+
+  // All material should have been transacted, including the resource of size 1
+  EXPECT_EQ(0, buf.quantity());
+}
+
 }
 }

--- a/tests/toolkit/matl_sell_policy_tests.cc
+++ b/tests/toolkit/matl_sell_policy_tests.cc
@@ -192,36 +192,24 @@ TEST_F(MatlSellPolicyTests, Package) {
   EXPECT_EQ(1, qr_trans.GetVal<int>("Time", 1));
   EXPECT_EQ(2, qr_trans.GetVal<int>("Time", 2));
 
-<<<<<<< Updated upstream
+  // Resource 0 is the material of 5 that we first created. 
+  QueryResult qr_all_res = sim.db().Query("Resources", NULL);
+  EXPECT_EQ(5, qr_all_res.GetVal<double>("Quantity", 0));
+
+  // Then check that three packaged materials were created of size 2, 2, and 1
   std::vector<cyclus::Cond> conds;
   conds.push_back(cyclus::Cond("PackageName", "==", std::string("foo")));
-  QueryResult qr_res = sim.db().Query("Resources", &conds);
-  EXPECT_EQ(qr_res.rows.size(), 3);
-  EXPECT_EQ(2, qr_res.GetVal<double>("Quantity", 0));
-  EXPECT_EQ(2, qr_res.GetVal<double>("Quantity", 1));
-  EXPECT_EQ(1, qr_res.GetVal<double>("Quantity", 2));
-=======
-  // Resource 0 is the material of 5 that we first created. The first resource 
-  // is split into 3 and 2, then split again into 1 and 2
-  // the first resource split into 3 and 2. Resource 3/4 is split into 1 and 2
-  EXPECT_EQ(5, qr_res.GetVal<double>("Quantity", 0));
+  QueryResult qr_pkgd_res = sim.db().Query("Resources", &conds);
+  EXPECT_EQ(qr_pkgd_res.rows.size(), 3);
 
-  std::vector<double> pkg_first_split = {qr_res.GetVal<double>("Quantity", 1),
-                                         qr_res.GetVal<double>("Quantity", 2),
-  std::sort(pkg_first_split.begin(), pkg_first_split.end(),
-            std::greater<double>());
-  std::vector<double> exp_first = {3, 2};
-  
-  EXPECT_EQ(exp_first, pkgng_split);
+  std::vector<double> pkged_res = {qr_pkgd_res.GetVal<double>("Quantity", 0),
+                                   qr_pkgd_res.GetVal<double>("Quantity", 1),
+                                   qr_pkgd_res.GetVal<double>("Quantity", 2)};
+  std::sort(pkged_res.begin(), pkged_res.end(), std::greater<double>());
 
-  std::vector<double> pkg_second_split = {qr_res.GetVal<double>("Quantity", 3),
-                                          qr_res.GetVal<double>("Quantity", 4)};
-  std::sort(pkg_second_split.begin(), pkg_second_split.end(), 
-            std::greater<double>());
-  std::vector<double> exp_second = {2, 1};
+  std::vector<double> exp = {2, 2, 1};
 
-  EXPECT_EQ(exp_second, pkg_second_split);
->>>>>>> Stashed changes
+  EXPECT_EQ(exp, pkged_res);
 
   // All material should have been transacted, including the resource of size 1
   EXPECT_EQ(0, buf.quantity());

--- a/tests/xml_file_loader_tests.cc
+++ b/tests/xml_file_loader_tests.cc
@@ -243,10 +243,15 @@ std::string XMLFileLoaderTests::PackageSequence() {
           " <control>"
           "  <package>"
           "    <name>TestPackage</name>"
+          "    <fill_min>1.1</fill_min>"
+          "    <fill_max>2.1</fill_max>"
+          "    <strategy>First</strategy>"
+          "  </package>"
+          "  <transportunit>"
+          "    <name>TestTransport</name>"
           "    <fill_min>1</fill_min>"
           "    <fill_max>2</fill_max>"
           "    <strategy>First</strategy>"
-          "  </package>"
           " </control>"
           "</simulation>";
 }


### PR DESCRIPTION
Creates new class, `TransportUnit`. Builds on `Package`s, intended to be used to restrict trading to an integer number of packages to mimic a second layer of containerization, such as a truck that holds fuel assembly packages, or a barge that holds spent fuel casks.

Simpler implementation than packages, because transport units are *not* a fundamental property of materials/products, unlike packages. They will be simply applied at the response to request for bids step in `MatlSellPolicy` to make sure that a packages are being shipped in reasonable quantities. For example, shipping 24 UOC drums together instead of shipping 1 drum at a time.

Closes #1660 
Closes #1661
Closes #1624 
Closes #1625 
Closes #1662 