### PR TITLE
Add link to fuelcycle.org in doxygen homepage

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Since last release
 * Use keep_packaging instead of unpackaged in ResBuf (#1778)
 * Temporarily pin Boost libraries to <1.86.0 (#1796)
 * Package GetFillMass returns vector of masses (#1790, #1813)
+* Modified Doxygen homepage (#1815)
 
 **Removed:**
 

--- a/src/cyclus.h
+++ b/src/cyclus.h
@@ -6,6 +6,7 @@
  * \mainpage Cyclus API Reference
  *
  * Welcome to the Cyclus API reference! Below are some helpful links for learning more:
+ *   - Cyclus Homepage: https://fuelcycle.org
  *   - GitHub repository: https://github.com/cyclus/cyclus
  *   - Kernel developer guide: https://fuelcycle.org/kernel
  *   - Archetype developer guide: https://fuelcycle.org/arche


### PR DESCRIPTION
Partially addresses https://github.com/cyclus/cyclus.github.com/issues/389 in conjunction with https://github.com/cyclus/cycamore/pull/632