### PR TITLE
warning and limit for splitting resources into too many packages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Since last release
 * Consistently use hyphens in ``install.py`` flags (#1748)
 * Material sell policy can package materials (#1749)
 * Use miniforge for conda CI builds instead of miniconda (#1763)
+* Warning and limits on number of packages that can be created from a resource at once (#1771)
 
 **Removed:**
 

--- a/src/package.h
+++ b/src/package.h
@@ -55,6 +55,14 @@ class Package {
     // returns the unpackaged singleton object
     static Ptr& unpackaged();
 
+    // When a resource is split into individual items, warn when more than 
+    // one million items are trying to be created at once
+    static int SplitWarn() { return 1000000; }
+
+    // Numeric limits for splitting resources is based on vector limits and 
+    // memory constraints. Use unsigned int max / 10 to be safe
+    static int SplitLimit() { return std::numeric_limits<unsigned int>::max() / 10; }
+
   private:
     Package(std::string name, 
             double fill_min = 0, 

--- a/src/package.h
+++ b/src/package.h
@@ -1,6 +1,8 @@
 #ifndef CYCLUS_SRC_PACKAGE_H_
 #define CYCLUS_SRC_PACKAGE_H_
 
+#include <iostream>
+
 #include <limits>
 #include <string>
 #include <vector>
@@ -60,8 +62,10 @@ class Package {
     static int SplitWarn() { return 1000000; }
 
     // Numeric limits for splitting resources is based on vector limits and 
-    // memory constraints. Use unsigned int max / 10 to be safe
-    static int SplitLimit() { return std::numeric_limits<unsigned int>::max() / 10; }
+    // memory constraints. Use unsigned int max / 100 to be safe
+    static int SplitLimit() { 
+      return (std::numeric_limits<unsigned int>::max() / 10); 
+    }
 
   private:
     Package(std::string name, 

--- a/src/package.h
+++ b/src/package.h
@@ -57,7 +57,7 @@ class Package {
 
     // When a resource is split into individual items, warn when more than 
     // one million items are trying to be created at once
-    static int SplitWarn() { return 1000000; }
+    static int SplitWarn() { return 100000; }
 
     // Numeric limits for splitting resources is based on vector limits and 
     // memory constraints. Use unsigned int max / 100 to be safe

--- a/src/package.h
+++ b/src/package.h
@@ -1,8 +1,6 @@
 #ifndef CYCLUS_SRC_PACKAGE_H_
 #define CYCLUS_SRC_PACKAGE_H_
 
-#include <iostream>
-
 #include <limits>
 #include <string>
 #include <vector>

--- a/src/resource.h
+++ b/src/resource.h
@@ -5,8 +5,6 @@
 #include <vector>
 #include <boost/shared_ptr.hpp>
 
-#include "error.h"
-#include "logger.h"
 #include "package.h"
 
 class SimInitTest;
@@ -139,17 +137,10 @@ std::vector<typename T::Ptr> Resource::Package(Package::Ptr pkg) {
     return ts_pkgd;
   }
 
-  int approx_num_pkgs = quantity() / fill_mass;
   // Check if the number of packages is within the limits, including if
   // int overflow is reached
-  if (approx_num_pkgs > Package::SplitLimit() || approx_num_pkgs == std::numeric_limits<int>::min()) {
-    throw ValueError("Resource::Package() cannot package into more than " + 
-                     std::to_string(Package::SplitLimit()) + 
-                     " items at once.");
-  } else if (approx_num_pkgs > Package::SplitWarn()) {
-    CLOG(cyclus::LEV_INFO1) << "Resource::Package() is attempting to package into " 
-                           << approx_num_pkgs << " items at once, is this intended?";
-  }
+  int approx_num_pkgs = quantity() / fill_mass;
+  Package::ExceedsSplitLimits(approx_num_pkgs);
 
   while (quantity() > 0 && quantity() >= pkg->fill_min()) {
     double pkg_fill = std::min(quantity(), fill_mass);

--- a/src/resource.h
+++ b/src/resource.h
@@ -138,6 +138,16 @@ std::vector<typename T::Ptr> Resource::Package(Package::Ptr pkg) {
     return ts_pkgd;
   }
 
+  int approx_num_pkgs = quantity() / fill_mass;
+  if (approx_num_pkgs > Package::SplitLimit()) {
+    throw ValueError("Resource::Package() cannot package into more than " + 
+                     std::to_string(Package::SplitLimit()) + 
+                     " items at once.");
+  } else if (approx_num_pkgs > Package::SplitWarn()) {
+    LOG(cyclus::LEV_INFO1) << "Resource::Package() is attempting to package into " 
+                           << approx_num_pkgs << " items at once, is this intended?";
+  }
+
   while (quantity() > 0 && quantity() >= pkg->fill_min()) {
     double pkg_fill = std::min(quantity(), fill_mass);
     t_pkgd = boost::dynamic_pointer_cast<T>(ExtractRes(pkg_fill));

--- a/src/resource.h
+++ b/src/resource.h
@@ -6,6 +6,7 @@
 #include <boost/shared_ptr.hpp>
 
 #include "error.h"
+#include "logger.h"
 #include "package.h"
 
 class SimInitTest;
@@ -144,7 +145,7 @@ std::vector<typename T::Ptr> Resource::Package(Package::Ptr pkg) {
                      std::to_string(Package::SplitLimit()) + 
                      " items at once.");
   } else if (approx_num_pkgs > Package::SplitWarn()) {
-    LOG(cyclus::LEV_INFO1) << "Resource::Package() is attempting to package into " 
+    CLOG(cyclus::LEV_INFO1) << "Resource::Package() is attempting to package into " 
                            << approx_num_pkgs << " items at once, is this intended?";
   }
 

--- a/src/resource.h
+++ b/src/resource.h
@@ -140,7 +140,9 @@ std::vector<typename T::Ptr> Resource::Package(Package::Ptr pkg) {
   }
 
   int approx_num_pkgs = quantity() / fill_mass;
-  if (approx_num_pkgs > Package::SplitLimit()) {
+  // Check if the number of packages is within the limits, including if
+  // int overflow is reached
+  if (approx_num_pkgs > Package::SplitLimit() || approx_num_pkgs == std::numeric_limits<int>::min()) {
     throw ValueError("Resource::Package() cannot package into more than " + 
                      std::to_string(Package::SplitLimit()) + 
                      " items at once.");

--- a/src/toolkit/matl_sell_policy.cc
+++ b/src/toolkit/matl_sell_policy.cc
@@ -180,7 +180,7 @@ std::set<BidPortfolio<Material>::Ptr> MatlSellPolicy::GetMatlBids(
   Request<Material>* req;
   Material::Ptr m, offer;
   double qty;
-  int n_full_bids;
+  int n_full_bids = 0;
   double bid_qty;  
   double remaining_qty;
   std::vector<double> bids;
@@ -199,6 +199,14 @@ std::set<BidPortfolio<Material>::Ptr> MatlSellPolicy::GetMatlBids(
       bid_qty = excl ? quantize_ : package_->GetFillMass(qty);
       if (bid_qty != 0) {
         n_full_bids = static_cast<int>(std::floor(qty / bid_qty));
+        if (n_full_bids > Package::SplitLimit()) {
+          throw ValueError("splitting resource into more than " + 
+                           std::to_string(Package::SplitLimit()) + 
+                           " bids is not allowed due to vector limits");
+        } else if (n_full_bids > Package::SplitWarn()) {
+          LGH(WARN) << "splitting resource into " << n_full_bids << " bids for " 
+          << commod << ", is this intended?";
+        }
         bids.assign(n_full_bids, bid_qty);
 
         remaining_qty = fmod(qty, bid_qty);

--- a/src/toolkit/matl_sell_policy.cc
+++ b/src/toolkit/matl_sell_policy.cc
@@ -202,21 +202,17 @@ std::set<BidPortfolio<Material>::Ptr> MatlSellPolicy::GetMatlBids(
 
         // Throw if number of bids above limit or if casting to int caused
         // overflow to negative int limit 
-        if (n_full_bids > Package::SplitLimit() || n_full_bids == std::numeric_limits<int>::min()) {
-          std::stringstream ss;
-          ss << "When calculating the number of bids for agent "
-             << Trader::manager()->prototype() << "-" \
-             << Trader::manager()->id()
-             << ", material on hand would result in more bids than the limit: " 
-             << Package::SplitLimit() << ". This is likely due to too much "
-             << "material (did you forget a throughput?) or small package "
-             << "limits relative to the quantity available. qty: " << qty 
-             << ", and each bid would be: " << bid_qty;
-          throw ValueError(ss.str());
-        } else if (n_full_bids > Package::SplitWarn()) {
-          LGH(WARN) << "splitting resource into " << n_full_bids << " bids for " 
-          << commod << ", is this intended?";
-        }
+        std::string s;
+        if (manager() != NULL)
+          s + " Agent: "
+            + Trader::manager()->prototype() + "-"
+            + std::to_string(Trader::manager()->id()) + ". ";
+        s + "This is likely due to too much material (did you forget a "
+          + "throughput?) or small package limits relative to the "
+          + "quantity available. qty: " + std::to_string(qty) 
+          + ", and each bid would be: " + std::to_string(bid_qty);
+        Package::ExceedsSplitLimits(n_full_bids, s);
+
         bids.assign(n_full_bids, bid_qty);
 
         remaining_qty = fmod(qty, bid_qty);


### PR DESCRIPTION
Adds a warning value (1e5) and a limit value (unsigned int / 10) for re-packaging. Implemented in Material Sell Policy, when calculating how many bids to respond with, and in the repackaging process itself (in Resource). If trying (or in the case of sell pol, intending) to repackage a single resource into more than warn/limit values, raise warning/limit

Closes #1766 