### PR TITLE
Modify Cython api to use `api` keyword 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,13 +65,17 @@ Debug/
 # generated cython ignores
 *.cc.gen
 *.cc.h
+*.cc_api.h
 *.h.gen
 src/eventhooks.cc
 src/eventhooks.h
+src/eventhooks_api.h
 src/pyinfile.cc
 src/pyinfile.h
+src/pyinfile_api.h
 src/pymodule.cc
 src/pymodule.h
+src/pymodule_api.h
 
 # this is copied over by the installer
 cyclus/cycpp.py

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,6 +36,7 @@ Since last release
 * Removed unnecessary records being added to the Resource database by packaging process (#1761)
 * Removed GTest source code from code coverage reports (#1759)
 * Updated action versions to avoid node.js deprecation (#1802)
+* Removed the module imports in `cyclus/__init__.py` and removed the need for multi-phase initialization of Cython modules (#1809)
 
 
 v1.6.0

--- a/cyclus/__init__.py
+++ b/cyclus/__init__.py
@@ -1,2 +1,2 @@
 __version__ = 'x.x.x' # will be populated during build
-import pymodule, eventhooks, pyinfile
+# import pymodule, eventhooks, pyinfile

--- a/cyclus/__init__.py
+++ b/cyclus/__init__.py
@@ -1,2 +1,1 @@
 __version__ = 'x.x.x' # will be populated during build
-# import pymodule, eventhooks, pyinfile

--- a/cyclus/cpp_cyclus.pxd
+++ b/cyclus/cpp_cyclus.pxd
@@ -272,12 +272,6 @@ cdef extern from "error.h" namespace "cyclus":
     cdef cpp_bool warn_as_error
 
 
-cdef extern from "pyhooks.h" namespace "cyclus":
-
-   cdef void PyAppendInitTab() except +
-   cdef void PyImportInit() except +
-
-
 cdef extern from "pyhooks.h" namespace "cyclus::toolkit":
 
     cdef std_string PyToJson(std_string) except +

--- a/cyclus/lib.pyx
+++ b/cyclus/lib.pyx
@@ -797,25 +797,6 @@ def set_warn_as_error(bint wae):
     """Sets whether warnings should be treated as errors."""
     cpp_cyclus.warn_as_error = wae
 
-
-#
-# PyHooks
-#
-def py_append_init_tab():
-    """Initializes Cyclus-internal Python import table. This is called
-    automatically when cyclus is imported. Users should not need to call
-    this function.
-    """
-    cpp_cyclus.PyAppendInitTab()
-
-
-def py_import_init():
-    """Initializes Cyclus-internal Python imports. This is called
-    automatically when cyclus is imported. Users should not need to call
-    this function.
-    """
-    cpp_cyclus.PyImportInit()
-
 #
 # XML
 #

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -157,7 +157,6 @@ if(Cython_FOUND)
           INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib"
           INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib"
           )
-        SET(LIBS ${LIBS} ${name})
 
         TARGET_LINK_LIBRARIES(${name} dl ${NoCythonLibs})
 
@@ -170,15 +169,9 @@ if(Cython_FOUND)
           LIBRARY DESTINATION ${PYTHON_SITE_PACKAGES}
           )
 
-        # IF (EXISTS ${_generated_h})
-          copy_when_diff(${_generated_h} ${_h_file})
-        # ENDIF()
-        # IF (EXISTS ${_generated_api})
-          copy_when_diff(${_generated_api} ${_api_file})
-        # ENDIF()
-        # IF (EXISTS ${_generated_cc})
-          copy_when_diff(${_generated_cc} ${_cc_file})
-        # ENDIF()
+        copy_when_diff(${_generated_h} ${_h_file})
+        copy_when_diff(${_generated_api} ${_api_file})
+        copy_when_diff(${_generated_cc} ${_cc_file})
     endforeach()
 endif(Cython_FOUND)
 ###########################################################

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -132,15 +132,18 @@ if(Cython_FOUND)
         message(STATUS "Cython Compiling ${file}")
         get_filename_component(name ${file} NAME_WE)
         set(_generated_h "${CMAKE_CURRENT_SOURCE_DIR}/${name}.cc.h")
+        set(_generated_api "${CMAKE_CURRENT_SOURCE_DIR}/${name}.cc_api.h")
         set(_generated_cc "${CMAKE_CURRENT_SOURCE_DIR}/${name}.cc.gen")
         set(_h_file "${CMAKE_CURRENT_SOURCE_DIR}/${name}.h")
+        set(_api_file "${CMAKE_CURRENT_SOURCE_DIR}/${name}_api.h")
         set(_cc_file "${CMAKE_CURRENT_SOURCE_DIR}/${name}.cc")
         set_source_files_properties(${_cc_file} PROPERTIES GENERATED TRUE)
 
         EXECUTE_PROCESS(COMMAND ${CYTHON_EXECUTABLE} --cplus
             ${include_directory_arg} ${version_arg}
             ${cython_debug_arg} ${CYTHON_FLAGS}
-            --output-file  ${_generated_cc} ${file}
+            --output-file  ${_generated_cc} 
+            ${file}
             RESULT_VARIABLE res_var_c)
         IF(NOT "${res_var_c}" STREQUAL "0")
             message(FATAL_ERROR "Cython compilation of ${file} failed!")
@@ -167,8 +170,15 @@ if(Cython_FOUND)
           LIBRARY DESTINATION ${PYTHON_SITE_PACKAGES}
           )
 
-        copy_when_diff(${_generated_h} ${_h_file})
-        copy_when_diff(${_generated_cc} ${_cc_file})
+        # IF (EXISTS ${_generated_h})
+          copy_when_diff(${_generated_h} ${_h_file})
+        # ENDIF()
+        # IF (EXISTS ${_generated_api})
+          copy_when_diff(${_generated_api} ${_api_file})
+        # ENDIF()
+        # IF (EXISTS ${_generated_cc})
+          copy_when_diff(${_generated_cc} ${_cc_file})
+        # ENDIF()
     endforeach()
 endif(Cython_FOUND)
 ###########################################################

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -142,8 +142,7 @@ if(Cython_FOUND)
         EXECUTE_PROCESS(COMMAND ${CYTHON_EXECUTABLE} --cplus
             ${include_directory_arg} ${version_arg}
             ${cython_debug_arg} ${CYTHON_FLAGS}
-            --output-file  ${_generated_cc} 
-            ${file}
+            --output-file  ${_generated_cc} ${file}
             RESULT_VARIABLE res_var_c)
         IF(NOT "${res_var_c}" STREQUAL "0")
             message(FATAL_ERROR "Cython compilation of ${file} failed!")

--- a/src/eventhooks.pxd
+++ b/src/eventhooks.pxd
@@ -1,3 +1,3 @@
 """Header for cyclus events."""
 
-cdef public void eventloophook "CyclusEventLoopHook" () except *
+cdef public api void eventloophook "CyclusEventLoopHook" () except *

--- a/src/eventhooks.pyx
+++ b/src/eventhooks.pyx
@@ -1,7 +1,7 @@
 """The event handling module in cyclus."""
 from __future__ import print_function, unicode_literals
 
-cdef public void eventloophook "CyclusEventLoopHook" () except *:
+cdef public api void eventloophook "CyclusEventLoopHook" () except *:
     from cyclus.events import loop
     loop()
 

--- a/src/pyhooks.cc
+++ b/src/pyhooks.cc
@@ -4,11 +4,9 @@
 #ifdef CYCLUS_WITH_PYTHON
 #include <stdlib.h>
 
-// extern "C" {
 #include "eventhooks_api.h"
 #include "pyinfile_api.h"
 #include "pymodule_api.h"
-// }
 
 namespace cyclus {
 int PY_INTERP_COUNT = 0;

--- a/src/pyhooks.cc
+++ b/src/pyhooks.cc
@@ -4,56 +4,20 @@
 #ifdef CYCLUS_WITH_PYTHON
 #include <stdlib.h>
 
-extern "C" {
-#include "eventhooks.h"
-#include "pyinfile.h"
-#include "pymodule.h"
-}
+// extern "C" {
+#include "eventhooks_api.h"
+#include "pyinfile_api.h"
+#include "pymodule_api.h"
+// }
 
 namespace cyclus {
 int PY_INTERP_COUNT = 0;
 bool PY_INTERP_INIT = false;
 
 
-void PyAppendInitTab(void) {
-  if (PyImport_AppendInittab("eventhooks", PyInit_eventhooks) == -1) {
-    fprintf(stderr, "Error appending 'eventhooks' to the initialization table\n");
-  }
-
-  if (PyImport_AppendInittab("pyinfile", PyInit_pyinfile) == -1) {
-    fprintf(stderr, "Error appending 'pyinfile' to the initialization table\n");
-  }
-
-  if (PyImport_AppendInittab("pymodule", PyInit_pymodule) == -1) {
-    fprintf(stderr, "Error appending 'pymodule' to the initialization table\n");
-  }
-}
-
-void PyImportInit(void) {
-  PyObject* module_eventhooks = PyImport_ImportModule("eventhooks");
-  if (module_eventhooks == NULL) {
-    PyErr_Print(); // Print Python error information
-    fprintf(stderr, "Error importing 'eventhooks' module\n");
-  }
-
-  PyObject* module_pyinfile = PyImport_ImportModule("pyinfile");
-  if (module_pyinfile == NULL) {
-    PyErr_Print();
-    fprintf(stderr, "Error importing 'pyinfile' module\n");
-  }
-
-  PyObject* module_pymodule = PyImport_ImportModule("pymodule");
-  if (module_pymodule == NULL) {
-    PyErr_Print();
-    fprintf(stderr, "Error importing 'pymodule' module\n");
-  }
-}
-
 void PyStart(void) {
   if (!PY_INTERP_INIT) {
-    PyAppendInitTab();
     Py_Initialize();
-    PyImportInit();
     atexit(PyStop);
     PY_INTERP_INIT = true;
   };
@@ -69,29 +33,32 @@ void PyStop(void) {
   };
 };
 
-void EventLoop(void) { CyclusEventLoopHook(); };
+void EventLoop(void) { import_eventhooks(); eventloophook(); };
 
-std::string PyFindModule(std::string lib) { return CyclusPyFindModule(lib); };
+std::string PyFindModule(std::string lib) { import_pymodule(); return py_find_module(lib); };
 
 Agent* MakePyAgent(std::string lib, std::string agent, void* ctx) {
-  return CyclusMakePyAgent(lib, agent, ctx);
+  import_pymodule();
+  return make_py_agent(lib, agent, ctx);
 };
 
 void InitFromPyAgent(Agent* src, Agent* dst, void* ctx) {
-  CyclusInitFromPyAgent(src, dst, ctx);
+  import_pymodule();
+  init_from_py_agent(src, dst, ctx);
 };
 
-void ClearPyAgentRefs(void) { CyclusClearPyAgentRefs(); };
+void ClearPyAgentRefs(void) { import_pymodule(); clear_pyagent_refs(); };
 
-void PyDelAgent(int i) { CyclusPyDelAgent(i); };
+void PyDelAgent(int i) { import_pymodule(); py_del_agent(i); };
 
 namespace toolkit {
-std::string PyToJson(std::string infile) { return CyclusPyToJson(infile); };
+std::string PyToJson(std::string infile) { import_pyinfile(); return py_to_json(infile); };
 
-std::string JsonToPy(std::string infile) { return CyclusJsonToPy(infile); };
+std::string JsonToPy(std::string infile) { import_pyinfile(); return json_to_py(infile); };
 
 void PyCallListeners(std::string tstype, Agent* agent, void* cpp_ctx, int time, boost::spirit::hold_any value){
-    CyclusPyCallListeners(tstype, agent, cpp_ctx, time, value);
+    import_pymodule(); 
+    py_call_listeners(tstype, agent, cpp_ctx, time, value);
 };
 
 }  // namespace toolkit
@@ -102,10 +69,6 @@ void PyCallListeners(std::string tstype, Agent* agent, void* cpp_ctx, int time, 
 namespace cyclus {
 int PY_INTERP_COUNT = 0;
 bool PY_INTERP_INIT = false;
-
-void PyAppendInitTab(void) {};
-
-void PyImportInit(void) {};
 
 void PyStart(void) {};
 

--- a/src/pyhooks.h
+++ b/src/pyhooks.h
@@ -16,12 +16,6 @@ extern int PY_INTERP_COUNT;
 /// Whether or not the Python interpreter has been initilized.
 extern bool PY_INTERP_INIT;
 
-/// Convience function for appending to import table for initialization
-void PyAppendInitTab(void);
-
-/// Convience function for import initialization
-void PyImportInit(void);
-
 /// Initialize Python functionality, this is a no-op if Python was not
 /// installed along with Cyclus. This may be called many times and safely
 /// initializes the Python interpreter only once.

--- a/src/pyinfile.pxd
+++ b/src/pyinfile.pxd
@@ -4,5 +4,5 @@ from libcpp.string cimport string as std_string
 cdef std_string str_py_to_cpp(object x)
 cdef object std_string_to_py(std_string x)
 
-cdef public std_string py_to_json "CyclusPyToJson" (std_string) except *
-cdef public std_string json_to_py "CyclusJsonToPy" (std_string) except *
+cdef public api std_string py_to_json "CyclusPyToJson" (std_string) except *
+cdef public api std_string json_to_py "CyclusJsonToPy" (std_string) except *

--- a/src/pyinfile.pyx
+++ b/src/pyinfile.pyx
@@ -22,7 +22,7 @@ cdef std_string str_py_to_cpp(object x):
     return s
 
 
-cdef public std_string py_to_json "CyclusPyToJson" (std_string cpp_infile) except *:
+cdef public api std_string py_to_json "CyclusPyToJson" (std_string cpp_infile) except *:
     """Converts a Python file to JSON"""
     infile = std_string_to_py(cpp_infile)
     if not infile.endswith('\n'):
@@ -53,7 +53,7 @@ cdef public std_string py_to_json "CyclusPyToJson" (std_string cpp_infile) excep
     return cpp_rtn
 
 
-cdef public std_string json_to_py "CyclusJsonToPy" (std_string cpp_infile) except *:
+cdef public api std_string json_to_py "CyclusJsonToPy" (std_string cpp_infile) except *:
     """Converts a JSON file to Python"""
     infile = std_string_to_py(cpp_infile)
     import json

--- a/src/pymodule.pxd
+++ b/src/pymodule.pxd
@@ -47,18 +47,18 @@ cdef std_string str_py_to_cpp(object x)
 cdef object std_string_to_py(std_string x)
 
 
-cdef public std_string py_find_module "CyclusPyFindModule" (std_string cpp_lib) except *
+cdef public api std_string py_find_module "CyclusPyFindModule" (std_string cpp_lib) except *
 
-cdef public Agent* make_py_agent "CyclusMakePyAgent" (std_string cpp_lib,
+cdef public api Agent* make_py_agent "CyclusMakePyAgent" (std_string cpp_lib,
                                                       std_string cpp_agent,
                                                       void* cpp_ctx) except *
 
-cdef public void init_from_py_agent "CyclusInitFromPyAgent" (Agent* cpp_src,
+cdef public api void init_from_py_agent "CyclusInitFromPyAgent" (Agent* cpp_src,
                                                              Agent* cpp_dst,
                                                              void* cpp_ctx) except *
 
-cdef public void clear_pyagent_refs "CyclusClearPyAgentRefs" () except *
-cdef public void py_del_agent "CyclusPyDelAgent" (int i) except *
+cdef public api void clear_pyagent_refs "CyclusClearPyAgentRefs" () except *
+cdef public api void py_del_agent "CyclusPyDelAgent" (int i) except *
 
-cdef public void py_call_listeners "CyclusPyCallListeners" (std_string cpp_tsname,
+cdef public api void py_call_listeners "CyclusPyCallListeners" (std_string cpp_tsname,
                             Agent* cpp_agent, void* cpp_ctx, int time, hold_any cpp_value) except *

--- a/src/pymodule.pyx
+++ b/src/pymodule.pyx
@@ -23,7 +23,7 @@ cdef std_string str_py_to_cpp(object x):
     return s
 
 
-cdef public std_string py_find_module "CyclusPyFindModule" (std_string cpp_lib) except *:
+cdef public api std_string py_find_module "CyclusPyFindModule" (std_string cpp_lib) except *:
     """Finds a Python module and returns a string of the form '<py>:modulepath'"""
     lib = std_string_to_py(cpp_lib)
     try:
@@ -35,7 +35,7 @@ cdef public std_string py_find_module "CyclusPyFindModule" (std_string cpp_lib) 
     return rtn
 
 
-cdef public Agent* make_py_agent "CyclusMakePyAgent" (std_string cpp_lib,
+cdef public api Agent* make_py_agent "CyclusMakePyAgent" (std_string cpp_lib,
                                                      std_string cpp_agent,
                                                      void* cpp_ctx) except *:
     """Makes a new Python agent instance."""
@@ -57,7 +57,7 @@ cdef public Agent* make_py_agent "CyclusMakePyAgent" (std_string cpp_lib,
     return rtn
 
 
-cdef public void init_from_py_agent "CyclusInitFromPyAgent" (Agent* cpp_src,
+cdef public api void init_from_py_agent "CyclusInitFromPyAgent" (Agent* cpp_src,
                                                              Agent* cpp_dst,
                                                              void* cpp_ctx) except *:
     """Initializes the dst agent with the settings from the src. Users will not
@@ -72,19 +72,19 @@ cdef public void init_from_py_agent "CyclusInitFromPyAgent" (Agent* cpp_src,
     PyErr_CheckSignals()
 
 
-cdef public void clear_pyagent_refs "CyclusClearPyAgentRefs" () except *:
+cdef public api void clear_pyagent_refs "CyclusClearPyAgentRefs" () except *:
     """Clears the cache of agent referencess"""
     cyclib._clear_agent_refs()
     PyErr_CheckSignals()
 
 
-cdef public void py_del_agent "CyclusPyDelAgent" (int i) except *:
+cdef public api void py_del_agent "CyclusPyDelAgent" (int i) except *:
     """Clears the cache of a single agent ref"""
     cyclib._del_agent(i)
     PyErr_CheckSignals()
 
 
-cdef public void py_call_listeners "CyclusPyCallListeners" (std_string cpp_tsname,
+cdef public api void py_call_listeners "CyclusPyCallListeners" (std_string cpp_tsname,
                             Agent* cpp_agent, void* cpp_ctx, int time, hold_any cpp_value) except *:
     """Calls the python time series listeners
     """


### PR DESCRIPTION
I stumbled upon [this section ](https://cython.readthedocs.io/en/latest/src/userguide/external_C_code.html#c-api-declarations)of the cython docs (I can't believe I missed it before!!) that discusses how to make cython declarations available to C code.  Since we only access cython methods in PyHooks we can define those methods with the `api` keyword and avoid dealing with the messy multi-phase module initialization (see #1781).  It also does not require that `libcyclus` is linked with our cython modules since "the Python import machinery is used to make the connection dynamically" (if you look at the generated `_api.h` headers it looks like they are doing a lot of the messy Python C-API calls that I was making in #1781, but in a robust/correct way :smile:).

This PR replaces #1781 and closes #1779.