### PR TITLE
Add doxygen to dependency list in dockerfile

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Since last release
 
 * Added TransportUnits (#1750, #1772, #1784)
 * Added CI support for Ubuntu 24.04 (#1770)
+* Added ``doxygen`` to list of dependencies installed in the Dockerfile (#1782)
 
 **Changed:**
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,8 @@ RUN apt update -y && apt install -y \
         python3-jinja2 \
         python3-pip \
         cython3 \
-        libwebsockets-dev
+        libwebsockets-dev \
+        doxygen
 
 RUN apt install -y python3-pprintpp; exit 0
 RUN apt clean -y all
@@ -83,6 +84,7 @@ RUN mamba update -y python --no-pin && \
                websockets \
                pprintpp \
                pip \
+               doxygen \
                && \
     mamba clean -y --all
 RUN mkdir -p $(python3 -m site --user-site)


### PR DESCRIPTION
In trying to build the api docs for cyclus.github.com I was having to rebuild cyclus and cycamore after installing doxygen.  I think it's easier if we just include it in our published images from the start so that the `cyclusdoc` and `cycamoredoc` make targets exist for when we need them downstream.