### PR TITLE
use keep_packaging in resbuf

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Since last release
 * Material sell policy can package materials (#1749, #1774)
 * Use miniforge for conda CI builds instead of miniconda (#1763)
 * Warning and limits on number of packages that can be created from a resource at once (#1771)
+* Use keep_packaging instead of unpackaged in ResBuf (#1778)
 
 **Removed:**
 

--- a/src/toolkit/res_buf.h
+++ b/src/toolkit/res_buf.h
@@ -61,7 +61,11 @@ typedef std::vector<Product::Ptr> ProdVec;
 template <class T>
 class ResBuf {
  public:
-  ResBuf(bool is_bulk=false, bool keep_packaging=false) : cap_(INFINITY), qty_(0), is_bulk_(is_bulk), keep_packaging_(keep_packaging) { }
+  ResBuf(bool is_bulk=false, bool keep_packaging=false) : cap_(INFINITY), qty_(0), is_bulk_(is_bulk), keep_packaging_(keep_packaging) {
+    if (is_bulk_ && keep_packaging_) {
+      throw ValueError("bulk storage resbufs cannot keep packaging. Only one of the two options can be true.");
+    }
+   }
 
   virtual ~ResBuf() {}
 

--- a/src/toolkit/res_buf.h
+++ b/src/toolkit/res_buf.h
@@ -61,7 +61,7 @@ typedef std::vector<Product::Ptr> ProdVec;
 template <class T>
 class ResBuf {
  public:
-  ResBuf(bool is_bulk=false, bool unpackaged=true) : cap_(INFINITY), qty_(0), is_bulk_(is_bulk), unpackaged_(unpackaged) { }
+  ResBuf(bool is_bulk=false, bool keep_packaging=false) : cap_(INFINITY), qty_(0), is_bulk_(is_bulk), keep_packaging_(keep_packaging) { }
 
   virtual ~ResBuf() {}
 
@@ -84,6 +84,13 @@ class ResBuf {
     }
     cap_ = cap;
   }
+
+  /// Sets whether the buffer should keep packaged resources
+  void keep_packaging(bool keep_packaging) {
+    keep_packaging_ = keep_packaging;
+  }
+
+  bool keep_packaging() const { return keep_packaging_; }
 
   /// Returns the total number of constituent resource objects
   /// in the buffer. Never throws.
@@ -267,7 +274,7 @@ class ResBuf {
 
     if (!is_bulk_  || rs_.size() == 0) {
       // strip package id and set as default
-      if (unpackaged_) {
+      if (!keep_packaging_) {
         m->ChangePackage();
       }
       rs_.push_back(m);
@@ -319,7 +326,7 @@ class ResBuf {
 
     for (int i = 0; i < rss.size(); i++) {
       if (!is_bulk_ || rs_.size() == 0) {
-        if (unpackaged_) {
+        if (!keep_packaging_) {
           rss[i]->ChangePackage();
         }
         rs_.push_back(rss[i]);
@@ -359,7 +366,7 @@ class ResBuf {
   bool is_bulk_;
   /// Whether materials should be stripped of their packaging before being
   /// pushed onto the resbuf. If res_buf is bulk, this is assumed true.
-  bool unpackaged_;
+  bool keep_packaging_;
 
   /// List of constituent resource objects forming the buffer's inventory
   std::list<typename T::Ptr> rs_;

--- a/src/toolkit/res_buf.h
+++ b/src/toolkit/res_buf.h
@@ -61,7 +61,9 @@ typedef std::vector<Product::Ptr> ProdVec;
 template <class T>
 class ResBuf {
  public:
-  ResBuf(bool is_bulk=false, bool keep_packaging=false) : cap_(INFINITY), qty_(0), is_bulk_(is_bulk), keep_packaging_(keep_packaging) {
+  ResBuf(bool is_bulk=false, bool keep_pkg=false) : qty_(0), is_bulk_(is_bulk) {
+    capacity(INFINITY);
+    keep_packaging(keep_pkg);
     if (is_bulk_ && keep_packaging_) {
       throw ValueError("bulk storage resbufs cannot keep packaging. Only one of the two options can be true.");
     }
@@ -80,6 +82,10 @@ class ResBuf {
   /// @throws ValueError the new capacity is lower (by eps_rsrc()) than the
   /// quantity of resources that exist in the buffer.
   void capacity(double cap) {
+    if (cap < 0) {
+      throw ValueError("capacity must not be negative");
+    }
+
     if (quantity() - cap > eps_rsrc()) {
       std::stringstream ss;
       ss << std::setprecision(17) << "new capacity " << cap

--- a/src/toolkit/res_buf.h
+++ b/src/toolkit/res_buf.h
@@ -64,9 +64,6 @@ class ResBuf {
   ResBuf(bool is_bulk=false, bool keep_pkg=false) : qty_(0), is_bulk_(is_bulk) {
     capacity(INFINITY);
     keep_packaging(keep_pkg);
-    if (is_bulk_ && keep_packaging_) {
-      throw ValueError("bulk storage resbufs cannot keep packaging. Only one of the two options can be true.");
-    }
    }
 
   virtual ~ResBuf() {}
@@ -97,6 +94,9 @@ class ResBuf {
 
   /// Sets whether the buffer should keep packaged resources
   void keep_packaging(bool keep_packaging) {
+    if (is_bulk_ && keep_packaging) {
+      throw ValueError("bulk storage resbufs cannot keep packaging. Only one of the two options can be true.");
+    }
     keep_packaging_ = keep_packaging;
   }
 

--- a/tests/toolkit/res_buf_tests.cc
+++ b/tests/toolkit/res_buf_tests.cc
@@ -444,6 +444,15 @@ TEST_F(MaterialBufTest, KeepPackaging) {
   ASSERT_EQ(keep_pkg_store_.Pop()->package_name(), pkg_name_);
 }
 
+TEST_F(MaterialBufTest, ChangeKeepPackaging) {
+  keep_pkg_store_.Push(mat4_pkgd_);
+  ASSERT_EQ(keep_pkg_store_.Pop()->package_name(), pkg_name_);
+
+  keep_pkg_store_.keep_packaging(false);
+  keep_pkg_store_.Push(mat4_pkgd_);
+  ASSERT_EQ(keep_pkg_store_.Pop()->package_name(), cyclus::Package::unpackaged_name());
+}
+
 TEST_F(MaterialBufTest, BulkKeepPackaging) {
   EXPECT_THROW(ResBuf<Material>(true, true), ValueError);
 }

--- a/tests/toolkit/res_buf_tests.cc
+++ b/tests/toolkit/res_buf_tests.cc
@@ -444,5 +444,10 @@ TEST_F(MaterialBufTest, KeepPackaging) {
   ASSERT_EQ(keep_pkg_store_.Pop()->package_name(), pkg_name_);
 }
 
+TEST_F(MaterialBufTest, BulkKeepPackaging) {
+  EXPECT_THROW(ResBuf<Material>(true, true), ValueError);
+}
+
+
 }  // namespace toolkit
 }  // namespace cyclus

--- a/tests/toolkit/res_buf_tests.cc
+++ b/tests/toolkit/res_buf_tests.cc
@@ -439,6 +439,10 @@ TEST_F(MaterialBufTest, BulkTest) {
 
 }
 
+TEST_F(MaterialBufTest, KeepPackaging) {
+  keep_pkg_store_.Push(mat4_pkgd_);
+  ASSERT_EQ(keep_pkg_store_.Pop()->package_name(), pkg_name_);
+}
 
 }  // namespace toolkit
 }  // namespace cyclus


### PR DESCRIPTION
Replace the `unpackaged` parameter in ResBuf with `keep_packaging`, switching the default from true to false to keep the logic the same.

This reflects the changes that are being made in Reactor and Sink to keep the packaging by default ([cycamore#618](https://github.com/cyclus/cycamore/pull/618))