### PR TITLE
Use miniforge instead of miniconda

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Since last release
 * Remove ``pandas`` as build dependency (#1748)
 * Consistently use hyphens in ``install.py`` flags (#1748)
 * Material sell policy can package materials (#1749)
+* Use miniforge for conda CI builds instead of miniconda (#1763)
 
 **Removed:**
 
@@ -28,13 +29,13 @@ v1.6.0
 **Added:**
 
 * adding compatibility with cbc 2.10 (#1557)
-* In `src/pyne.h`, replace a macro `isnan()` with `using std::isnan`, 
+* In `src/pyne.h`, replace a macro `isnan()` with `using std::isnan`,
   as the former has led to undesired macro expansion in Boost header files. (#1560)
 * updated cyclus_nuc_data.h5 URL after Dory retirement (#1567)
 * now default quantize are zero which corresponds to no quantize policy. (#1552)
-* Added several lines to DEPENDENCIES.rst to explain that even when using a 
-  machine with a single python3 install (such as a fresh Ubuntu 20.04), install 
-  will fail unless update-alternatives has been used to point python at the 
+* Added several lines to DEPENDENCIES.rst to explain that even when using a
+  machine with a single python3 install (such as a fresh Ubuntu 20.04), install
+  will fail unless update-alternatives has been used to point python at the
   correct python3 version (#1558)
 * build and test are now fown on githubAction in place or CircleCI (#1569)
 * Have separate workflows for testing, publishing dependency images, and publishing release images (#1597, #1602, #1606, #1609, #1629, #1633, #1637, #1668, #1672, #1676, #1708)
@@ -47,7 +48,7 @@ v1.6.0
 * Adds support for Cython3 (#1636)
 * Adds TotalInvTracker, which allows an inventory cap to be set for multiple resource buffers, and is now required for material buy policy (#1646)
 * AddMutalReqs and AddReciepe functions and exclusive bids in python API of DRE (#1584)
-* Created Package class and optional declaration of packages in input files (#1673, #1699, #1712, #1729), package id is default unpackaged (#1711) and is a member of 
+* Created Package class and optional declaration of packages in input files (#1673, #1699, #1712, #1729), package id is default unpackaged (#1711) and is a member of
   resources (materials/products) (#1675). Can pop resources as packaged from resource buffer, pushing resource onto a buffer defaults to stripping packaging (#1683)
 * CI support for Rocky Linux (#1691)
 * Added support for a ResBuf to behave as a single bulk storage with mixing & extraction of resources (#1687)
@@ -62,18 +63,18 @@ v1.6.0
 * Resolved various compilation warnings due to use of deprecated APIs (#1671)
 * Update version management in CMake build (#1696)
 * Changed dependency versions in README.rst, INSTALL.rst, and DEPENDENCIES.rst (#1703, #1735)
-* Updated minor documentation about updating CHANGELOG.rst, fix formatting for rendering 
+* Updated minor documentation about updating CHANGELOG.rst, fix formatting for rendering
   hyperlinks, and change branch name in README instructions on forking for development (#1715)
 * Updated GTest suite to be fetched from GitHub during the build process (#1738)
 * Default to building a Release version of Cyclus when installing via the python script (#1741)
 
 **Removed:**
 
-* A duplicate `using std::list` in `src/hdf5_back.cc.in`, which triggers compiler 
+* A duplicate `using std::list` in `src/hdf5_back.cc.in`, which triggers compiler
   errors with some GCC versions. (#1560)
-* Removed deprecated `smbchk.py` ABI consistency checking functionality and tests (#1706). This functionality was 
-  originally deprecated in #1396, and is removed in #1706 to clean up deprecated functionality 
-  with the pending v1.6 release. 
+* Removed deprecated `smbchk.py` ABI consistency checking functionality and tests (#1706). This functionality was
+  originally deprecated in #1396, and is removed in #1706 to clean up deprecated functionality
+  with the pending v1.6 release.
 
 **Fixed:**
 
@@ -140,7 +141,7 @@ v1.5.4
   variables for these classes are ``MaterialStateVar`` and ``ProductStateVar``.
 * Added the Decision Phase. This phase occurs after the tock phase and allows
   cyclus agents to make decisions based on what has occured during the
-  tick and tock phase of the current timestep. 
+  tick and tock phase of the current timestep.
 
 
 **Changed:**
@@ -157,7 +158,7 @@ v1.5.4
   Cython.
 * Updated cycstub readme to reflect changes
 * Updated the record time series function to also include the name of the field being
-  recorded. 
+  recorded.
 
 
 
@@ -240,7 +241,3 @@ v1.5.2
 * Fixed issue with Python agent prototypes not being registered correctly when created.
   This caused segfaults due the the agents being deallocated too soon.
 * Fixed many issues with institution kinds checking "Institution", rather than "Inst".
-
-
-
-

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,16 +48,15 @@ RUN apt update -y && apt install -y \
     && apt clean -y all
 
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
-    wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
-    /bin/bash ~/miniconda.sh -b -p /opt/conda && \
-    rm ~/miniconda.sh
+    wget --quiet "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" -O ~/miniforge.sh && \
+    /bin/bash ~/miniforge.sh -b -p /opt/conda && \
+    rm ~/miniforge.sh
 
 ENV PATH /opt/conda/bin:$PATH
-
-RUN conda config --add channels conda-forge
-RUN conda update -n base -c conda-forge conda
-RUN conda update -y --all && \
-    conda install -y \
+RUN mamba update -n base conda mamba && \
+    mamba update -y python --no-pin && \
+    mamba update -y --all && \
+    mamba install -y \
                gxx_linux-64 \
                gcc_linux-64 \
                cmake \
@@ -83,9 +82,8 @@ RUN conda update -y --all && \
                pprintpp \
                pip \
                && \
-    conda install -y --force-reinstall libsqlite libexpat && \
-    conda clean -y --all
-RUN mkdir -p `python3 -m site --user-site`
+    mamba clean -y --all
+RUN mkdir -p $(python3 -m site --user-site)
 ENV CC /opt/conda/bin/x86_64-conda-linux-gnu-gcc
 ENV CXX /opt/conda/bin/x86_64-conda-linux-gnu-g++
 ENV CPP /opt/conda/bin/x86_64-conda-linux-gnu-cpp
@@ -95,7 +93,7 @@ RUN apt install -y lcov curl
 ENV GCOV /usr/bin/gcov
 
 FROM conda-deps as conda-coverage-deps
-RUN conda install -y lcov curl
+RUN mamba install -y lcov curl
 ENV GCOV /opt/conda/bin/x86_64-conda-linux-gnu-gcov
 
 FROM ${pkg_mgr}-coverage-deps as cyclus-coverage

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,13 +26,13 @@ RUN apt update -y && apt install -y \
         libsqlite3-dev \
         libpcre2-dev \
         python3-setuptools \
-        python3-pytest \ 
+        python3-pytest \
         python3-tables \
         python3-pandas \
         python3-jinja2 \
         python3-pip \
         cython3 \
-        libwebsockets-dev 
+        libwebsockets-dev
 
 RUN apt install -y python3-pprintpp; exit 0
 RUN apt clean -y all
@@ -55,14 +55,9 @@ RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
 ENV PATH /opt/conda/bin:$PATH
 
 RUN conda config --add channels conda-forge
-RUN conda update -n base -c defaults conda
-RUN conda install -y conda-libmamba-solver
-RUN conda config --set solver libmamba
-RUN conda install -y mamba
-RUN conda uninstall -y conda-libmamba-solver
-RUN conda config --set solver classic
+RUN conda update -n base -c conda-forge conda
 RUN conda update -y --all && \
-    mamba install -y \
+    conda install -y \
                gxx_linux-64 \
                gcc_linux-64 \
                cmake \
@@ -88,19 +83,19 @@ RUN conda update -y --all && \
                pprintpp \
                pip \
                && \
-    mamba install -y --force-reinstall libsqlite && \
+    conda install -y --force-reinstall libsqlite libexpat && \
     conda clean -y --all
 RUN mkdir -p `python3 -m site --user-site`
-ENV CC /opt/conda/bin/x86_64-conda_cos6-linux-gnu-gcc
-ENV CXX /opt/conda/bin/x86_64-conda_cos6-linux-gnu-g++
-ENV CPP /opt/conda/bin/x86_64-conda_cos6-linux-gnu-cpp
+ENV CC /opt/conda/bin/x86_64-conda-linux-gnu-gcc
+ENV CXX /opt/conda/bin/x86_64-conda-linux-gnu-g++
+ENV CPP /opt/conda/bin/x86_64-conda-linux-gnu-cpp
 
 FROM apt-deps as apt-coverage-deps
 RUN apt install -y lcov curl
 ENV GCOV /usr/bin/gcov
 
 FROM conda-deps as conda-coverage-deps
-RUN mamba install -y lcov curl
+RUN conda install -y lcov curl
 ENV GCOV /opt/conda/bin/x86_64-conda-linux-gnu-gcov
 
 FROM ${pkg_mgr}-coverage-deps as cyclus-coverage


### PR DESCRIPTION
Closes #1762.

Looks like a forced reinstall of libexpat resolves the issue.  This PR also changes the build to use conda-forge::conda which should be more up to date and uses libmamba as the solver by default (can confirm via `conda info`)

One other change - we were using the compilers intended for CentOS.  Now we reference the generic compilers instead.