### PR TITLE
Pin Boost<1.86.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Since last release
 * Define constants ``CY_LARGE_DOUBLE``, ``CY_LARGE_INT``, and ``CY_NEAR_ZERO`` (#1757)
 * Warning and limits on number of packages that can be created from a resource at once (#1771)
 * Use keep_packaging instead of unpackaged in ResBuf (#1778)
+* Temporarily pin Boost libraries to <1.86.0 (#1796)
 
 **Removed:**
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,8 +53,10 @@ RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
     rm ~/miniforge.sh
 
 ENV PATH=/opt/conda/bin:$PATH
-RUN mamba update -n base conda mamba && mamba init bash
-SHELL ["mamba", "run", "-n", "base", "/bin/bash", "-c"]
+RUN mamba init bash
+SHELL ["/bin/bash", "--login",  "-c"]
+RUN mamba create -n cyclus
+SHELL ["mamba", "run", "--no-capture-output", "-n", "cyclus", "/bin/bash", "-c"]
 RUN mamba update -y python --no-pin && \
     mamba update -y --all && \
     mamba install -y \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,12 +53,12 @@ RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
     rm ~/miniforge.sh
 
 ENV PATH=/opt/conda/bin:$PATH
-RUN mamba update -n base conda mamba && \
-    mamba update -y python --no-pin && \
+RUN mamba update -n base conda mamba && mamba init bash
+SHELL ["mamba", "run", "-n", "base", "/bin/bash", "-c"]
+RUN mamba update -y python --no-pin && \
     mamba update -y --all && \
     mamba install -y \
-               gxx_linux-64 \
-               gcc_linux-64 \
+               compilers \
                cmake \
                make \
                git \
@@ -68,7 +68,7 @@ RUN mamba update -n base conda mamba && \
                liblapack \
                pkg-config \
                coincbc \
-               libboost-devel \
+               "boost-cpp<1.86.0" \
                hdf5 \
                sqlite \
                pcre \
@@ -84,9 +84,6 @@ RUN mamba update -n base conda mamba && \
                && \
     mamba clean -y --all
 RUN mkdir -p $(python3 -m site --user-site)
-ENV CC=/opt/conda/bin/x86_64-conda-linux-gnu-gcc
-ENV CXX=/opt/conda/bin/x86_64-conda-linux-gnu-g++
-ENV CPP=/opt/conda/bin/x86_64-conda-linux-gnu-cpp
 
 FROM apt-deps AS apt-coverage-deps
 RUN apt install -y lcov curl

--- a/src/toolkit/res_map.h
+++ b/src/toolkit/res_map.h
@@ -233,7 +233,7 @@ class ResMap {
   }
 
   /// Whether quantity_ should be recomputed or not.
-  bool dirty_quantity_;
+  mutable bool dirty_quantity_;
 
   /// Current total quantity of all resources in the mapping.
   double quantity_;

--- a/src/toolkit/res_map.h
+++ b/src/toolkit/res_map.h
@@ -233,7 +233,7 @@ class ResMap {
   }
 
   /// Whether quantity_ should be recomputed or not.
-  mutable bool dirty_quantity_;
+  bool dirty_quantity_;
 
   /// Current total quantity of all resources in the mapping.
   double quantity_;


### PR DESCRIPTION
Pin boost for now until #1791 is resolved.

This was more complex than anticipated, but now the shell is modified so that we always execute RUN commands inside of a conda env called `cyclus`.  Was running into issues where the compiler was having trouble finding GLIBCXX and this seemed to resolve the issue.  I tried to make it so that it is initializing the conda environment a more traditional way, instead of just setting our path to /opt/conda/bin:$PATH