### PR TITLE
Add normal and uniform packaging strategies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Since last release
 * Added macros in ``cmake/CyclusBuildSetup.cmake`` for common CMake boilerplate (#1793)
 * Added ``doxygen-awesome-css`` to doxygen docs for style (#1787)
 * Added installation of files for building docs to share/cyclus/doc (#1807)
+* New packaging strategies uniform and normal (#1813)
 
 **Changed:**
 
@@ -26,7 +27,7 @@ Since last release
 * Warning and limits on number of packages that can be created from a resource at once (#1771)
 * Use keep_packaging instead of unpackaged in ResBuf (#1778)
 * Temporarily pin Boost libraries to <1.86.0 (#1796)
-* Package GetFillMass returns fill mass and number of packages filled at that mass (#1790)
+* Package GetFillMass returns vector of masses (#1790, #1813)
 
 **Removed:**
 

--- a/share/cyclus-flat.rng.in
+++ b/share/cyclus-flat.rng.in
@@ -151,9 +151,9 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
     <element name="package">
       <interleave>
         <element name="name"><text/></element>
-        <element name="fill_min"><data type="double"/></element>
-        <element name="fill_max"><data type="double"/></element>
-        <element name="strategy"><text/></element>
+        <optional><element name="fill_min"><data type="double"/></element></optional>
+        <optional><element name="fill_max"><data type="double"/></element></optional>
+        <optional><element name="strategy"><text/></element></optional>
       </interleave>
     </element>
   </zeroOrMore>
@@ -162,9 +162,9 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
     <element name="transportunit">
       <interleave>
         <element name="name"><text/></element>
-        <element name="fill_min"><data type="nonNegativeInteger"/></element>
-        <element name="fill_max"><data type="nonNegativeInteger"/></element>
-        <element name="strategy"><text/></element>
+        <optional><element name="fill_min"><data type="nonNegativeInteger"/></element></optional>
+        <optional><element name="fill_max"><data type="nonNegativeInteger"/></element></optional>
+        <optional><element name="strategy"><text/></element></optional>
       </interleave>
     </element>
   </zeroOrMore>

--- a/share/cyclus.rng.in
+++ b/share/cyclus.rng.in
@@ -183,9 +183,9 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
     <element name="package">
       <interleave>
         <element name="name"><text/></element>
-        <element name="fill_min"><data type="double"/></element>
-        <element name="fill_max"><data type="double"/></element>
-        <element name="strategy"><text/></element>
+        <optional><element name="fill_min"><data type="double"/></element></optional>
+        <optional><element name="fill_max"><data type="double"/></element></optional>
+        <optional><element name="strategy"><text/></element></optional>
       </interleave>
     </element>
   </zeroOrMore>
@@ -194,9 +194,9 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
     <element name="transportunit">
       <interleave>
         <element name="name"><text/></element>
-        <element name="fill_min"><data type="nonNegativeInteger"/></element>
-        <element name="fill_max"><data type="nonNegativeInteger"/></element>
-        <element name="strategy"><text/></element>
+        <optional><element name="fill_min"><data type="nonNegativeInteger"/></element></optional>
+        <optional><element name="fill_max"><data type="nonNegativeInteger"/></element></optional>
+        <optional><element name="strategy"><text/></element></optional>
       </interleave>
     </element>
   </zeroOrMore>

--- a/src/package.cc
+++ b/src/package.cc
@@ -81,14 +81,14 @@ std::vector<double> Package::GetFillMass(double qty) {
   if (strategy_ == "uniform" || strategy_ == "normal") {
     // only use random if a full package amount is available. if less than one
     // full amount is available, below will fill a partial package (no random).
-    while ((qty > 0) && (qty >= fill_max_)) {
+    while ( qty > std::max(0,fill_max_) ) {
       fill_mass = dist_->sample();
       packages.push_back(fill_mass);
       qty -= fill_mass;
     }
   }
 
-  if (qty > eps_rsrc() && qty >= fill_min_) {
+  if (qty > std::max(eps_rsrc(),fill_min_) ) {
     // leftover material is enough to fill one more partial package. 
     packages.push_back(qty);
   }

--- a/src/package.cc
+++ b/src/package.cc
@@ -30,11 +30,27 @@ Package::Ptr& Package::unpackaged() {
   return unpackaged_;
 }
 
-std::pair<double, int> Package::GetFillMass(double qty) {
+void Package::SetDistribution() {
+  if (strategy_ == "uniform") {
+    dist_ = UniformDoubleDist::Ptr (new UniformDoubleDist(fill_min_, fill_max_));
+  } else if (strategy_ == "normal") {
+    dist_ = NormalDoubleDist::Ptr (new NormalDoubleDist(
+      (fill_min_ + fill_max_) / 2,
+      (fill_max_ - fill_min_) / 6,
+      fill_min_,
+      fill_max_));
+  }
+}
+
+std::vector<double> Package::GetFillMass(double qty) {
+  std::vector<double> packages;
   if ((qty - fill_min_) < -eps_rsrc()) {
     // less than one pkg of material available
-    return std::pair<double, int> (0, 0);
+    return packages;
   }
+
+  // simple check for whether vector limits *might* be exceeded
+  ExceedsSplitLimits(qty / fill_max_);
 
   double fill_mass;
   int num_at_fill_mass;
@@ -52,9 +68,34 @@ std::pair<double, int> Package::GetFillMass(double qty) {
       fill_mass = fill_max_;
     }
   }
-  fill_mass = std::min(qty, fill_mass);
-  num_at_fill_mass = static_cast<int>(std::floor(qty / fill_mass));
-  return std::pair<double, int>(fill_mass, num_at_fill_mass);
+
+  if (strategy_ == "first" || strategy_ == "equal") {
+    fill_mass = std::min(qty, fill_mass);
+    num_at_fill_mass = static_cast<int>(std::floor(qty / fill_mass));
+    ExceedsSplitLimits(num_at_fill_mass);
+    packages.assign(num_at_fill_mass, fill_mass);
+
+    qty -= num_at_fill_mass * fill_mass;
+  }
+
+  if (strategy_ == "uniform" || strategy_ == "normal") {
+    // only use random if a full package amount is available. if less than one
+    // full amount is available, below will fill a partial package (no random).
+    while ((qty > 0) && (qty >= fill_max_)) {
+      fill_mass = dist_->sample();
+      packages.push_back(fill_mass);
+      qty -= fill_mass;
+    }
+  }
+
+  if (qty > eps_rsrc() && qty >= fill_min_) {
+    // leftover material is enough to fill one more partial package. 
+    packages.push_back(qty);
+  }
+    
+  Package::ExceedsSplitLimits(packages.size());
+
+  return packages;
 }
   
 Package::Package(std::string name, double fill_min, double fill_max,
@@ -65,9 +106,10 @@ Package::Package(std::string name, double fill_min, double fill_max,
         throw ValueError("can't create a new package with name 'unpackaged'");
       }
   }
-    if (strategy != "first" && strategy != "equal") {
+    if (!IsValidStrategy(strategy_)) {
       throw ValueError("Invalid strategy for package: " + strategy_);
     }
+    SetDistribution();
 }
 
 TransportUnit::Ptr TransportUnit::unrestricted_ = NULL;

--- a/src/package.cc
+++ b/src/package.cc
@@ -81,14 +81,14 @@ std::vector<double> Package::GetFillMass(double qty) {
   if (strategy_ == "uniform" || strategy_ == "normal") {
     // only use random if a full package amount is available. if less than one
     // full amount is available, below will fill a partial package (no random).
-    while ( qty > std::max(0,fill_max_) ) {
+    while ( qty >= std::max(eps_rsrc(), fill_max_) ) {
       fill_mass = dist_->sample();
       packages.push_back(fill_mass);
       qty -= fill_mass;
     }
   }
 
-  if (qty > std::max(eps_rsrc(),fill_min_) ) {
+  if (qty >= std::max(eps_rsrc(),fill_min_) ) {
     // leftover material is enough to fill one more partial package. 
     packages.push_back(qty);
   }

--- a/src/package.h
+++ b/src/package.h
@@ -9,7 +9,8 @@
 
 #include "error.h"
 #include "logger.h"
-#include "random_number_generator.h"
+class DoubleDistribution;
+class DoubleDistribution::Ptr;
 
 namespace cyclus {
 

--- a/src/package.h
+++ b/src/package.h
@@ -9,8 +9,7 @@
 
 #include "error.h"
 #include "logger.h"
-class DoubleDistribution;
-class DoubleDistribution::Ptr;
+#include "random_number_generator.h"
 
 namespace cyclus {
 

--- a/src/resource.h
+++ b/src/resource.h
@@ -141,22 +141,17 @@ std::vector<typename T::Ptr> Resource::Package(Package::Ptr pkg) {
   std::vector<typename T::Ptr> ts_pkgd;
   typename T::Ptr t_pkgd;
 
-  std::pair<double, int> fill = pkg->GetFillMass(quantity());
-  double fill_mass = fill.first;
-  if (fill_mass == 0) {
+  std::vector<double> packages = pkg->GetFillMass(quantity());
+  if (packages.size() == 0) {
     return ts_pkgd;
   }
 
-  // Check if the number of packages is within the limits, including if
-  // int overflow is reached
-  int approx_num_pkgs = fill.second;
-  Package::ExceedsSplitLimits(approx_num_pkgs);
-
-  while (quantity() > 0 && (quantity() - pkg->fill_min()) >= -eps_rsrc()) {
-    double pkg_fill = std::min(quantity(), fill_mass);
+  for (int i = 0; i < packages.size(); ++i) {
+    double pkg_fill = packages[i];
     t_pkgd = boost::dynamic_pointer_cast<T>(PackageExtract(pkg_fill, pkg->name()));
-    ts_pkgd.push_back(t_pkgd); 
+    ts_pkgd.push_back(t_pkgd);
   }
+
   return ts_pkgd;
 }
 


### PR DESCRIPTION
Closes #1812. Also closes #1777 

Note that the new strategies do not come with any flexibility. The uniform distribution is created with min of `fill_min` and max of `fill_max`. The (truncated) normal distribution is created with mean in the middle of `fill_min` and `fill_max` and its three standard deviations to the boundaries of `fill_min` and `fill_max`. It may be of interest to someone in the future to add user inputs to change these values, but I don't think that's of critical importance now. Or, maybe it's not important enough to be changed later either! 

Because the distributions are dependent on the package values of `fill_min` and `fill_max`, they do not sample when less than `fill_max` of material is available. Otherwise, we would be sampling from only part of the distribution which would throw off the randomness. Instead, when less than `fill_max` (but more than `fill_min`) is available, that amount is used directly to fill up a partial package