### PR TITLE
update github action version

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -67,7 +67,7 @@ jobs:
           format: lcov
 
       - name: Upload Coverage HTML Artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           name: cyclus-coverage-report-${{ matrix.ubuntu_versions }}-${{ matrix.pkg_mgr }}
           path: ${{ github.workspace }}/html

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,7 +35,7 @@ Since last release
 
 * Removed unnecessary records being added to the Resource database by packaging process (#1761)
 * Removed GTest source code from code coverage reports (#1759)
-* Updated action versions to avoid node.js deprectation ()
+* Updated action versions to avoid node.js deprectation (#1802)
 
 
 v1.6.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,7 @@ Since last release
 
 * Removed unnecessary records being added to the Resource database by packaging process (#1761)
 * Removed GTest source code from code coverage reports (#1759)
+* Updated action versions to avoid node.js deprectation ()
 
 
 v1.6.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,7 +35,7 @@ Since last release
 
 * Removed unnecessary records being added to the Resource database by packaging process (#1761)
 * Removed GTest source code from code coverage reports (#1759)
-* Updated action versions to avoid node.js deprectation (#1802)
+* Updated action versions to avoid node.js deprecation (#1802)
 
 
 v1.6.0


### PR DESCRIPTION
Github actions reports that the current version of `action/upload-pages-artifact` relies on a version of node.js that is soon to be deprecated.  This should resolve that concern.

Fixes #1801 