### PR TITLE
Update mamba management in Dockerfile to reflect new mamba cli

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -52,6 +52,7 @@ Since last release
 * No longer use deprecated Numpy Cython api when Cython>=3 (#1811)
 * ResTracker Extract gave the wrong parent_id to one of the child resources (#1806)
 * Support Boost v1.86 (#1792)
+* Support mamba v2 CLI in Dockerfile (#1839)
 
 
 v1.6.0

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,10 +54,8 @@ RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
     rm ~/miniforge.sh
 
 ENV PATH=/opt/conda/bin:$PATH
-RUN mamba init bash
-SHELL ["/bin/bash", "--login",  "-c"]
 RUN mamba create -n cyclus
-SHELL ["mamba", "run", "--no-capture-output", "-n", "cyclus", "/bin/bash", "-c"]
+SHELL ["mamba", "run", "-n", "cyclus", "/bin/bash", "-c"]
 RUN mamba install -y "python<3.13" --no-pin && \
     mamba update -y --all && \
     mamba install -y \


### PR DESCRIPTION
The latest miniforge release upgrades to mamba v2, which has a slightly different CLI than v1.  Seeing the publish_latest.yml workflow fail after #1837.  This PR updates the Dockerfile to conform to both versions of the mamba CLI.  The biggest discrepancy was the method to initialize the shell (`mamba init bash` vs. `mamba shell init --shell bash`), but since we change the Dockerfile shell to run all commands within `mamba run -n cyclus /bin/bash -c ...` we don't actually have to make any changes to the `.bashrc` within the container.