### PR TITLE
Prevent extra unecessary records in resources database due to packaging

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,7 @@ Since last release
 * Removed the ResourceBuff class and replaced its instances with ResBuf (#1755)
 
 **Fixed:**
-
+* Removed unnecessary records being added to the Resource database by packaging process (#1761)
 
 v1.6.0
 ====================

--- a/src/res_tracker.cc
+++ b/src/res_tracker.cc
@@ -45,15 +45,17 @@ void ResTracker::Extract(ResTracker* removed) {
     return;
   }
 
-  parent1_ = res_->state_id();
-  parent2_ = 0;
+  if (res_->quantity() > eps_rsrc()) {
+    parent1_ = res_->state_id();
+    parent2_ = 0;
+    
+    Record();
+  }
+  
   removed->parent1_ = res_->state_id();
   removed->parent2_ = 0;
   removed->tracked_ = tracked_;
 
-  if (res_->quantity() > eps_rsrc()) {
-    Record();
-  }
   removed->Record();
 }
 

--- a/src/res_tracker.cc
+++ b/src/res_tracker.cc
@@ -1,6 +1,7 @@
 #include "res_tracker.h"
 
 #include "recorder.h"
+#include "cyc_limits.h"
 
 namespace cyclus {
 
@@ -50,7 +51,9 @@ void ResTracker::Extract(ResTracker* removed) {
   removed->parent2_ = 0;
   removed->tracked_ = tracked_;
 
-  Record();
+  if (res_->quantity() > eps_rsrc()) {
+    Record();
+  }
   removed->Record();
 }
 


### PR DESCRIPTION
Closes #1760 
Solves root cause issue of [cycamore#611](https://github.com/cyclus/cycamore/issues/611)

Two changes arose out of #1749
1. When materials were fully packaged, the now-zero-quantity old material was recorded as a new resource in the table, even though it was fully absorbed into the new packaged material. This created unexpected zero quantity lines in the Resources database
2. When materials were effectively not packaged (i.e. unpackaged, or going through packaging with the new packaging type equal to the old type), they were still being "packaged" in the sense that they became new resources, with new resource ids and records in the Resources database. The material sell policy would package all trades, meaning that even when packaging wasn't being used, resources were getting bumped with new state ids every time they exited an agent using the policy

This PR solves both of those issues