### PR TITLE
Active/dormant cycle lengths database table

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Since last release
 * Methods to reset behavaiors of MaterialBuyPolicy (#1822)
 * More random distributions for the random number generator (#1821, #1827)
 * Added example of header code injection for facility cost (#1829)
+* Table for recording active/dormant cycle periods (#1830)
 
 **Changed:**
 

--- a/src/toolkit/matl_buy_policy.cc
+++ b/src/toolkit/matl_buy_policy.cc
@@ -348,18 +348,11 @@ void MatlBuyPolicy::SetNextActiveTime() {
   int active_length = active_dist_->sample();
   next_active_end_ = active_length + manager()->context()->time();
   if (manager() != NULL) {
-    std::string adtype;
     if (use_cumulative_capacity()) {
-      adtype = "CumulativeCap";
+      RecordActiveDormantTime(manager()->context()->time(), "CumulativeCap", active_length);
     } else {
-      adtype = "Active";
+      RecordActiveDormantTime(manager()->context()->time(), "Active", active_length);
     }
-    manager()->context()->NewDatum("BuyPolActiveDormant")
-                        ->AddVal("Agent", manager()->id())
-                        ->AddVal("Time", manager()->context()->time())
-                        ->AddVal("Type", adtype)
-                        ->AddVal("Length", active_length)
-                        ->Record();
   }
   return;
 };
@@ -385,13 +378,7 @@ void MatlBuyPolicy::SetNextDormantTime() {
   }
   next_dormant_end_ = dormant_length + dormant_start;
   if (manager() != NULL) {
-    std::string adtype = "Dormant";
-    manager()->context()->NewDatum("BuyPolActiveDormant")
-                        ->AddVal("Agent", manager()->id())
-                        ->AddVal("Time", dormant_start)
-                        ->AddVal("Type", adtype)
-                        ->AddVal("Length", dormant_length)
-                        ->Record();
+    RecordActiveDormantTime(dormant_start, "Dormant", dormant_length);
   }
   return;
 }
@@ -410,6 +397,16 @@ void MatlBuyPolicy::CheckActiveDormantCumulativeTimes() {
       LGH(INFO4) << "end of dormant period, next active time end: " << next_active_end_ << ", and next dormant time end: " << next_dormant_end_ << std::endl;
       }
   }
+  return;
+}
+
+void MatlBuyPolicy::RecordActiveDormantTime(int time, std::string type, int length) {
+  manager()->context()->NewDatum("BuyPolActiveDormant")
+                      ->AddVal("Agent", manager()->id())
+                      ->AddVal("Time", time)
+                      ->AddVal("Type", type)
+                      ->AddVal("Length", length)
+                      ->Record();
   return;
 }
 

--- a/src/toolkit/matl_buy_policy.cc
+++ b/src/toolkit/matl_buy_policy.cc
@@ -366,20 +366,23 @@ void MatlBuyPolicy::SetNextActiveTime() {
 
 void MatlBuyPolicy::SetNextDormantTime() {
   int dormant_length;
+  int dormant_start;
   if (use_cumulative_capacity()) {
     // need the +1 when not using next_active_end_ 
     dormant_length = dormant_dist_->sample();
-    next_dormant_end_ = dormant_length + manager()->context()->time() + 1;
+    dormant_start = manager()->context()->time() + 1;
   }
   else if (next_dormant_end_ >= 0) {
     dormant_length = dormant_dist_->sample();
-    next_dormant_end_ = dormant_length + std::max(next_active_end_, 1);
+    dormant_start = std::max(next_active_end_, 1);
+    
   }
+  next_dormant_end_ = dormant_length + dormant_start;
   if (manager() != NULL) {
     std::string adtype = "Dormant";
     manager()->context()->NewDatum("BuyPolActiveDormant")
                         ->AddVal("Agent", manager()->id())
-                        ->AddVal("Time", manager()->context()->time())
+                        ->AddVal("Time", dormant_start)
                         ->AddVal("Type", adtype)
                         ->AddVal("Length", dormant_length)
                         ->Record();

--- a/src/toolkit/matl_buy_policy.cc
+++ b/src/toolkit/matl_buy_policy.cc
@@ -380,7 +380,7 @@ void MatlBuyPolicy::SetNextDormantTime() {
     // length and add to active cycle
     dormant_length = dormant_dist_->sample();
     dormant_start = std::max(next_active_end_, 1);
-  } else { // always active. Do not enter dormant
+  } else { // next_active_end_ < 0 used to indicate always active. Do not enter dormant
     return;
   }
   next_dormant_end_ = dormant_length + dormant_start;

--- a/src/toolkit/matl_buy_policy.cc
+++ b/src/toolkit/matl_buy_policy.cc
@@ -368,14 +368,20 @@ void MatlBuyPolicy::SetNextDormantTime() {
   int dormant_length;
   int dormant_start;
   if (use_cumulative_capacity()) {
-    // need the +1 when not using next_active_end_ 
+    // cumulative_cap dormant portion is updated only after the active cycle
+    // ends, because it's based on actual material recieved and not a dist
+    // that can be sampled at any time. Therefore, need the +1 when 
+    // because next_active_end_ is not useful
     dormant_length = dormant_dist_->sample();
     dormant_start = manager()->context()->time() + 1;
   }
-  else if (next_dormant_end_ >= 0) {
+  else if (next_dormant_end_ >= 0) { 
+    // dormant dist is used, and so is active dist. Just need to sample for
+    // length and add to active cycle
     dormant_length = dormant_dist_->sample();
     dormant_start = std::max(next_active_end_, 1);
-    
+  } else { // always active. Do not enter dormant
+    return;
   }
   next_dormant_end_ = dormant_length + dormant_start;
   if (manager() != NULL) {

--- a/src/toolkit/matl_buy_policy.h
+++ b/src/toolkit/matl_buy_policy.h
@@ -231,6 +231,7 @@ class MatlBuyPolicy : public Trader {
   void SetNextDormantTime();
   double SampleRequestSize();
   void CheckActiveDormantCumulativeTimes();
+  void RecordActiveDormantTime(int time, std::string type, int length);
 
  private:
   struct CommodDetail {


### PR DESCRIPTION
With all the new active/dormant cycle options in the buy policy, spurred on by random distributions (#1634, #1596,  #1827, #1821), inventory space alone does not govern whether buy-policy-implementing agents request materials at any given time step. However, we weren't recording the length of active/dormant cycles anywhere and it's not straightforward to pull from other tables. 

 I found myself wishing that I could hone in on details about active/dormant lengths. For example, when using the new binary distribution (#1827) I want to see easily if/when the simulation undergoes a disruption. It also provides a convenient way to pull the distribution of cycle lengths separate from relying on demand and transactions, which are confounded with additional information.

A broader way to approach this idea might be to have a table that records all the random numbers pulled from the simulation-managed PRNG. In fact, that might still be useful? I think that this table is useful because it can also record the relevant agent and the relevant time, which isn't necessarily the current time

This is still a draft because I'm still seeing how my own need for this info involves. But I opened a PR because I'm happy to take requests or feedback