### PR TITLE
Pin `python<3.13` in CI

### DIFF
--- a/.github/workflows/macos_build_test.yml
+++ b/.github/workflows/macos_build_test.yml
@@ -54,6 +54,7 @@ jobs:
       - name: Set up Miniconda
         uses: conda-incubator/setup-miniconda@v3
         with:
+          python-version: "3.12"
           miniforge-version: "latest"
           conda-solver: "libmamba"
           auto-update-conda: true

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,7 @@ Since last release
 * Temporarily pin Boost libraries to <1.86.0 (#1796)
 * Package GetFillMass returns vector of masses (#1790, #1813)
 * Modified Doxygen homepage (#1815)
+* Pin ``python<3.13`` in CI workflows (#1826)
 
 **Removed:**
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -58,7 +58,7 @@ RUN mamba init bash
 SHELL ["/bin/bash", "--login",  "-c"]
 RUN mamba create -n cyclus
 SHELL ["mamba", "run", "--no-capture-output", "-n", "cyclus", "/bin/bash", "-c"]
-RUN mamba update -y python --no-pin && \
+RUN mamba install -y "python<3.13" --no-pin && \
     mamba update -y --all && \
     mamba install -y \
                compilers \


### PR DESCRIPTION
Temporarily pin python until other packages have full support for python3.13 (specifically cython(?), see https://github.com/cyclus/cyclus/issues/1824#issuecomment-2440267587)