### PR TITLE
Fix ResBuf Decay

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -111,7 +111,7 @@ v1.6.0
 * Resolve pytest and compilation warnings related to invalid escape sequences (#1684, #1698)
 * Fix how Env::GetInstallPath() finds the location of the cyclus installation (#1689)
 * Fix Debian package generation (#1676)
-* Fixed ResBuf.Decay() and added test ()
+* Fixed ResBuf.Decay() and added test (#1825)
 
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -111,6 +111,7 @@ v1.6.0
 * Resolve pytest and compilation warnings related to invalid escape sequences (#1684, #1698)
 * Fix how Env::GetInstallPath() finds the location of the cyclus installation (#1689)
 * Fix Debian package generation (#1676)
+* Fixed ResBuf.Decay() and added test ()
 
 
 

--- a/src/toolkit/res_buf.h
+++ b/src/toolkit/res_buf.h
@@ -352,8 +352,8 @@ class ResBuf {
   /// @param curr_time time to calculate decay inventory
   ///        (default: -1 uses the current time of the context)
   void Decay(int curr_time = -1) {
-    for (int i = 0; i < rs_.size(); i++) {
-      rs_.at(i)->Decay(curr_time);
+    for (auto rs : rs_) {
+      rs->Decay(curr_time);
     }
   }
 

--- a/tests/material_tests.cc
+++ b/tests/material_tests.cc
@@ -7,6 +7,7 @@
 #include "cyc_limits.h"
 #include "toolkit/mat_query.h"
 #include "error.h"
+#include "toolkit/res_buf.h"
 
 using pyne::nucname::id;
 
@@ -206,6 +207,28 @@ TEST_F(MaterialTest, ExtractInGrams) {
   // and it should be okay to extract part of the original composiiton IN GRAMS
   EXPECT_NO_THROW(default_mat_->ExtractComp(g_to_rem * units::g, comp_to_rem));
   EXPECT_DOUBLE_EQ(test_size_ - kg_to_rem, default_mat_->quantity());
+}
+
+TEST_F(MaterialTest, DecayResBuf) {
+  // prequeries
+  cyclus::toolkit::MatQuery orig(tracked_mat_);
+  double u235_qty = orig.mass(u235_);
+  double pb208_qty = orig.mass(pb208_);
+  double am241_qty = orig.mass(am241_);
+  double orig_mass = tracked_mat_->quantity();
+
+  cyclus::toolkit::ResBuf<cyclus::Material> res_buf;
+  res_buf.Push(tracked_mat_);
+  res_buf.Decay(100);
+  cyclus::Material::Ptr pop_mat = res_buf.Pop();
+
+  // postquery
+  cyclus::toolkit::MatQuery mq(pop_mat);
+
+  // postchecks
+  EXPECT_NE(u235_qty, mq.mass(u235_));
+  EXPECT_NE(pb208_qty, mq.mass(pb208_));
+  EXPECT_NE(am241_qty, mq.mass(am241_));
 }
 
 TEST_F(MaterialTest, DecayManual) {

--- a/tests/material_tests.cc
+++ b/tests/material_tests.cc
@@ -215,11 +215,13 @@ TEST_F(MaterialTest, DecayResBuf) {
   double u235_qty = orig.mass(u235_);
   double pb208_qty = orig.mass(pb208_);
   double am241_qty = orig.mass(am241_);
+  double sr89_qty = orig.mass(sr89_);
   double orig_mass = tracked_mat_->quantity();
 
   cyclus::toolkit::ResBuf<cyclus::Material> res_buf;
   res_buf.Push(tracked_mat_);
-  res_buf.Decay(100);
+  // decay for 2 months which is just over 1 Sr-89 half-life
+  res_buf.Decay(2);
   cyclus::Material::Ptr pop_mat = res_buf.Pop();
 
   // postquery
@@ -229,6 +231,7 @@ TEST_F(MaterialTest, DecayResBuf) {
   EXPECT_NE(u235_qty, mq.mass(u235_));
   EXPECT_NE(pb208_qty, mq.mass(pb208_));
   EXPECT_NE(am241_qty, mq.mass(am241_));
+  EXPECT_NE(sr89_qty, mq.mass(sr89_));
 }
 
 TEST_F(MaterialTest, DecayManual) {
@@ -237,6 +240,7 @@ TEST_F(MaterialTest, DecayManual) {
   double u235_qty = orig.mass(u235_);
   double pb208_qty = orig.mass(pb208_);
   double am241_qty = orig.mass(am241_);
+  double sr89_qty = orig.mass(sr89_);
   double orig_mass = tracked_mat_->quantity();
 
   tracked_mat_->Decay(100);
@@ -248,6 +252,7 @@ TEST_F(MaterialTest, DecayManual) {
   EXPECT_NE(u235_qty, mq.mass(u235_));
   EXPECT_NE(pb208_qty, mq.mass(pb208_));
   EXPECT_NE(am241_qty, mq.mass(am241_));
+  EXPECT_NE(sr89_qty, mq.mass(sr89_));
 }
 
 TEST_F(MaterialTest, DecayLazy) {

--- a/tests/material_tests.h
+++ b/tests/material_tests.h
@@ -18,7 +18,7 @@ namespace cyclus {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 class MaterialTest : public ::testing::Test {
  protected:
-  Nuc u235_, am241_, th228_, pb208_, pu239_;
+  Nuc u235_, am241_, th228_, pb208_, pu239_, sr89_;
   int one_g_;  // grams
   Composition::Ptr test_comp_, diff_comp_;
   double test_size_, fraction;
@@ -56,6 +56,7 @@ class MaterialTest : public ::testing::Test {
     am241_ = 952410000;
     th228_ = 902280000;
     pb208_ = 822080000;
+    sr89_ = 380890000;
     test_size_ = 10 * units::g;
     fraction = 2.0 / 3.0;
 
@@ -67,6 +68,7 @@ class MaterialTest : public ::testing::Test {
     v[u235_] = 1;
     v[pb208_] = 1;
     v[am241_] = 1;
+    v[sr89_] = 1;
     diff_comp_ = Composition::CreateFromMass(v);
 
     default_mat_ = Material::CreateUntracked(0 * units::g, test_comp_);


### PR DESCRIPTION
The new `Decay()` method added to `ResBuf` had a syntax error for `std::list` but was never exposed because templating meant that it was never compiled.

This fixes the loop over the contents of the buffer and adds a test.  The test was added to `material_tests.cc` because it already had all the infrastructure for testing decay.

Closes #1823 (but not in the way it intended)