### PR TITLE
Add CI to trigger feedstock rebuild on push to `main`

### DIFF
--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -191,7 +191,6 @@ jobs:
       - name: Set up Miniconda
         uses: conda-incubator/setup-miniconda@v3
         with:
-          python-version: "3.12"
           miniforge-version: "latest"
           conda-solver: "libmamba"
           auto-update-conda: true

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -227,4 +227,4 @@ jobs:
             --draft \
             --label automerge \
             --title "Cyclus commit \`main - ${SHORT_SHA}\`" \
-            --body "Auto-triggered PR from push to Cyclus `main` branch.  If CI passes this will be merged automatically."
+            --body "Auto-triggered PR from push to Cyclus \`main\` branch.  If CI passes this will be merged automatically."

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -215,4 +215,4 @@ jobs:
           git add .
           git commit -m "Trigger build for Cyclus commit ${SHORT_SHA}"
           git push --set-upstream origin ${NEW_BRANCH}
-          gh pr create --repo conda-forge/cyclus-feedstock --base dev --draft --label automerge --title "Cyclus `main - ${SHORT_SHA}`"
+          gh pr create --repo conda-forge/cyclus-feedstock --base dev --draft --label automerge --title "Cyclus `main - ${SHORT_SHA}`" --fill

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -178,8 +178,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: bennibbelink/cyclus-feedstock
-          ref: dev
           token: ${{ secrets.FEEDSTOCK_TOKEN }}
+
+      - name: Sync fork
+        env:
+          GH_TOKEN: ${{ secrets.FEEDSTOCK_TOKEN }}
+        run: |
+          gh repo sync bennibbelink/cyclus-feedstock -b main
+          gh repo sync bennibbelink/cyclus-feedstock -b dev
 
       - name: Set up Miniconda
         uses: conda-incubator/setup-miniconda@v3
@@ -215,4 +221,10 @@ jobs:
           git add .
           git commit -m "Trigger build for Cyclus commit ${SHORT_SHA}"
           git push --set-upstream origin ${NEW_BRANCH}
-          gh pr create --repo conda-forge/cyclus-feedstock --base dev --draft --label automerge --title "Cyclus `main - ${SHORT_SHA}`" --fill
+          gh pr create \
+            --repo conda-forge/cyclus-feedstock \
+            --base dev \
+            --draft \
+            --label automerge \
+            --title "Cyclus commit `main - ${SHORT_SHA}`" \
+            --body "Auto-triggered PR from push to Cyclus `main` branch.  If CI passes this will be merged automatically."

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -227,4 +227,4 @@ jobs:
             --draft \
             --label automerge \
             --title "Cyclus commit \`main - ${SHORT_SHA}\`" \
-            --body "Auto-triggered PR from push to Cyclus \`main\` branch.  If CI passes this will be merged automatically."
+            --body "Auto-triggered PR from a push to Cyclus \`main\` branch.  If CI passes this will be merged automatically."

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -174,7 +174,7 @@ jobs:
       - name: Checkout cyclus-feedstock
         uses: actions/checkout@v4
         with:
-          repository: bennnibbelink/cyclus-feedstock
+          repository: bennibbelink/cyclus-feedstock
           ref: dev
 
       - name: PR cyclus-feedstock

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -181,7 +181,28 @@ jobs:
           ref: dev
           token: ${{ secrets.FEEDSTOCK_TOKEN }}
 
+      - name: Set up Miniconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          python-version: "3.12"
+          miniforge-version: "latest"
+          conda-solver: "libmamba"
+          auto-update-conda: true
+          channels: conda-forge
+
+      - name: Increment build number and rerender
+        shell: bash -el {0}
+        run: |
+          mamba install -y yq conda-smithy
+          BUILD_NUMBER=$(yq eval '.build.number' recipe/meta.yaml)
+          NEW_BUILD_NUMBER=$((BUILD_NUMBER + 1))
+          yq eval ".build.number = ${NEW_BUILD_NUMBER}" -i recipe/meta.yaml
+          conda-smithy rerender
+
       - name: PR cyclus-feedstock
+        env:
+          GH_TOKEN: ${{ secrets.FEEDSTOCK_TOKEN }}
+        shell: bash -el {0}
         run: |
           SHORT_SHA=$(echo ${{github.sha}} | cut -c1-7)
           NEW_BRANCH=cyclus-${SHORT_SHA}
@@ -190,6 +211,7 @@ jobs:
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
           git checkout -b ${NEW_BRANCH}
-          git commit --allow-empty -m "Trigger build for Cyclus commit ${SHORT_SHA}"
+          git add .
+          git commit -m "Trigger build for Cyclus commit ${SHORT_SHA}"
           git push --set-upstream origin ${NEW_BRANCH}
           gh pr create --repo conda-forge/cyclus-feedstock --base dev --draft --label automerge --title "Cyclus `main - ${SHORT_SHA}`"

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -179,7 +179,7 @@ jobs:
         with:
           repository: bennibbelink/cyclus-feedstock
           ref: dev
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.FEEDSTOCK_TOKEN }}
 
       - name: PR cyclus-feedstock
         run: |

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -155,3 +155,31 @@ jobs:
           tags: ghcr.io/cyclus/cyclus_rocky_${{ matrix.rocky_versions }}/cyclus:${{ env.tag }}
           build-args: |
             rocky_version=${{ matrix.rocky_versions }}
+
+
+  trigger-feedstock-ci:
+    if: github.event.workflow == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install GitHub CLI
+        run: |
+          (type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
+          && sudo mkdir -p -m 755 /etc/apt/keyrings \
+          && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+          && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+          && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+          && sudo apt update \
+          && sudo apt install gh -y
+
+      - name: Checkout cyclus-feedstock
+        uses: actions/checkout@v4
+        with:
+          repository: bennnibbelink/cyclus-feedstock
+          ref: dev
+
+      - name: PR cyclus-feedstock
+        run: |
+          git checkout -b cyclus-${{ github.sha }}
+          git commit --allow-empty -m "Trigger build for Cyclus commit ${{ github.sha }}"
+          git push
+          gh pr create --repo conda-forge/cyclus-feedstock --base dev --draft --label automerge --title "Cyclus `main - ${{ github.sha }}`"

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -158,6 +158,9 @@ jobs:
 
 
   trigger-feedstock-ci:
+    permissions:
+      contents: write
+      pull-requests: write
     # if: github.event.workflow == 'push'
     runs-on: ubuntu-latest
     steps:
@@ -176,6 +179,7 @@ jobs:
         with:
           repository: bennibbelink/cyclus-feedstock
           ref: dev
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: PR cyclus-feedstock
         run: |
@@ -183,8 +187,8 @@ jobs:
           NEW_BRANCH=cyclus-${SHORT_SHA}
           echo ${SHORT_SHA}
           echo ${NEW_BRANCH}
-          git config user.email "cyclus-bot@email.com"
-          git config user.name "cyclus-bot"
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
           git checkout -b ${NEW_BRANCH}
           git commit --allow-empty -m "Trigger build for Cyclus commit ${SHORT_SHA}"
           git push --set-upstream origin ${NEW_BRANCH}

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -181,7 +181,8 @@ jobs:
         run: |
           pwd
           ls -l
-          cd ${{ github.workspace }}/cyclus-feedstock
+          git config user.email "cyclus-bot@email.com"
+          git config user.name "cyclus-bot"
           git checkout -b cyclus-${{ github.sha }}
           git commit --allow-empty -m "Trigger build for Cyclus commit ${{ github.sha }}"
           git push

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -193,10 +193,11 @@ jobs:
       - name: Increment build number and rerender
         shell: bash -el {0}
         run: |
-          mamba install -y yq conda-smithy
-          BUILD_NUMBER=$(yq eval '.build.number' recipe/meta.yaml)
+          mamba install -y conda-smithy
+          BUILD_NUMBER=$(sed -n 's/^[[:space:]]*number:[[:space:]]*\([0-9][0-9]*\).*/\1/p' recipe/meta.yaml)
           NEW_BUILD_NUMBER=$((BUILD_NUMBER + 1))
-          yq eval ".build.number = ${NEW_BUILD_NUMBER}" -i recipe/meta.yaml
+          echo "NEW_BUILD_NUMBER=${NEW_BUILD_NUMBER}"
+          sed -i "s/^\([[:space:]]*number:[[:space:]]*\)[0-9][0-9]*/\1$NEW_BUILD_NUMBER/" recipe/meta.yaml
           conda-smithy rerender
 
       - name: PR cyclus-feedstock

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -161,7 +161,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    # if: github.event.workflow == 'push'
+    if: github.event.workflow == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Install GitHub CLI

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -178,6 +178,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: bennibbelink/cyclus-feedstock
+          ref: dev
           token: ${{ secrets.FEEDSTOCK_TOKEN }}
 
       - name: Sync fork
@@ -186,7 +187,6 @@ jobs:
         run: |
           gh repo sync bennibbelink/cyclus-feedstock -b main
           gh repo sync bennibbelink/cyclus-feedstock -b dev
-          git checkout dev
 
       - name: Set up Miniconda
         uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -158,7 +158,7 @@ jobs:
 
 
   trigger-feedstock-ci:
-    if: github.event.workflow == 'push'
+    # if: github.event.workflow == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Install GitHub CLI

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -179,11 +179,13 @@ jobs:
 
       - name: PR cyclus-feedstock
         run: |
-          pwd
-          ls -l
+          SHORT_SHA=$(echo ${{github.sha}} | cut -c1-7)
+          NEW_BRANCH=cyclus-${SHORT_SHA}
+          echo ${SHORT_SHA}
+          echo ${NEW_BRANCH}
           git config user.email "cyclus-bot@email.com"
           git config user.name "cyclus-bot"
-          git checkout -b cyclus-${{ github.sha }}
-          git commit --allow-empty -m "Trigger build for Cyclus commit ${{ github.sha }}"
-          git push
-          gh pr create --repo conda-forge/cyclus-feedstock --base dev --draft --label automerge --title "Cyclus `main - ${{ github.sha }}`"
+          git checkout -b ${NEW_BRANCH}
+          git commit --allow-empty -m "Trigger build for Cyclus commit ${SHORT_SHA}"
+          git push --set-upstream origin ${NEW_BRANCH}
+          gh pr create --repo conda-forge/cyclus-feedstock --base dev --draft --label automerge --title "Cyclus `main - ${SHORT_SHA}`"

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -186,6 +186,7 @@ jobs:
         run: |
           gh repo sync bennibbelink/cyclus-feedstock -b main
           gh repo sync bennibbelink/cyclus-feedstock -b dev
+          git checkout dev
 
       - name: Set up Miniconda
         uses: conda-incubator/setup-miniconda@v3
@@ -226,5 +227,5 @@ jobs:
             --base dev \
             --draft \
             --label automerge \
-            --title "Cyclus commit `main - ${SHORT_SHA}`" \
+            --title "Cyclus commit \`main - ${SHORT_SHA}\`" \
             --body "Auto-triggered PR from push to Cyclus `main` branch.  If CI passes this will be merged automatically."

--- a/.github/workflows/publish_latest.yml
+++ b/.github/workflows/publish_latest.yml
@@ -179,6 +179,9 @@ jobs:
 
       - name: PR cyclus-feedstock
         run: |
+          pwd
+          ls -l
+          cd ${{ github.workspace }}/cyclus-feedstock
           git checkout -b cyclus-${{ github.sha }}
           git commit --allow-empty -m "Trigger build for Cyclus commit ${{ github.sha }}"
           git push


### PR DESCRIPTION
The `dev` branch of `conda-forge/cyclus-feedstock` will build a conda package from the `main` branch of cyclus, but has no way of knowing when new commits are made to `cyclus/cyclus`.  This PR adds CI to automate the process of rebuilding those `dev` conda packages when our cyclus `main` branch has new commits.  

The new CI job does the following:
1. Syncs the fork of cyclus-feedstock (both main and dev branches)
2. On the dev branch of a cyclus-feedstock fork, increment the build number and rerender the feedstock
3. Commit and push these changes to a new branch
4. Create a PR into conda-forge/cyclus-feedstock:dev with the `automerge` label, so if CI passes it will get merged automatically

I tested this on my forks (using different triggers for debugging's sake) and auto-created [this PR](https://github.com/conda-forge/cyclus-feedstock/pull/97) as a POC (in draft state so it doesn't get automerged).  To implement this in the main `cyclus/cyclus` repo it would require that we create a fork of `conda-forge/cyclus-feedstock` owned by the `cyclus` organization so that all PRs to `conda-forge/cyclus-feedstock` come from this organization-owned fork.  

I also created a personal access token (with repo access) and exposed it as a repository secret `FEEDSTOCK_TOKEN` in `bennibbelink/cyclus`.  This is how I enabled the actions run in `bennibbelink/cyclus` to have permissions to write to `bennibbelink/cyclus-feedstock`.  I am not sure what the equivalent of this permissioning looks like at the organization level, but we need some way to give the workflow in `cyclus/cyclus` access to `cyclus/cyclus-feedstock`.  @gonuke do you have a better idea of what options are available at the organization level to make this work? I've looked at [these docs](https://docs.github.com/en/organizations/managing-programmatic-access-to-your-organization/about-programmatic-access-in-your-organization) but I feel like we had a similar issue when configuring package write permissions, and the methods listed in those docs don't look familiar to me.

TODO: 

- [ ] remove --draft flag
- [ ] reference cyclus/cyclus-feedstock instead of bennibbelink/cyclus-feedstock