### PR TITLE
Packaging updates - failed trades send zero material and more robust GetFillMass 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Since last release
 * Warning and limits on number of packages that can be created from a resource at once (#1771)
 * Use keep_packaging instead of unpackaged in ResBuf (#1778)
 * Temporarily pin Boost libraries to <1.86.0 (#1796)
+* Package GetFillMass returns fill mass and number of packages filled at that mass (#1790)
 
 **Removed:**
 

--- a/src/package.cc
+++ b/src/package.cc
@@ -29,13 +29,15 @@ Package::Ptr& Package::unpackaged() {
   return unpackaged_;
 }
 
-double Package::GetFillMass(double qty) {
+std::pair<double, int> Package::GetFillMass(double qty) {
   if (qty < fill_min_) {
     // less than one pkg of material available
-    return 0;
+    return std::pair<double, int> (0, 0);
   }
 
   double fill_mass;
+  int num_at_fill_mass;
+  
   if (strategy_ == "first") {
     fill_mass = fill_max_;
   } else if (strategy_ == "equal") {
@@ -49,7 +51,13 @@ double Package::GetFillMass(double qty) {
       fill_mass = fill_max_;
     }
   }
-  return std::min(qty, fill_mass);
+  fill_mass = std::min(qty, fill_mass);
+  if (fill_mass >= fill_min_) {
+    num_at_fill_mass = static_cast<int>(std::floor(qty / fill_mass));
+    return std::pair<double, int>(fill_mass, num_at_fill_mass);
+  } else {
+    return std::pair<double, int>(0, 0);
+  }
 }
   
 Package::Package(std::string name, double fill_min, double fill_max,

--- a/src/package.cc
+++ b/src/package.cc
@@ -52,12 +52,8 @@ std::pair<double, int> Package::GetFillMass(double qty) {
     }
   }
   fill_mass = std::min(qty, fill_mass);
-  if (fill_mass >= fill_min_) {
-    num_at_fill_mass = static_cast<int>(std::floor(qty / fill_mass));
-    return std::pair<double, int>(fill_mass, num_at_fill_mass);
-  } else {
-    return std::pair<double, int>(0, 0);
-  }
+  num_at_fill_mass = static_cast<int>(std::floor(qty / fill_mass));
+  return std::pair<double, int>(fill_mass, num_at_fill_mass);
 }
   
 Package::Package(std::string name, double fill_min, double fill_max,

--- a/src/package.h
+++ b/src/package.h
@@ -26,9 +26,12 @@ class Package {
                       double fill_max = std::numeric_limits<double>::max(),
                       std::string strategy = "first");
 
-    /// Returns optimal fill mass for a resource to be packaged. Can be used
-    /// to determine how to respond to requests for material, and to actually
-    /// package and send off trades.
+    /// Returns optimal fill mass for a resource to be packaged, and number of
+    /// packages that can be crated at that fill mass (note that up to one
+    /// additional package may be possible to create with a lower fill mass,
+    /// which much be checked separately). 
+    /// Can be used to determine how to respond to requests for material, and 
+    /// to actually package and send off trades.
     /// Packaging strategy "first" simply fills the packages one by one to the
     /// maximum fill. Therefore, it should always try to max fill.
     /// Packaging strategy "equal" tries to fill all packages to the same mass.
@@ -41,7 +44,7 @@ class Package {
     /// quantity = 5, fill_min = 3, fill_max = 4. num_min_fill = floor(5/3) = 1,
     /// num_max_fill = ceil(5/4) = 2. num_min_fill < num_max_fill, so fill to
     /// the max.
-    double GetFillMass(double qty);
+    std::pair<double, int> GetFillMass(double qty);
 
     // returns package name
     std::string name() const { return name_; }

--- a/src/resource.h
+++ b/src/resource.h
@@ -132,14 +132,15 @@ std::vector<typename T::Ptr> Resource::Package(Package::Ptr pkg) {
   std::vector<typename T::Ptr> ts_pkgd;
   typename T::Ptr t_pkgd;
 
-  double fill_mass = pkg->GetFillMass(quantity());
+  std::pair<double, int> fill = pkg->GetFillMass(quantity());
+  double fill_mass = fill.first;
   if (fill_mass == 0) {
     return ts_pkgd;
   }
 
   // Check if the number of packages is within the limits, including if
   // int overflow is reached
-  int approx_num_pkgs = quantity() / fill_mass;
+  int approx_num_pkgs = fill.second;
   Package::ExceedsSplitLimits(approx_num_pkgs);
 
   while (quantity() > 0 && quantity() >= pkg->fill_min()) {

--- a/src/toolkit/matl_sell_policy.cc
+++ b/src/toolkit/matl_sell_policy.cc
@@ -202,8 +202,6 @@ std::set<BidPortfolio<Material>::Ptr> MatlSellPolicy::GetMatlBids(
       std::pair<double, int> fill = package_->GetFillMass(qty);
       bid_qty = excl ? quantize_ : fill.first;
       if (bid_qty != 0) {
-        std::cerr << "bid_qty: " << bid_qty << std::endl;
-        std::cerr << "full bids: " << fill.second << std::endl;
         n_full_bids = excl ? std::floor(qty / quantize_) : fill.second;
 
         // Throw if number of bids above limit or if casting to int caused

--- a/src/toolkit/matl_sell_policy.cc
+++ b/src/toolkit/matl_sell_policy.cc
@@ -280,6 +280,9 @@ void MatlSellPolicy::GetMatlTrades(
           // packaging successful
           trade_mat = mat_pkgd[0];
           shippable_pkgs-=1;
+        } else {
+          // packaging failed. Will need to ship empty trade
+          trade_mat = Material::CreateUntracked(0, mat->comp());
         }
 
       } else { // no packaging needed

--- a/src/trade_executor.h
+++ b/src/trade_executor.h
@@ -89,14 +89,16 @@ class TradeExecutor {
       for (v_it = trades.begin(); v_it != trades.end(); ++v_it) {
         Trade<T>& trade = v_it->first;
         typename T::Ptr rsrc =  v_it->second;
-        ctx->NewDatum("Transactions")
-            ->AddVal("TransactionId", ctx->NextTransactionID())
-            ->AddVal("SenderId", supplier->id())
-            ->AddVal("ReceiverId", requester->id())
-            ->AddVal("ResourceId", rsrc->state_id())
-            ->AddVal("Commodity", trade.request->commodity())
-            ->AddVal("Time", ctx->time())
-            ->Record();
+        if (rsrc->quantity() > cyclus::eps_rsrc()) {
+          ctx->NewDatum("Transactions")
+              ->AddVal("TransactionId", ctx->NextTransactionID())
+              ->AddVal("SenderId", supplier->id())
+              ->AddVal("ReceiverId", requester->id())
+              ->AddVal("ResourceId", rsrc->state_id())
+              ->AddVal("Commodity", trade.request->commodity())
+              ->AddVal("Time", ctx->time())
+              ->Record();
+        }
       }
     }
   }

--- a/tests/package_tests.cc
+++ b/tests/package_tests.cc
@@ -56,26 +56,56 @@ TEST(PackageTests, GetPackageFillMass) {
     Package::Ptr q = Package::Create("bar", min, max, "equal");
     Package::Ptr r = Package::Create("baz", tight_min, max, "equal");
 
+    std::pair<double, int> p_fill, q_fill, r_fill;
+
     double exp;
 
+    // no fit
     double no_fit = 0.05;
-    EXPECT_EQ(0, p->GetFillMass(no_fit));
-    EXPECT_EQ(0, q->GetFillMass(no_fit));
+    p_fill = p->GetFillMass(no_fit);;
+    EXPECT_EQ(0, p_fill.first);
+    EXPECT_EQ(0, p_fill.second);
 
+    q_fill = q->GetFillMass(no_fit);
+    EXPECT_EQ(0, q_fill.first);
+    EXPECT_EQ(0, q_fill.second);
+
+    // perfect fit
     double perfect_fit = 0.9;
-    EXPECT_EQ(perfect_fit, p->GetFillMass(perfect_fit));
-    EXPECT_EQ(perfect_fit, q->GetFillMass(perfect_fit));
+    p_fill = p->GetFillMass(perfect_fit);
+    EXPECT_EQ(perfect_fit, p_fill.first);
+    EXPECT_EQ(1, p_fill.second);
 
+    q_fill = q->GetFillMass(perfect_fit);
+    EXPECT_EQ(perfect_fit, q_fill.first);
+    EXPECT_EQ(1, q_fill.second);
+
+    // partial fit 
     double partial_fit = 1;
-    EXPECT_EQ(max, p->GetFillMass(partial_fit));
-    exp = partial_fit / 2;
-    EXPECT_EQ(exp, q->GetFillMass(partial_fit));
-    EXPECT_EQ(max, r->GetFillMass(partial_fit));
 
+    p_fill = p->GetFillMass(partial_fit);
+    EXPECT_EQ(max, p_fill.first);
+    EXPECT_EQ(1, p_fill.second);
+
+    q_fill = q->GetFillMass(partial_fit);
+    exp = partial_fit / 2;
+    EXPECT_EQ(exp, q_fill.first);
+    EXPECT_EQ(2, q_fill.second);
+
+    r_fill = r->GetFillMass(partial_fit);
+    EXPECT_EQ(max, r_fill.first);
+    EXPECT_EQ(1, r_fill.second);
+
+    // two full packages for equal, only one for 
     double two_packages = 1.4;
-    EXPECT_EQ(max, p->GetFillMass(two_packages));
+
+    p_fill = p->GetFillMass(two_packages);
+    EXPECT_EQ(max, p_fill.first);
+    EXPECT_EQ(1, p_fill.second);
+
+    q_fill = q->GetFillMass(two_packages);
     exp = two_packages / 2;
-    EXPECT_EQ(exp, q->GetFillMass(two_packages));
+    EXPECT_EQ(exp, q_fill.first);
 }
 
 TEST(PackageTests, CreateTransportUnit) {


### PR DESCRIPTION
Addresses @gonuke's comments on [cycamore#621](https://github.com/cyclus/cycamore/pull/621)

Closes #1785 and is part of process for addressing #1786 