### PR TITLE
add methods to reset/unset build policy

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Since last release
 * Added installation of files for building docs to share/cyclus/doc (#1807)
 * New packaging strategies uniform and normal (#1813)
 * Add CI support for MacOS 12, 13, and 14 (#1814)
+* Methods to reset behavaiors of MaterialBuyPolicy (#1822)
 
 **Changed:**
 

--- a/src/toolkit/matl_buy_policy.cc
+++ b/src/toolkit/matl_buy_policy.cc
@@ -34,6 +34,19 @@ MatlBuyPolicy::~MatlBuyPolicy() {
     manager()->context()->UnregisterTrader(this);
 }
 
+MatlBuyPolicy& MatlBuyPolicy::ResetBehavior() {
+  throughput_ = std::numeric_limits<double>::max();
+  quantize_ = 1;
+  fill_to_ = std::numeric_limits<double>::max();
+  req_at_ = std::numeric_limits<double>::max();
+  cumulative_cap_ = -1;
+  cycle_total_inv_ = 0;
+  active_dist_ = NULL;
+  dormant_dist_ = NULL;
+  size_dist_ = NULL;
+  return *this;
+}
+
 void MatlBuyPolicy::set_manager(Agent* m) {
   if (m != NULL) {
     Trader::manager_ = m;
@@ -235,6 +248,12 @@ MatlBuyPolicy& MatlBuyPolicy::Set(std::string commod, Composition::Ptr c,
   d.comp = c;
   d.pref = pref;
   commod_details_[commod] = d;
+  return *this;
+}
+
+MatlBuyPolicy& MatlBuyPolicy::Unset(std::string commod){
+
+  commod_details_.erase(commod);
   return *this;
 }
 

--- a/src/toolkit/matl_buy_policy.cc
+++ b/src/toolkit/matl_buy_policy.cc
@@ -36,7 +36,7 @@ MatlBuyPolicy::~MatlBuyPolicy() {
 
 MatlBuyPolicy& MatlBuyPolicy::ResetBehavior() {
   throughput_ = std::numeric_limits<double>::max();
-  quantize_ = 1;
+  quantize_ = -1;
   fill_to_ = std::numeric_limits<double>::max();
   req_at_ = std::numeric_limits<double>::max();
   cumulative_cap_ = -1;

--- a/src/toolkit/matl_buy_policy.h
+++ b/src/toolkit/matl_buy_policy.h
@@ -141,6 +141,13 @@ class MatlBuyPolicy : public Trader {
                       IntDistribution::Ptr);
   /// @}
 
+  /// Reset a material buy policy parameters that govern its behavior 
+  /// to the default state.  Preserve the Trader that manages the policy.
+  /// The primary use case of this method is when there is a desire to
+  /// change the behavior of a policy. This reset can be called prior
+  /// to calling a new `Init()` to establish the new behavior.
+  MatlBuyPolicy& ResetBehavior();
+
   /// Instructs the policy to fill its buffer with requests on the given
   /// commodity of composition c and the given preference.  This must be called
   /// at least once or the policy will do nothing.  The policy can request on an
@@ -155,6 +162,9 @@ class MatlBuyPolicy : public Trader {
   MatlBuyPolicy& Set(std::string commod, Composition::Ptr c);
   MatlBuyPolicy& Set(std::string commod, Composition::Ptr c, double pref);
   /// @}
+
+  /// Instructs the policy to stop requesting a speific commodity
+  MatlBuyPolicy& Unset(std::string commod);
 
   /// Registers this policy as a trader in the current simulation.  This
   /// function must be called for the policy to begin participating in resource

--- a/tests/toolkit/matl_buy_policy_tests.cc
+++ b/tests/toolkit/matl_buy_policy_tests.cc
@@ -140,6 +140,39 @@ TEST_F(MatlBuyPolicyTests, Init_RQ) {
   p.Init(fac1, &buff, "", &buff_tracker, "RQ", Q, R);  
   ASSERT_FALSE(p.MakeReq());
 }
+TEST_F(MatlBuyPolicyTests, ResetBehavior) {
+  double cap = 10;
+  ResBuf<Material> buff;
+  buff.capacity(cap);
+  TotalInvTracker buff_tracker({&buff});
+  MatlBuyPolicy p;
+
+  double amt;
+
+  // Setup up initially with sS policy
+  double S = 4, s = 2;
+  p.Init(fac1, &buff, "", &buff_tracker, "sS", S, s);
+  ASSERT_TRUE(p.MakeReq());
+  amt = p.TotalAvailable();
+  ASSERT_FLOAT_EQ(amt, S);
+  ASSERT_FLOAT_EQ(p.ReqQty(amt), S);
+  ASSERT_EQ(p.NReq(amt), 1);
+
+  // Attempt to reinitialize with no strategy WITHOUT reset
+  p.Init(fac1, &buff, "", &buff_tracker, std::numeric_limits<double>::max()); 
+  amt = p.TotalAvailable();
+  ASSERT_NE(amt, cap);
+  ASSERT_NE(p.ReqQty(amt), cap);
+
+  // reset and initialize with no strategy
+  p.ResetBehavior();
+  p.Init(fac1, &buff, "", &buff_tracker, std::numeric_limits<double>::max()); 
+  amt = p.TotalAvailable();
+  ASSERT_FLOAT_EQ(amt, cap);
+  ASSERT_FLOAT_EQ(p.ReqQty(amt), cap);
+  ASSERT_EQ(p.NReq(amt), 1);
+
+}
 
 TEST_F(MatlBuyPolicyTests, StartStop) {
   double cap = 5;


### PR DESCRIPTION
Introduce methods that allow us to reset a buy policy in case we want to initialize it with better behavior.

Also allow us to unset a specific commodity.