### PR TITLE
Recording for 1:1 extracted resources

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Since last release
 * Rely on ``python3`` in environment instead of ``python`` (#1747)
 * Remove ``pandas`` as build dependency (#1748)
 * Consistently use hyphens in ``install.py`` flags (#1748)
-* Material sell policy can package materials (#1749, #1774, #1775)
+* Material sell policy can package materials (#1749, #1774, #1775, #1795)
 * Use miniforge for conda CI builds instead of miniconda (#1763)
 * Define constants ``CY_LARGE_DOUBLE``, ``CY_LARGE_INT``, and ``CY_NEAR_ZERO`` (#1757)
 * Warning and limits on number of packages that can be created from a resource at once (#1771)

--- a/src/material.cc
+++ b/src/material.cc
@@ -93,10 +93,7 @@ Material::Ptr Material::ExtractComp(double qty, Composition::Ptr c,
   // this material regardless of composition.
   other->prev_decay_time_ = prev_decay_time_;
 
-  if (qty_ > cyclus::eps()) {
-    tracker_.Extract(&other->tracker_);
-  } // else, this material is being fully extracted and nothing has effectively
-  // changed. Don't need to bump state, parent, etc.
+  tracker_.Extract(&other->tracker_);
 
   return other;
 }

--- a/src/material.cc
+++ b/src/material.cc
@@ -141,7 +141,7 @@ void Material::Transmute(Composition::Ptr c) {
 }
 
 Resource::Ptr Material::PackageExtract(double qty, std::string new_package_name) {
-  if (qty > qty_) {
+  if ((qty - qty_) > eps_rsrc()) {
     throw ValueError("Attempted to extract more quantity than exists.");
   }
   
@@ -155,7 +155,7 @@ Resource::Ptr Material::PackageExtract(double qty, std::string new_package_name)
   // this call to res_tracker must come first before the parent resource 
   // state id gets modified
   other->tracker_.Package(&tracker_);
-  if (qty_ > cyclus::eps_rsrc()) {
+  if (qty_ > eps_rsrc()) {
     tracker_.Modify();
   }
   return boost::static_pointer_cast<Resource>(other);

--- a/src/material.cc
+++ b/src/material.cc
@@ -152,7 +152,12 @@ Resource::Ptr Material::PackageExtract(double qty, std::string new_package_name)
   // this material regardless of composition.
   other->prev_decay_time_ = prev_decay_time_;
 
-  tracker_.Extract(&other->tracker_);
+  // this call to res_tracker must come first before the parent resource 
+  // state id gets modified
+  other->tracker_.Package(&tracker_);
+  if (qty_ > cyclus::eps_rsrc()) {
+    tracker_.Modify();
+  }
   return boost::static_pointer_cast<Resource>(other);
 }
 

--- a/src/material.h
+++ b/src/material.h
@@ -158,6 +158,9 @@ class Material: public Resource {
 
   virtual std::string package_name();
 
+  virtual Resource::Ptr PackageExtract(double qty,
+    std::string new_package_name = Package::unpackaged_name());
+
   /// Changes the package id. Checks that the resource fits the package 
   /// type minimum and maximum mass criteria.
   virtual void ChangePackage(std::string new_package_name = Package::unpackaged_name());

--- a/src/package.cc
+++ b/src/package.cc
@@ -1,5 +1,6 @@
 #include "package.h"
 #include "error.h"
+#include "cyc_limits.h"
 
 namespace cyclus {
 
@@ -30,7 +31,7 @@ Package::Ptr& Package::unpackaged() {
 }
 
 std::pair<double, int> Package::GetFillMass(double qty) {
-  if (qty < fill_min_) {
+  if ((qty - fill_min_) < -eps_rsrc()) {
     // less than one pkg of material available
     return std::pair<double, int> (0, 0);
   }

--- a/src/product.cc
+++ b/src/product.cc
@@ -76,6 +76,18 @@ std::string Product::package_name() {
   return package_name_;
 }
 
+Resource::Ptr Product::PackageExtract(double qty, std::string new_package_name) {
+  if (qty > quantity_) {
+    throw ValueError("Attempted to extract more quantity than exists.");
+  }
+
+  quantity_ -= qty;
+  Product::Ptr other(new Product(ctx_, qty, quality_, new_package_name));
+
+  tracker_.Extract(&other->tracker_);
+  return boost::static_pointer_cast<Resource>(other);
+}
+
 void Product::ChangePackage(std::string new_package_name) {
   if (new_package_name == package_name_ || ctx_ == NULL) {
     // no change needed

--- a/src/product.cc
+++ b/src/product.cc
@@ -2,6 +2,7 @@
 
 #include "error.h"
 #include "logger.h"
+#include "cyc_limits.h"
 
 namespace cyclus {
 
@@ -84,7 +85,12 @@ Resource::Ptr Product::PackageExtract(double qty, std::string new_package_name) 
   quantity_ -= qty;
   Product::Ptr other(new Product(ctx_, qty, quality_, new_package_name));
 
-  tracker_.Extract(&other->tracker_);
+  // this call to res_tracker must come first before the parent resource 
+  // state id gets modified
+  other->tracker_.Package(&tracker_);
+  if (quantity_ > cyclus::eps_rsrc()) {
+    tracker_.Modify();
+  }
   return boost::static_pointer_cast<Resource>(other);
 }
 

--- a/src/product.h
+++ b/src/product.h
@@ -74,6 +74,8 @@ class Product : public Resource {
   /// Returns the package id.
   virtual std::string package_name();
 
+  virtual Resource::Ptr PackageExtract(double qty, std::string new_package_name = Package::unpackaged_name());
+
   /// Changes the product's package id
   virtual void ChangePackage(std::string new_package_name = Package::unpackaged_name());
 

--- a/src/res_tracker.cc
+++ b/src/res_tracker.cc
@@ -23,8 +23,8 @@ void ResTracker::Create(Agent* creator) {
 
   parent1_ = 0;
   parent2_ = 0;
-  bool no_bump = true;
-  Record(no_bump);
+  bool bumpId = false;
+  Record(bumpId);
   ctx_->NewDatum("ResCreators")
       ->AddVal("ResourceId", res_->state_id())
       ->AddVal("AgentId", creator->id())
@@ -83,8 +83,8 @@ void ResTracker::Package(ResTracker* parent) {
     
     // Resource was just created, with packaging info, and assigned a state id. 
     // Do not need to bump again
-    bool no_bump = true;
-    Record(no_bump);
+    bool bumpId = false;
+    Record(bumpId);
   } else {
     // Resource was not just created. It is being re-packaged. It needs to be
     // bumped to get a new state id.
@@ -96,8 +96,8 @@ void ResTracker::Package(ResTracker* parent) {
   
 }
 
-void ResTracker::Record(bool no_bump) {
-  if (!no_bump) {
+void ResTracker::Record(bool bumpId) {
+  if (bumpId) {
     res_->BumpStateId();
   }
   ctx_->NewDatum("Resources")

--- a/src/res_tracker.cc
+++ b/src/res_tracker.cc
@@ -53,9 +53,9 @@ void ResTracker::Extract(ResTracker* removed) {
     Record();
   }
 
-    removed->parent1_ = res_->state_id();
-    removed->parent2_ = 0;
-    removed->tracked_ = tracked_;
+  removed->parent1_ = res_->state_id();
+  removed->parent2_ = 0;
+  removed->tracked_ = tracked_;
 
   removed->Record();
 }

--- a/src/res_tracker.cc
+++ b/src/res_tracker.cc
@@ -50,15 +50,11 @@ void ResTracker::Extract(ResTracker* removed) {
     parent2_ = 0;
     
     Record();
+  }
 
     removed->parent1_ = res_->state_id();
     removed->parent2_ = 0;
     removed->tracked_ = tracked_;
-  } else {
-    removed->parent1_ = parent1_;
-    removed->parent2_ = parent2_;
-    removed->tracked_ = tracked_;
-  }
 
   removed->Record();
 }
@@ -82,8 +78,7 @@ void ResTracker::Package() {
   Record();
 }
 
-void ResTracker::Record(bool no_bump) {
-  if (!no_bump) {
+void ResTracker::Record() {
   res_->BumpStateId();
   ctx_->NewDatum("Resources")
       ->AddVal("ResourceId", res_->state_id())
@@ -97,7 +92,6 @@ void ResTracker::Record(bool no_bump) {
       ->AddVal("Parent1", parent1_)
       ->AddVal("Parent2", parent2_)
       ->Record();
-  }
   res_->Record(ctx_);
 }
 

--- a/src/res_tracker.cc
+++ b/src/res_tracker.cc
@@ -50,11 +50,15 @@ void ResTracker::Extract(ResTracker* removed) {
     parent2_ = 0;
     
     Record();
+
+    removed->parent1_ = res_->state_id();
+    removed->parent2_ = 0;
+    removed->tracked_ = tracked_;
+  } else {
+    removed->parent1_ = parent1_;
+    removed->parent2_ = parent2_;
+    removed->tracked_ = tracked_;
   }
-  
-  removed->parent1_ = res_->state_id();
-  removed->parent2_ = 0;
-  removed->tracked_ = tracked_;
 
   removed->Record();
 }
@@ -78,7 +82,8 @@ void ResTracker::Package() {
   Record();
 }
 
-void ResTracker::Record() {
+void ResTracker::Record(bool no_bump) {
+  if (!no_bump) {
   res_->BumpStateId();
   ctx_->NewDatum("Resources")
       ->AddVal("ResourceId", res_->state_id())
@@ -92,7 +97,7 @@ void ResTracker::Record() {
       ->AddVal("Parent1", parent1_)
       ->AddVal("Parent2", parent2_)
       ->Record();
-
+  }
   res_->Record(ctx_);
 }
 

--- a/src/res_tracker.h
+++ b/src/res_tracker.h
@@ -49,7 +49,7 @@ class ResTracker {
   void Package(ResTracker* parent = NULL);
 
  private:
-  void Record(bool no_bump = false);
+  void Record(bool bumpId = true);
 
   int parent1_;
   int parent2_;

--- a/src/res_tracker.h
+++ b/src/res_tracker.h
@@ -46,7 +46,7 @@ class ResTracker {
   void Package();
 
  private:
-  void Record(bool no_bump = false);
+  void Record();
 
   int parent1_;
   int parent2_;

--- a/src/res_tracker.h
+++ b/src/res_tracker.h
@@ -46,7 +46,7 @@ class ResTracker {
   void Package();
 
  private:
-  void Record();
+  void Record(bool no_bump = false);
 
   int parent1_;
   int parent2_;

--- a/src/res_tracker.h
+++ b/src/res_tracker.h
@@ -42,11 +42,14 @@ class ResTracker {
   /// decay).
   void Modify();
 
-  /// Should be called when a resource's package gets modified
-  void Package();
+  /// Should be called when a resource's package gets modified. If the resource
+  /// was just created from a parent resource, the parent should be passed in.
+  /// If the resource is just being repackaged (e.g. to unpackaged), the parent
+  /// should be NULL.
+  void Package(ResTracker* parent = NULL);
 
  private:
-  void Record();
+  void Record(bool no_bump = false);
 
   int parent1_;
   int parent2_;

--- a/src/resource.h
+++ b/src/resource.h
@@ -94,6 +94,8 @@ class Resource {
   /// Returns the package id.
   virtual std::string package_name() { return Package::unpackaged_name(); };
 
+  virtual Ptr PackageExtract(double qty, std::string new_package_name = Package::unpackaged_name()) = 0;
+
   /// Changes the product's package id
   virtual void ChangePackage(std::string new_package_name = Package::unpackaged_name()) {};
 
@@ -107,6 +109,12 @@ class Resource {
   static int nextstate_id_;
   static int nextobj_id_;
   int state_id_;
+  // Setting the state id should only be done when extracting one resource
+  void state_id(int st_id) {
+    state_id_ = st_id;
+  }
+
+
   int obj_id_;
 };
 
@@ -145,8 +153,7 @@ std::vector<typename T::Ptr> Resource::Package(Package::Ptr pkg) {
 
   while (quantity() > 0 && quantity() >= pkg->fill_min()) {
     double pkg_fill = std::min(quantity(), fill_mass);
-    t_pkgd = boost::dynamic_pointer_cast<T>(ExtractRes(pkg_fill));
-    t_pkgd->ChangePackage(pkg->name());
+    t_pkgd = boost::dynamic_pointer_cast<T>(PackageExtract(pkg_fill, pkg->name()));
     ts_pkgd.push_back(t_pkgd); 
   }
   return ts_pkgd;

--- a/src/resource.h
+++ b/src/resource.h
@@ -95,7 +95,7 @@ class Resource {
   /// Returns the package id.
   virtual std::string package_name() { return Package::unpackaged_name(); };
 
-  virtual Ptr PackageExtract(double qty, std::string new_package_name = Package::unpackaged_name()) = 0;
+  virtual Ptr PackageExtract(double qty, std::string new_package_name) = 0;
 
   /// Changes the product's package id
   virtual void ChangePackage(std::string new_package_name = Package::unpackaged_name()) {};

--- a/src/resource.h
+++ b/src/resource.h
@@ -6,6 +6,7 @@
 #include <boost/shared_ptr.hpp>
 
 #include "package.h"
+#include "cyc_limits.h"
 
 class SimInitTest;
 
@@ -151,7 +152,7 @@ std::vector<typename T::Ptr> Resource::Package(Package::Ptr pkg) {
   int approx_num_pkgs = fill.second;
   Package::ExceedsSplitLimits(approx_num_pkgs);
 
-  while (quantity() > 0 && quantity() >= pkg->fill_min()) {
+  while (quantity() > 0 && (quantity() - pkg->fill_min()) >= -eps_rsrc()) {
     double pkg_fill = std::min(quantity(), fill_mass);
     t_pkgd = boost::dynamic_pointer_cast<T>(PackageExtract(pkg_fill, pkg->name()));
     ts_pkgd.push_back(t_pkgd); 

--- a/src/toolkit/matl_buy_policy.cc
+++ b/src/toolkit/matl_buy_policy.cc
@@ -318,7 +318,7 @@ void MatlBuyPolicy::AcceptMatlTrades(
   // check if cumulative cap has been reached. If yes, then sample for dormant
   // length and reset cycle_total_inv
   if (use_cumulative_capacity() && (
-    (cumulative_cap_ - cycle_total_inv_) < eps())) {
+    (cumulative_cap_ - cycle_total_inv_) < eps_rsrc())) {
       SetNextDormantTime();
       LGH(INFO3) << "cycle cumulative inventory has been reached. Dormant period will end at " << next_dormant_end_ << std::endl;
       cycle_total_inv_ = 0;

--- a/src/toolkit/matl_sell_policy.cc
+++ b/src/toolkit/matl_sell_policy.cc
@@ -265,7 +265,7 @@ void MatlSellPolicy::GetMatlTrades(
     if (shippable_pkgs > 0){
       qty = it->amt;
       LGH(INFO3) << " sending " << qty << " kg of " << it->request->commodity();
-      Material::Ptr mat = buf_->Pop(qty, cyclus::eps_rsrc());
+      Material::Ptr mat = buf_->Pop(qty, eps_rsrc());
       Material::Ptr trade_mat;
 
       // don't go through packaging if you don't need to. packaging always bumps
@@ -274,7 +274,7 @@ void MatlSellPolicy::GetMatlTrades(
       if (package_->name() != mat->package_name()) { // packaging needed
         std::vector<Material::Ptr> mat_pkgd = mat->Package<Material>(package_);
 
-        if (mat->quantity() > eps()) {
+        if (mat->quantity() > eps_rsrc()) {
           // push any extra material that couldn't be packaged back onto buffer
           // don't push unless there's leftover material
           buf_->Push(mat);


### PR DESCRIPTION
Closes #1794. Closes #1797 

Fixes the broken cycamore python tests

~~Still has the failures on conda 22.04 and 24.04 that I don't understand~~

~~#1790 should be merged first~~ (merged)