### PR TITLE
Remove GTest source from code coverage

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,10 @@ Since last release
 * Removed the ResourceBuff class and replaced its instances with ResBuf (#1755)
 
 **Fixed:**
+
 * Removed unnecessary records being added to the Resource database by packaging process (#1761)
+* Removed GTest source code from code coverage reports (#1759)
+
 
 v1.6.0
 ====================

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -110,7 +110,7 @@ RUN lcov -c -d /cyclus -o initial_coverage.info --gcov-tool ${GCOV} --initial --
     cd tests && python3 -m pytest && cd .. && \
     lcov -c -d /cyclus -o test_coverage.info --gcov-tool ${GCOV} --no-external && \
     lcov --add-tracefile initial_coverage.info --add-tracefile test_coverage.info -o temp_coverage.info && \
-    lcov --remove temp_coverage.info -o total_coverage.info '/cyclus/build/_deps/**'
+    lcov --remove temp_coverage.info -o total_coverage.info '/cyclus/build/_deps/**' && \
     mkdir -p html && genhtml total_coverage.info --output-directory html
 
 FROM scratch as coverage-report

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -105,13 +105,13 @@ WORKDIR /cyclus
 RUN python3 install.py -j ${make_cores} --allow-milps --code-coverage
 
 ENV PATH /root/.local/bin:$PATH
-ENV LD_LIBRARY_PATH /root/.local/lib:/root/.local/lib/cyclus
 RUN lcov -c -d /cyclus -o initial_coverage.info --gcov-tool ${GCOV} --initial --no-external && \
     cyclus_unit_tests && \
     cd tests && python3 -m pytest && cd .. && \
     lcov -c -d /cyclus -o test_coverage.info --gcov-tool ${GCOV} --no-external && \
     lcov --add-tracefile initial_coverage.info --add-tracefile test_coverage.info -o total_coverage.info && \
-    mkdir -p html && genhtml total_coverage.info --output-directory html
+    lcov --remove total_coverage.info -o filtered_coverage.info '/cyclus/build/_deps/**'
+    mkdir -p html && genhtml filtered_coverage.info --output-directory html
 
 FROM scratch as coverage-report
 COPY --from=cyclus-coverage /cyclus /

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -109,9 +109,9 @@ RUN lcov -c -d /cyclus -o initial_coverage.info --gcov-tool ${GCOV} --initial --
     cyclus_unit_tests && \
     cd tests && python3 -m pytest && cd .. && \
     lcov -c -d /cyclus -o test_coverage.info --gcov-tool ${GCOV} --no-external && \
-    lcov --add-tracefile initial_coverage.info --add-tracefile test_coverage.info -o total_coverage.info && \
-    lcov --remove total_coverage.info -o filtered_coverage.info '/cyclus/build/_deps/**'
-    mkdir -p html && genhtml filtered_coverage.info --output-directory html
+    lcov --add-tracefile initial_coverage.info --add-tracefile test_coverage.info -o temp_coverage.info && \
+    lcov --remove temp_coverage.info -o total_coverage.info '/cyclus/build/_deps/**'
+    mkdir -p html && genhtml total_coverage.info --output-directory html
 
 FROM scratch as coverage-report
 COPY --from=cyclus-coverage /cyclus /


### PR DESCRIPTION
Removes the `build/_deps/` directory from coverage reports.  When CMake fetches the GTest source this is where it is placed.