### PR TITLE
ResTracker Extract gave the wrong parent_id to one of the child resources

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,7 @@ Since last release
 * Removed GTest source code from code coverage reports (#1759)
 * Updated action versions to avoid node.js deprecation (#1802)
 * Removed the module imports in `cyclus/__init__.py` and removed the need for multi-phase initialization of Cython modules (#1809)
+* ResTracker Extract gave the wrong parent_id to one of the child resources (#1806)
 
 
 v1.6.0

--- a/src/res_tracker.cc
+++ b/src/res_tracker.cc
@@ -46,18 +46,20 @@ void ResTracker::Extract(ResTracker* removed) {
     return;
   }
 
+  // removed parent must be set before the resource is recorded, otherwise
+  // removed ends up with parent1 of the other child (which is this resource
+  // after being bumped)
+  removed->parent1_ = res_->state_id();
+  removed->parent2_ = 0;
+  removed->tracked_ = tracked_;
+  removed->Record();
+
   if (res_->quantity() > eps_rsrc()) {
     parent1_ = res_->state_id();
     parent2_ = 0;
     
     Record();
   }
-
-  removed->parent1_ = res_->state_id();
-  removed->parent2_ = 0;
-  removed->tracked_ = tracked_;
-
-  removed->Record();
 }
 
 void ResTracker::Absorb(ResTracker* absorbed) {

--- a/src/res_tracker.cc
+++ b/src/res_tracker.cc
@@ -46,19 +46,19 @@ void ResTracker::Extract(ResTracker* removed) {
     return;
   }
 
+  if (res_->quantity() > eps_rsrc()) {
+    parent1_ = res_->state_id();
+    parent2_ = 0;
+  }
+
   // removed parent must be set before the resource is recorded, otherwise
   // removed ends up with parent1 of the other child (which is this resource
   // after being bumped)
   removed->parent1_ = res_->state_id();
   removed->parent2_ = 0;
   removed->tracked_ = tracked_;
-
-  if (res_->quantity() > eps_rsrc()) {
-    parent1_ = res_->state_id();
-    parent2_ = 0;
-  }
-
   removed->Record();
+
   if (res_->quantity() > eps_rsrc()) {
     Record();
   }

--- a/src/res_tracker.cc
+++ b/src/res_tracker.cc
@@ -52,12 +52,14 @@ void ResTracker::Extract(ResTracker* removed) {
   removed->parent1_ = res_->state_id();
   removed->parent2_ = 0;
   removed->tracked_ = tracked_;
-  removed->Record();
 
   if (res_->quantity() > eps_rsrc()) {
     parent1_ = res_->state_id();
     parent2_ = 0;
-    
+  }
+
+  removed->Record();
+  if (res_->quantity() > eps_rsrc()) {
     Record();
   }
 }


### PR DESCRIPTION
Setting parent1 for the removed resource must come before the original resource is recorded. Otherwise, the original (parent) resource becomes its own child, with a new state id. Then that first child becomes the parent1 for the second child.

Closes #1805 