### PR TITLE
Set locale before (de)serializing data for SQLite

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -52,6 +52,7 @@ Since last release
 * No longer use deprecated Numpy Cython api when Cython>=3 (#1811)
 * ResTracker Extract gave the wrong parent_id to one of the child resources (#1806)
 * Support Boost v1.86 (#1792)
+* Set locale when writing/reading from serialized SQLite data (#1837)
 
 
 v1.6.0

--- a/src/sqlite_back.cc
+++ b/src/sqlite_back.cc
@@ -2,6 +2,7 @@
 
 #include <iomanip>
 #include <sstream>
+#include <locale>
 
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid_io.hpp>
@@ -258,6 +259,7 @@ void SqliteBack::Bind(boost::spirit::hold_any v, DbTypes type, SqlStatement::Ptr
     case D: { \
     T vect = v.cast<T>(); \
     std::stringstream ss; \
+    ss.imbue(std::locale("")); \
     { \
       boost::archive::xml_oarchive ar(ss); \
       ar & BOOST_SERIALIZATION_NVP(vect); \
@@ -376,6 +378,7 @@ boost::spirit::hold_any SqliteBack::ColAsVal(SqlStatement::Ptr stmt,
       case D: { \
       char* data =  stmt->GetText(col, NULL); \
       std::stringstream ss; \
+      ss.imbue(std::locale("")); \
       ss << data; \
       boost::archive::xml_iarchive ar(ss); \
       T vect; \

--- a/tests/sqlite_back_tests.cc
+++ b/tests/sqlite_back_tests.cc
@@ -41,6 +41,50 @@ class SqliteBackTests : public ::testing::Test {
 //       EXPECT_NO_THROW(f = qr.GetVal<Foo>("python"));
 //     }
 
+TEST_F(SqliteBackTests, Locale_HU) {
+  typedef int Foo;
+  Foo f;
+  r.NewDatum("nukleáris")
+      ->AddVal("jó", f)
+      ->Record();
+  r.Close();
+  cyclus::QueryResult qr = b->Query("nukleáris", NULL);
+  EXPECT_NO_THROW(f = qr.GetVal<Foo>("jó"));
+}
+
+TEST_F(SqliteBackTests, Locale_AR) {
+  typedef int Foo;
+  Foo f;
+  r.NewDatum("نووي")
+      ->AddVal("جيد", f)
+      ->Record();
+  r.Close();
+  cyclus::QueryResult qr = b->Query("نووي", NULL);
+  EXPECT_NO_THROW(f = qr.GetVal<Foo>("جيد"));
+}
+
+TEST_F(SqliteBackTests, Locale_JP) {
+  typedef int Foo;
+  Foo f;
+  r.NewDatum("原子力")
+      ->AddVal("良い", f)
+      ->Record();
+  r.Close();
+  cyclus::QueryResult qr = b->Query("原子力", NULL);
+  EXPECT_NO_THROW(f = qr.GetVal<Foo>("良い"));
+}
+
+TEST_F(SqliteBackTests, Locale_Emoji) {
+  typedef int Foo;
+  Foo f;
+  r.NewDatum("☢️")
+      ->AddVal("👍", f)
+      ->Record();
+  r.Close();
+  cyclus::QueryResult qr = b->Query("☢️", NULL);
+  EXPECT_NO_THROW(f = qr.GetVal<Foo>("👍"));
+}
+
 TEST_F(SqliteBackTests, VecPairPairDoubleDoubleMapStringDouble) {
   typedef std::vector<std::pair<std::pair<double, double>, std::map<std::string, double> > > Foo;
   


### PR DESCRIPTION
Closes https://github.com/cyclus/cymetric/issues/205.  

I think there must be some inconsistency with how `libc++` and `libboost` handle default locales.  This PR calls `ss.imbue()` to set the locale according to the user's environment, which seems to solve the segfault describe in https://github.com/cyclus/cymetric/issues/205 (at least when I build and test on my arm Mac machine).  We could hardcode this to the "C" locale if we want to make it more robust.  The instance where I could see issues arising is if a user runs a sim in one environment then reads the SQLite DB in a different environment with a different locale.

