### PR TITLE
Fix ability to generate a master schema

### DIFF
--- a/.github/workflows/macos_build_test.yml
+++ b/.github/workflows/macos_build_test.yml
@@ -86,7 +86,7 @@ jobs:
             pytables \
             pandas \
             jinja2 \
-            cython \
+            "cython<3.1.0" \
             websockets \
             pprintpp \
             pip

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -55,7 +55,7 @@ Since last release
 * Support Boost v1.86 (#1792)
 * Set locale when writing/reading from serialized SQLite data (#1837)
 * Support mamba v2 CLI in Dockerfile (#1839)
-
+* Allow master schema be to reported with all discoverable archetypes (#1846)
 
 v1.6.0
 ====================

--- a/agents/sink.h
+++ b/agents/sink.h
@@ -86,7 +86,7 @@ class Sink : public cyclus::Facility  {
 
   #pragma cyclus var { \
     "tooltip": "input/request recipe name", \
-    "doc": "Name of recipe to request." \
+    "doc": "Name of recipe to request. " \
            "If empty, sink requests material no particular composition.", \
     "default": "", \
     "uilabel": "Input Recipe",			\

--- a/cli/cyclus.cc
+++ b/cli/cyclus.cc
@@ -350,9 +350,7 @@ int EarlyExitArgs(const ArgInfo& ai) {
     std::cout << Env::nuc_data() << "\n";
     return 0;
   } else if (ai.vm.count("schema")) {
-    std::stringstream f;
-    LoadStringstreamFromFile(f, ai.schema_path);
-    std::cout << f.str() << "\n";
+    std::cout << cyclus::BuildMasterSchema(ai.schema_path) << "\n";
     return 0;
   } else if (ai.vm.count("agent-schema")) {
     std::string name(ai.vm["agent-schema"].as<std::string>());

--- a/cli/cycpp.py
+++ b/cli/cycpp.py
@@ -38,7 +38,7 @@ following handy table!
        namespace from the classes.  Since this gives you direct access to the
        Python interpreter, try to be a little careful.
 :note: Merges the argument (which like with var must evaluate to a dict) with the
-       current class level annotations. Enrties here overwrite previous entries.
+       current class level annotations. Entries here overwrite previous entries.
 
 cycpp is implemented entirely in this file and with tools from the Python standard
 library. It requires Python 2.7+ or Python 3.3+ to run.

--- a/cli/cycpp.py
+++ b/cli/cycpp.py
@@ -37,7 +37,7 @@ following handy table!
        is great for. Any variables defined here are kept in a separate
        namespace from the classes.  Since this gives you direct access to the
        Python interpreter, try to be a little careful.
-:note: Merges the argument (which like with var must evalutae to a dict) with the
+:note: Merges the argument (which like with var must evaluate to a dict) with the
        current class level annotations. Enrties here overwrite previous entries.
 
 cycpp is implemented entirely in this file and with tools from the Python standard

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -78,7 +78,7 @@ RUN mamba install -y "python<3.13" --no-pin && \
                pytables \
                pandas \
                jinja2 \
-               cython \
+               cython<3.1.0 \
                websockets \
                pprintpp \
                pip \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -78,7 +78,7 @@ RUN mamba install -y "python<3.13" --no-pin && \
                pytables \
                pandas \
                jinja2 \
-               cython<3.1.0 \
+               "cython<3.1.0" \
                websockets \
                pprintpp \
                pip \

--- a/share/cyclus-flat.rng.in
+++ b/share/cyclus-flat.rng.in
@@ -1,28 +1,45 @@
 <grammar xmlns="http://relaxng.org/ns/structure/1.0"
-datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  xmlns:a="http://relaxng.org/ns/annotation/1.0"
+  datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
 <start>
 <element name="simulation">
+  <a:documentation>A complete Cyclus simulation</a:documentation>
   <optional><element name="schematype"><text/></element></optional>
 <interleave>
 
   <optional><element name="ui"><text/></element></optional>
 
   <element name ="control">
+    <a:documentation>Block to define control parameters of simulation.</a:documentation>
     <interleave>
       <optional>
-        <element name="simhandle"><data type="string"/></element>
+        <element name="simhandle"> <data type="string"/></element>
       </optional>
-      <element name="duration"><data type="nonNegativeInteger"/></element>
-      <element name="startmonth"><data type="nonNegativeInteger"/></element>
-      <element name="startyear"><data type="nonNegativeInteger"/></element>
+      <element name="duration"> 
+          <a:documentation>Simulation duration in units of time steps. Default time steps
+            are 1 month. See `dt` to change default time step length.</a:documentation>
+          <data type="nonNegativeInteger"/> </element>
+      <element name="startyear"> 
+          <a:documentation>First year of simulation, e.g. 2015 (integer)</a:documentation>
+          <data type="nonNegativeInteger"/> </element>
+      <element name="startmonth">
+        <a:documentation>First month of the simulation, e.g. 3 for March (integer)</a:documentation>
+        <data type="nonNegativeInteger"/> </element>
       <optional> 
-        <element name="decay"><text/></element> 
+        <element name="decay"> 
+          <a:documentation>Mode for when radioactive decay occurs. Choose from "never", "manual", "lazy".</a:documentation>
+          <text/> </element> 
       </optional>
       <optional> 
-        <element name="dt"><data type="nonNegativeInteger"/></element> 
+        <element name="dt">
+            <a:documentation>Length of a time step in seconds. Default: 1 month = 1 year/12.</a:documentation>
+          <data type="nonNegativeInteger"/></element> 
       </optional>
       <optional>
-        <element name="explicit_inventory"> <data type="boolean"/> </element>
+        <element name="explicit_inventory">
+          <a:documentation>A Boolean flag to indicate whether the database should include tables that explicitly
+            record the inventory of each resource buffer in each agent at each time step.</a:documentation>
+          <data type="boolean"/> </element>
       </optional>
       <optional>
         <element name="explicit_inventory_compact"> <data type="boolean"/> </element>

--- a/share/cyclus-flat.rng.in
+++ b/share/cyclus-flat.rng.in
@@ -4,184 +4,200 @@
 <start>
 <element name="simulation">
   <a:documentation>A complete Cyclus simulation</a:documentation>
-  <optional><element name="schematype"><text/></element></optional>
-<interleave>
+  <optional><element name="schematype">
+    <a:documentation>Select between a hierarchical schema (default) and a flat schema.</a:documentation>
+    <text/></element></optional>
 
-  <optional><element name="ui"><text/></element></optional>
+  <interleave>
 
-  <element name ="control">
-    <a:documentation>Block to define control parameters of simulation.</a:documentation>
-    <interleave>
-      <optional>
-        <element name="simhandle"> <data type="string"/></element>
-      </optional>
-      <element name="duration"> 
-          <a:documentation>Simulation duration in units of time steps. Default time steps
-            are 1 month. See `dt` to change default time step length.</a:documentation>
-          <data type="nonNegativeInteger"/> </element>
-      <element name="startyear"> 
-          <a:documentation>First year of simulation, e.g. 2015 (integer)</a:documentation>
-          <data type="nonNegativeInteger"/> </element>
-      <element name="startmonth">
-        <a:documentation>First month of the simulation, e.g. 3 for March (integer)</a:documentation>
-        <data type="nonNegativeInteger"/> </element>
-      <optional> 
-        <element name="decay"> 
-          <a:documentation>Mode for when radioactive decay occurs. Choose from "never", "manual", "lazy".</a:documentation>
-          <text/> </element> 
-      </optional>
-      <optional> 
-        <element name="dt">
-            <a:documentation>Length of a time step in seconds. Default: 1 month = 1 year/12.</a:documentation>
-          <data type="nonNegativeInteger"/></element> 
-      </optional>
-      <optional>
-        <element name="explicit_inventory">
-          <a:documentation>A Boolean flag to indicate whether the database should include tables that explicitly
-            record the inventory of each resource buffer in each agent at each time step.</a:documentation>
-          <data type="boolean"/> </element>
-      </optional>
-      <optional>
-        <element name="explicit_inventory_compact"> <data type="boolean"/> </element>
-      </optional>
-      <optional>
-          <element name="tolerance_generic"><data type="double"/></element>
-      </optional>
-      <optional>
-          <element name="tolerance_resource"><data type="double"/></element>
-      </optional>
-      <optional>
-          <element name="seed"><data type="positiveInteger" /></element>
-      </optional>
-      <optional>
-          <element name="stride"><data type="positiveInteger" /></element>
-      </optional>
-      <optional>
-        <element name="solver"> 
-          <interleave>
-            <optional><element name="config">
-            <choice>
-              <element name="greedy">
-                <interleave>
-                  <optional>
-                    <element name="preconditioner"> <text/> </element>
-                  </optional>
-                </interleave>
-              </element>
-              <element name="coin-or">
-                <interleave>
-                  <optional>
-                    <element name="timeout">  <data type="positiveInteger"/>  </element>
-                  </optional>
-                  <optional><element name="verbose"><data type="boolean"/></element></optional>
-                  <optional><element name="mps"><data type="boolean"/></element></optional>
-                </interleave>
-              </element>
-            </choice>
-            </element></optional>
-            <optional>
-              <element name="allow_exclusive_orders">
-                <data type="boolean" />
-              </element>
-            </optional>
-          </interleave>
-        </element>
-      </optional>
-    </interleave>
-  </element>
+    <optional><element name="ui"><text/></element></optional>
 
-  <zeroOrMore>
-    <element name="commodity">
+    <element name ="control">
+      <a:documentation>Block to define control parameters of simulation.</a:documentation>
       <interleave>
-        <element name="name"><text/></element>
-        <element name="solution_priority"><data type="double"/></element>
-      </interleave>
-    </element>
-  </zeroOrMore>
-
-  <element name="archetypes"> 
-    <oneOrMore>
-      <element name="spec">
-        <interleave>
-          <optional><element name="path"><text/></element></optional>
-          <optional><element name="lib"><text/></element></optional>
-          <element name="name"><text/></element>
-          <optional><element name="alias"><text/></element></optional>
-        </interleave>
-      </element>
-    </oneOrMore>
-  </element>
-
-  <oneOrMore>
-    <element name="prototype">
-    <interleave>
-      <element name="name"><text/></element>
-      <optional>
-        <element name="lifetime"> <data type="nonNegativeInteger"/> </element>
-      </optional>
-
-      <element name="config">
-        <choice>
-          @MODEL_SCHEMAS@
-        </choice>
-      </element>
-
-    </interleave>
-    </element>
-  </oneOrMore>
-
-  <oneOrMore>
-    <element name="agent">
-      <interleave>
-        <element name="name"><text/></element>
-        <element name="prototype"><text/></element>
         <optional>
-          <element name="parent"><text/></element>
+          <element name="simhandle">
+              <a:documentation>A user-defined simulation handle. Default is to generate a long random UUID.</a:documentation>
+              <data type="string"/></element>
+        </optional>
+        <element name="duration"> 
+            <a:documentation>Simulation duration in units of time steps. Default time steps
+              are 1 month. See `dt` to change default time step length.</a:documentation>
+            <data type="nonNegativeInteger"/> </element>
+        <element name="startyear"> 
+            <a:documentation>First year of simulation, e.g. 2015 (integer)</a:documentation>
+            <data type="nonNegativeInteger"/> </element>
+        <element name="startmonth">
+          <a:documentation>First month of the simulation, e.g. 3 for March (integer)</a:documentation>
+          <data type="nonNegativeInteger"/> </element>
+        <optional> 
+          <element name="decay"> 
+            <a:documentation>Mode for when radioactive decay occurs. Choose from "never", "manual", "lazy".</a:documentation>
+            <text/> </element> 
+        </optional>
+        <optional> 
+          <element name="dt">
+            <a:documentation>Length of a time step in seconds. Default: 1 month = 1 year/12.</a:documentation>
+            <data type="nonNegativeInteger"/></element> 
+        </optional>
+        <optional>
+          <element name="explicit_inventory">
+            <a:documentation>A Boolean flag to indicate whether the database should include tables that explicitly
+              record the inventory of each resource buffer in each agent at each time step. (Default: False)</a:documentation>
+            <data type="boolean"/> </element>
+        </optional>
+        <optional>
+          <element name="explicit_inventory_compact">
+            <a:documentation>A Boolean flag to indicate whether the database should include compact tables that explicitly
+              record the inventory of each resource buffer in each agent at each time step. (Default: False)</a:documentation>
+            <data type="boolean"/> </element>
+        </optional>
+        <optional>
+            <element name="tolerance_generic">
+              <a:documentation>Value used as tolerance when comparing two generic floating point numbers. (Default: 1e-06)</a:documentation>
+              <<data type="double"/></element>
+        </optional>
+        <optional>
+            <element name="tolerance_resource">
+              <a:documentation>Value used as tolerance when comparing two resource quantities. (Default: 1e-06)</a:documentation>              
+              <data type="double"/></element>
+        </optional>
+        <optional>
+            <element name="seed">
+              <a:documentation>Value used for seed in built in random number generator. (Default: 20160212)</a:documentation>              
+              <data type="positiveInteger" /></element>
+        </optional>
+        <optional>
+            <element name="stride">
+              <a:documentation>Value used for stride in built in random number generator. (Default: 10000)</a:documentation>              
+              <data type="positiveInteger" /></element>
+        </optional>
+        <optional>
+          <element name="solver"> 
+            <interleave>
+              <optional><element name="config">
+              <choice>
+                <element name="greedy">
+                  <interleave>
+                    <optional>
+                      <element name="preconditioner"> <text/> </element>
+                    </optional>
+                  </interleave>
+                </element>
+                <element name="coin-or">
+                  <interleave>
+                    <optional>
+                      <element name="timeout">  <data type="positiveInteger"/>  </element>
+                    </optional>
+                    <optional><element name="verbose"><data type="boolean"/></element></optional>
+                    <optional><element name="mps"><data type="boolean"/></element></optional>
+                  </interleave>
+                </element>
+              </choice>
+              </element></optional>
+              <optional>
+                <element name="allow_exclusive_orders">
+                  <data type="boolean" />
+                </element>
+              </optional>
+            </interleave>
+          </element>
         </optional>
       </interleave>
     </element>
-  </oneOrMore>
 
-  <zeroOrMore>
-    <element name="recipe">
+    <zeroOrMore>
+      <element name="commodity">
+        <interleave>
+          <element name="name"><text/></element>
+          <element name="solution_priority"><data type="double"/></element>
+        </interleave>
+      </element>
+    </zeroOrMore>
+
+    <element name="archetypes"> 
+      <oneOrMore>
+        <element name="spec">
+          <interleave>
+            <optional><element name="path"><text/></element></optional>
+            <optional><element name="lib"><text/></element></optional>
+            <element name="name"><text/></element>
+            <optional><element name="alias"><text/></element></optional>
+          </interleave>
+        </element>
+      </oneOrMore>
+    </element>
+
+    <oneOrMore>
+      <element name="prototype">
       <interleave>
         <element name="name"><text/></element>
-        <element name="basis"><text/></element>
-        <oneOrMore>
-          <element name="nuclide">
-            <interleave>
-              <element name="id"><data type="string"/></element>
-              <element name="comp"><data type="double"/></element>
-            </interleave>
-          </element>
-        </oneOrMore>
-      </interleave>
-    </element>
-  </zeroOrMore>
+        <optional>
+          <element name="lifetime"> <data type="nonNegativeInteger"/> </element>
+        </optional>
 
-  <zeroOrMore>
-    <element name="package">
-      <interleave>
-        <element name="name"><text/></element>
-        <optional><element name="fill_min"><data type="double"/></element></optional>
-        <optional><element name="fill_max"><data type="double"/></element></optional>
-        <optional><element name="strategy"><text/></element></optional>
-      </interleave>
-    </element>
-  </zeroOrMore>
+        <element name="config">
+          <choice>
+            @MODEL_SCHEMAS@
+          </choice>
+        </element>
 
-  <zeroOrMore>
-    <element name="transportunit">
-      <interleave>
-        <element name="name"><text/></element>
-        <optional><element name="fill_min"><data type="nonNegativeInteger"/></element></optional>
-        <optional><element name="fill_max"><data type="nonNegativeInteger"/></element></optional>
-        <optional><element name="strategy"><text/></element></optional>
       </interleave>
-    </element>
-  </zeroOrMore>
+      </element>
+    </oneOrMore>
 
-</interleave>
+    <oneOrMore>
+      <element name="agent">
+        <interleave>
+          <element name="name"><text/></element>
+          <element name="prototype"><text/></element>
+          <optional>
+            <element name="parent"><text/></element>
+          </optional>
+        </interleave>
+      </element>
+    </oneOrMore>
+
+    <zeroOrMore>
+      <element name="recipe">
+        <interleave>
+          <element name="name"><text/></element>
+          <element name="basis"><text/></element>
+          <oneOrMore>
+            <element name="nuclide">
+              <interleave>
+                <element name="id"><data type="string"/></element>
+                <element name="comp"><data type="double"/></element>
+              </interleave>
+            </element>
+          </oneOrMore>
+        </interleave>
+      </element>
+    </zeroOrMore>
+
+    <zeroOrMore>
+      <element name="package">
+        <interleave>
+          <element name="name"><text/></element>
+          <optional><element name="fill_min"><data type="double"/></element></optional>
+          <optional><element name="fill_max"><data type="double"/></element></optional>
+          <optional><element name="strategy"><text/></element></optional>
+        </interleave>
+      </element>
+    </zeroOrMore>
+
+    <zeroOrMore>
+      <element name="transportunit">
+        <interleave>
+          <element name="name"><text/></element>
+          <optional><element name="fill_min"><data type="nonNegativeInteger"/></element></optional>
+          <optional><element name="fill_max"><data type="nonNegativeInteger"/></element></optional>
+          <optional><element name="strategy"><text/></element></optional>
+        </interleave>
+      </element>
+    </zeroOrMore>
+
+  </interleave>
 </element><!-- end of simulation -->
 </start>
 </grammar>

--- a/share/cyclus-flat.rng.in
+++ b/share/cyclus-flat.rng.in
@@ -55,7 +55,7 @@
         <optional>
             <element name="tolerance_generic">
               <a:documentation>Value used as tolerance when comparing two generic floating point numbers. (Default: 1e-06)</a:documentation>
-              <<data type="double"/></element>
+              <data type="double"/></element>
         </optional>
         <optional>
             <element name="tolerance_resource">
@@ -74,29 +74,45 @@
         </optional>
         <optional>
           <element name="solver"> 
+            <a:documentation>Input block to select the solver mode and provide solver parameters.</a:documentation>
             <interleave>
               <optional><element name="config">
+              <a:documentation>Provide a solver configuration</a:documentation>
               <choice>
                 <element name="greedy">
+                  <a:documentation>Choose the greedy solver</a:documentation>
                   <interleave>
                     <optional>
-                      <element name="preconditioner"> <text/> </element>
+                      <element name="preconditioner"> 
+                        <a:documentation>Select a preconditioner for the greedy solver</a:documentation>
+                        <text/> </element>
                     </optional>
                   </interleave>
                 </element>
                 <element name="coin-or">
+                  <a:documentation>Select the COIN-OR mixed integer linear programming library solver</a:documentation>
                   <interleave>
                     <optional>
-                      <element name="timeout">  <data type="positiveInteger"/>  </element>
+                      <element name="timeout">
+                        <a:documentation>Select a time limit for how long you are willing to let the solver find a solution</a:documentation>
+                        <data type="positiveInteger"/>  </element>
                     </optional>
-                    <optional><element name="verbose"><data type="boolean"/></element></optional>
-                    <optional><element name="mps"><data type="boolean"/></element></optional>
+                    <optional>
+                      <element name="verbose">
+                        <a:documentation>A Boolean variable to determine whether there is verbose output from the COIN-OR solver.</a:documentation>
+                        <data type="boolean"/></element>
+                      </optional>
+                    <optional>
+                      <element name="mps">
+                        <a:documentation>A Boolean variable to determine whether an MPS file is written for each exchange.</a:documentation>
+                        <data type="boolean"/></element></optional>
                   </interleave>
                 </element>
               </choice>
               </element></optional>
               <optional>
                 <element name="allow_exclusive_orders">
+                  <a:documentation>A Boolean variable to determine whether exclusive orders are allowed (default: True)</a:documentation>
                   <data type="boolean" />
                 </element>
               </optional>
@@ -108,21 +124,39 @@
 
     <zeroOrMore>
       <element name="commodity">
+        <a:documentation>Commodities can be listed in order to provide a priority ordering for solving them in the DRE.</a:documentation>
         <interleave>
-          <element name="name"><text/></element>
-          <element name="solution_priority"><data type="double"/></element>
+          <element name="name"> 
+            <a:documentation>The name of a commodity being given priority treatment.</a:documentation>
+            <text/> </element>
+          <element name="solution_priority"> 
+            <a:documentation>The relative solution priority of this commodity. Higher values have higher priorit. (Default: -1)</a:documentation>
+            <data type="double"/> </element>
         </interleave>
       </element>
     </zeroOrMore>
 
     <element name="archetypes"> 
+      <a:documentation>A list of archetypes that will be dynamically loaded for use in agent Prototypes.</a:documentation>
       <oneOrMore>
         <element name="spec">
+          <a:documentation>A complete archetype specification</a:documentation>
           <interleave>
-            <optional><element name="path"><text/></element></optional>
-            <optional><element name="lib"><text/></element></optional>
-            <element name="name"><text/></element>
-            <optional><element name="alias"><text/></element></optional>
+            <optional>
+              <element name="path">
+                <a:documentation>An optional path to find this archetype; only needed if not discoverable in the standard locations.</a:documentation>
+                <text/></element></optional>
+            <optional>
+              <element name="lib">
+                <a:documentation>An optional name for the library that contains this archetype.</a:documentation>
+                <text/></element></optional>
+            <element name="name">
+              <a:documentation>The name that will be used to refer to this archetype.</a:documentation>
+              <text/></element>
+            <optional>
+              <element name="alias">
+                <a:documentation>An optional alias to refer to this archetype by a different name.</a:documentation>
+                <text/></element></optional>
           </interleave>
         </element>
       </oneOrMore>
@@ -130,29 +164,45 @@
 
     <oneOrMore>
       <element name="prototype">
-      <interleave>
-        <element name="name"><text/></element>
-        <optional>
-          <element name="lifetime"> <data type="nonNegativeInteger"/> </element>
-        </optional>
+        <a:documentation>A Facility prototype specification, with archetype,
+          archetype-specific parameters, and general facility parameters. Must
+          occur once, but may occur many times.</a:documentation> 
 
-        <element name="config">
-          <choice>
-            @MODEL_SCHEMAS@
-          </choice>
-        </element>
+        <interleave>
+          <element name="name">
+            <a:documentation>Prototype name</a:documentation>
+            <text/></element>
+          <optional>
+            <element name="lifetime">
+              <a:documentation>Number of time steps that this archetypes is participating after it is deployed.</a:documentation>
+              <data type="nonNegativeInteger"/> </element>
+          </optional>
 
-      </interleave>
+          <element name="config">
+            <a:documentation>Configuration to specify which archetype is being used for this prototype, and then 
+              provide parameters to specify a particular prototype definition.</a:documentation>
+            <choice>
+              @MODEL_SCHEMAS@
+            </choice>
+          </element>
+        </interleave>
       </element>
     </oneOrMore>
 
     <oneOrMore>
       <element name="agent">
+        <a:documentation>Describes an agent that will be deployed in a scenario.</a:documentation>
         <interleave>
-          <element name="name"><text/></element>
-          <element name="prototype"><text/></element>
+          <element name="name">
+            <a:documentation>The name of the agent.</a:documentation>
+            <text/></element>
+          <element name="prototype">
+            <a:documentation>The prototype, specified by name, used for this agent. (Must be specified in a `prototypes` block.)</a:documentation>
+            <text/></element>
           <optional>
-            <element name="parent"><text/></element>
+            <element name="parent">
+              <a:documentation>An agent that acts as a parent to this agent in an arbitrary hierarchical arrangement.</a:documentation>
+              <text/></element>
           </optional>
         </interleave>
       </element>
@@ -160,14 +210,24 @@
 
     <zeroOrMore>
       <element name="recipe">
+        <a:documentation>A material composition recipe that can be reused in other places in the simulation.</a:documentation>
         <interleave>
-          <element name="name"><text/></element>
-          <element name="basis"><text/></element>
+          <element name="name">
+            <a:documentation>The name of the recipe used to refer to it elsewhere.</a:documentation>
+            <text/></element>
+          <element name="basis">
+            <a:documentation>Indicating whether this recipe is defined by mass or atom fraction. Valid values: `mass` or `atom`.</a:documentation>
+            <text/></element>
           <oneOrMore>
             <element name="nuclide">
+              <a:documentation>Information about each nuclde in this composition.</a:documentation>
               <interleave>
-                <element name="id"><data type="string"/></element>
-                <element name="comp"><data type="double"/></element>
+                <element name="id">
+                  <a:documentation>A nuclide identifier in any form allowed by PyNE</a:documentation>
+                  <data type="string"/></element>
+                <element name="comp">
+                  <a:documentation>The relative concentration of this nuclide in the basis defined above.</a:documentation>
+                  <data type="double"/></element>
               </interleave>
             </element>
           </oneOrMore>
@@ -177,22 +237,46 @@
 
     <zeroOrMore>
       <element name="package">
+        <a:documentation>A package that defines how bulk quantities are shipped between facilities.</a:documentation>
         <interleave>
-          <element name="name"><text/></element>
-          <optional><element name="fill_min"><data type="double"/></element></optional>
-          <optional><element name="fill_max"><data type="double"/></element></optional>
-          <optional><element name="strategy"><text/></element></optional>
+          <element name="name">
+            <a:documentation>The name of this package.</a:documentation>
+            <text/></element>
+          <optional>
+            <element name="fill_min">
+              <a:documentation>The minimum amount of material that is allowed to be shipped in this package.</a:documentation>
+              <data type="double"/></element></optional>
+          <optional>
+            <element name="fill_max">
+              <a:documentation>The maximums amount of material that is allowed to be shipped in this package.</a:documentation>            
+              <data type="double"/></element></optional>
+          <optional>
+            <element name="strategy">
+              <a:documentation>The strategy for filling a set of packages.</a:documentation>
+              <text/></element></optional>
         </interleave>
       </element>
     </zeroOrMore>
 
     <zeroOrMore>
       <element name="transportunit">
+        <a:documentation>A transport unit that describes how multiple packages may be shipped in some collection.</a:documentation>
         <interleave>
-          <element name="name"><text/></element>
-          <optional><element name="fill_min"><data type="nonNegativeInteger"/></element></optional>
-          <optional><element name="fill_max"><data type="nonNegativeInteger"/></element></optional>
-          <optional><element name="strategy"><text/></element></optional>
+          <element name="name">
+            <a:documentation>The name of this transport unit.</a:documentation>
+            <text/></element>
+          <optional>
+            <element name="fill_min">
+              <a:documentation>The minimum number of packages allowed to be shipped in this transport unit.</a:documentation>
+              <data type="nonNegativeInteger"/></element></optional>
+          <optional>
+            <element name="fill_max">
+              <a:documentation>The maximum number of packages allowed to be shipped in this transport unit.</a:documentation>
+              <data type="nonNegativeInteger"/></element></optional>
+          <optional>
+            <element name="strategy">
+              <a:documentation>The strategy for filling multiple transport units</a:documentation>
+              <text/></element></optional>
         </interleave>
       </element>
     </zeroOrMore>

--- a/share/cyclus-flat.rng.in
+++ b/share/cyclus-flat.rng.in
@@ -37,7 +37,7 @@
         </optional>
         <optional> 
           <element name="dt">
-            <a:documentation>Length of a time step in seconds. Default: 1 month = 1 year/12.</a:documentation>
+            <a:documentation>Length of a time step in seconds. Default: 1 month = 1 year/12 (i.e. 2,629,846 seconds).</a:documentation>
             <data type="nonNegativeInteger"/></element> 
         </optional>
         <optional>

--- a/share/cyclus.rng.in
+++ b/share/cyclus.rng.in
@@ -6,6 +6,7 @@
 <element name="simulation">
   <a:documentation>A complete Cyclus simulation</a:documentation>
   <optional><element name="schematype">
+    <a:documentation>Select between a hierarchical schema (default) and a flat schema.</a:documentation>
     <text/></element></optional>
 
   <interleave>
@@ -16,7 +17,9 @@
       <a:documentation>Block to define control parameters of simulation.</a:documentation>
       <interleave>
         <optional>
-          <element name="simhandle"> <data type="string"/> </element>
+          <element name="simhandle">
+            <a:documentation>A user-defined simulation handle. Default is to generate a long random UUID.</a:documentation>
+            <data type="string"/> </element>
         </optional>
         <element name="duration"> 
           <a:documentation>Simulation duration in units of time steps. Default time steps
@@ -36,28 +39,39 @@
         <optional> 
           <element name="dt">
             <a:documentation>Length of a time step in seconds. Default: 1 month = 1 year/12.</a:documentation>
-          <data type="nonNegativeInteger"/></element> 
+            <data type="nonNegativeInteger"/></element> 
         </optional>
         <optional>
           <element name="explicit_inventory">
-          <a:documentation>A Boolean flag to indicate whether the database should include tables that explicitly
-            record the inventory of each resource buffer in each agent at each time step.</a:documentation>
-          <data type="boolean"/> </element>
+            <a:documentation>A Boolean flag to indicate whether the database should include tables that explicitly
+              record the inventory of each resource buffer in each agent at each time step. (Default: False)</a:documentation>
+            <data type="boolean"/> </element>
         </optional>
         <optional>
-          <element name="explicit_inventory_compact"> <data type="boolean"/> </element>
+          <element name="explicit_inventory_compact">
+            <a:documentation>A Boolean flag to indicate whether the database should include compact tables that explicitly
+            record the inventory of each resource buffer in each agent at each time step. (Default: False)</a:documentation>
+            <data type="boolean"/> </element>
         </optional>
         <optional>
-            <element name="tolerance_generic"><data type="double"/></element>
+            <element name="tolerance_generic">
+              <a:documentation>Value used as tolerance when comparing two generic floating point numbers. (Default: 1e-06)</a:documentation>
+              <data type="double"/></element>
         </optional>
         <optional>
-            <element name="tolerance_resource"><data type="double"/></element>
+            <element name="tolerance_resource">
+              <a:documentation>Value used as tolerance when comparing two resource quantities. (Default: 1e-06)</a:documentation>              
+              <data type="double"/></element>
         </optional>
         <optional>
-            <element name="seed"><data type="positiveInteger" /></element>
+            <element name="seed">
+              <a:documentation>Value used for seed in built in random number generator. (Default: 20160212)</a:documentation>              
+              <data type="positiveInteger" /></element>
         </optional>
         <optional>
-            <element name="stride"><data type="positiveInteger" /></element>
+            <element name="stride">
+              <a:documentation>Value used for stride in built in random number generator. (Default: 10000)</a:documentation>              
+              <data type="positiveInteger" /></element>
         </optional>
         <optional>
           <element name="solver"> 

--- a/share/cyclus.rng.in
+++ b/share/cyclus.rng.in
@@ -38,7 +38,7 @@
         </optional>
         <optional> 
           <element name="dt">
-            <a:documentation>Length of a time step in seconds. Default: 1 month = 1 year/12.</a:documentation>
+            <a:documentation>Length of a time step in seconds. Default: 1 month = 1 year/12 (i.e. 2,629,846 seconds).</a:documentation>
             <data type="nonNegativeInteger"/></element> 
         </optional>
         <optional>

--- a/share/cyclus.rng.in
+++ b/share/cyclus.rng.in
@@ -75,29 +75,45 @@
         </optional>
         <optional>
           <element name="solver"> 
+            <a:documentation>Input block to select the solver mode and provide solver parameters.</a:documentation>
             <interleave>
               <optional><element name="config">
+              <a:documentation>Provide a solver configuration</a:documentation>
               <choice>
                 <element name="greedy">
+                  <a:documentation>Choose the greedy solver</a:documentation>
                   <interleave>
                     <optional>
-                      <element name="preconditioner"> <text/> </element>
+                      <element name="preconditioner"> 
+                        <a:documentation>Select a preconditioner for the greedy solver</a:documentation>
+                        <text/> </element>
                     </optional>
                   </interleave>
                 </element>
                 <element name="coin-or">
+                  <a:documentation>Select the COIN-OR mixed integer linear programming library solver</a:documentation>
                   <interleave>
                     <optional>
-                      <element name="timeout">  <data type="positiveInteger"/>  </element>
+                      <element name="timeout">
+                        <a:documentation>Select a time limit for how long you are willing to let the solver find a solution</a:documentation>
+                        <data type="positiveInteger"/>  </element>
                     </optional>
-                    <optional><element name="verbose"><data type="boolean"/></element></optional>
-                    <optional><element name="mps"><data type="boolean"/></element></optional>
+                    <optional>
+                      <element name="verbose">
+                        <a:documentation>A Boolean variable to determine whether there is verbose output from the COIN-OR solver.</a:documentation>
+                        <data type="boolean"/></element>
+                      </optional>
+                    <optional>
+                      <element name="mps">
+                        <a:documentation>A Boolean variable to determine whether an MPS file is written for each exchange.</a:documentation>
+                        <data type="boolean"/></element></optional>
                   </interleave>
                 </element>
               </choice>
               </element></optional>
               <optional>
                 <element name="allow_exclusive_orders">
+                  <a:documentation>A Boolean variable to determine whether exclusive orders are allowed (default: True)</a:documentation>
                   <data type="boolean" />
                 </element>
               </optional>
@@ -109,21 +125,39 @@
 
     <zeroOrMore>
       <element name="commodity">
+        <a:documentation>Commodities can be listed in order to provide a priority ordering for solving them in the DRE.</a:documentation>
         <interleave>
-          <element name="name"> <text/> </element>
-          <element name="solution_priority"> <data type="double"/> </element>
+          <element name="name"> 
+            <a:documentation>The name of a commodity being given priority treatment.</a:documentation>
+            <text/> </element>
+          <element name="solution_priority"> 
+            <a:documentation>The relative solution priority of this commodity. Higher values have higher priorit. (Default: -1)</a:documentation>
+            <data type="double"/> </element>
         </interleave>
       </element>
     </zeroOrMore>
       
     <element name="archetypes"> 
+      <a:documentation>A list of archetypes that will be dynamically loaded for use in Regions, Insitutions, and Facilities.</a:documentation>
       <oneOrMore>
         <element name="spec">
+          <a:documentation>A complete archetype specification</a:documentation>
           <interleave>
-            <optional><element name="path"><text/></element></optional>
-            <optional><element name="lib"><text/></element></optional>
-            <element name="name"><text/></element>
-            <optional><element name="alias"><text/></element></optional>
+            <optional>
+              <element name="path">
+                <a:documentation>An optional path to find this archetype; only needed if not discoverable in the standard locations.</a:documentation>
+                <text/></element></optional>
+            <optional>
+              <element name="lib">
+                <a:documentation>An optional name for the library that contains this archetype.</a:documentation>
+                <text/></element></optional>
+            <element name="name">
+              <a:documentation>The name that will be used to refer to this archetype.</a:documentation>
+              <text/></element>
+            <optional>
+              <element name="alias">
+                <a:documentation>An optional alias to refer to this archetype by a different name.</a:documentation>
+                <text/></element></optional>
           </interleave>
         </element>
       </oneOrMore>
@@ -131,13 +165,22 @@
 
     <oneOrMore>
       <element name="facility">
+        <a:documentation>A Facility prototype specification, with archetype,
+          archetype-specific parameters, and general facility parameters. Must
+          occur once, but may occur many times.</a:documentation> 
         <interleave>
-          <element name="name"> <text/> </element>
+          <element name="name">
+            <a:documentation>Prototype name</a:documentation>
+            <text/> </element>
           <optional>
-            <element name="lifetime"> <data type="nonNegativeInteger"/> </element>
+            <element name="lifetime"> 
+              <a:documentation>Number of time steps that this archetypes is participating after it is deployed.</a:documentation>
+              <data type="nonNegativeInteger"/> </element>
           </optional>
 
           <element name="config">
+            <a:documentation>Configuration to specify which archetype is being used for this facility, and then 
+              provide parameters to specify a particular prototype.</a:documentation>
             <choice>
             @Facility_REFS@
             </choice>
@@ -148,42 +191,63 @@
 
     <oneOrMore>
       <element name="region"> <interleave>
-        <element name="name"> <text/> </element>
+        <a:documentation>A region that represents a geopolitical division of the world and contains one or more institutions.</a:documentation>
+        <element name="name">
+          <a:documentation>The name of the region</a:documentation>
+          <text/> </element>
         <optional>
-          <element name="lifetime"> <data type="nonNegativeInteger"/> </element>
+          <element name="lifetime">
+            <a:documentation>The number of time steps that this region participates in the simulation once it begins.</a:documentation>
+            <data type="nonNegativeInteger"/> </element>
         </optional>
 
         <element name="config">
+          <a:documentation>Configuration to specify which archetype is being used for this region, and then 
+            provide parameters to specify a particular prototype.</a:documentation>
           <choice>
           @Region_REFS@
           </choice>
         </element>
 
         <oneOrMore>
-          <element name="institution"> <interleave>
-            <element name="name"> <text/> </element>
-            <optional>
-              <element name="lifetime"> <data type="nonNegativeInteger"/> </element>
-            </optional>
+          <element name="institution"> 
+            <a:documentation>An institution that represents an entity that can own/operate facilities within a region.</a:documentation>
+            <interleave>
+              <element name="name">
+                <a:documentation>The name of the institution</a:documentation>
+                <text/> </element>
+              <optional>
+                <element name="lifetime"> 
+                  <a:documentation>The number of time steps that this institution participates in the simulation once it begins.</a:documentation>
+                  <data type="nonNegativeInteger"/> </element>
+              </optional>
 
-            <optional>
-              <element name="initialfacilitylist">
-                <oneOrMore>
-                  <element name="entry">
-                    <interleave>
-                      <element name="prototype"> <text/> </element>
-                      <element name="number"> <data type="nonNegativeInteger"/> </element>
-                    </interleave>
-                  </element>
-                </oneOrMore>
+              <optional>
+                <element name="initialfacilitylist">
+                  <a:documentation>A list of facility prototypes that are operating when this institution begins participating in the simulation.</a:documentation>
+                  <oneOrMore>
+                    <element name="entry">
+                      <a:documentation>An entry for each prototype that has some number of initial facilities.</a:documentation>
+                      <interleave>
+                        <element name="prototype"> 
+                          <a:documentation>The name of the prototype that has at least one initial facility.</a:documentation>
+                          <text/> </element>
+                        <element name="number"> 
+                          <a:documentation>The number of this prototype that are operating initially.</a:documentation>
+                          <data type="nonNegativeInteger"/> </element>
+                      </interleave>
+                    </element>
+                  </oneOrMore>
+                </element>
+              </optional>
+
+              <element name="config">
+                <a:documentation>Configuration to specify which archetype is being used for this institution, and then 
+                  provide parameters to specify a particular prototype.</a:documentation>
+                <choice>
+                @Inst_REFS@
+                </choice>
               </element>
-            </optional>
-
-            <element name="config">
-              <choice>
-              @Inst_REFS@
-              </choice>
-            </element>
           </interleave> </element>
         </oneOrMore>
 
@@ -192,14 +256,24 @@
 
     <zeroOrMore>
       <element name="recipe">
+        <a:documentation>A material composition recipe that can be reused in other places in the simulation.</a:documentation>
         <interleave>
-          <element name="name"><text/></element>
-          <element name="basis"><text/></element>
+          <element name="name">
+            <a:documentation>The name of the recipe used to refer to it elsewhere.</a:documentation>
+            <text/></element>
+          <element name="basis">
+            <a:documentation>Indicating whether this recipe is defined by mass or atom fraction. Valid values: `mass` or `atom`.</a:documentation>
+            <text/></element>
           <oneOrMore>
             <element name="nuclide">
+              <a:documentation>Information about each nuclde in this composition.</a:documentation>
               <interleave>
-                <element name="id"><data type="string"/></element>
-                <element name="comp"><data type="double"/></element>
+                <element name="id">
+                  <a:documentation>A nuclide identifier in any form allowed by PyNE</a:documentation>
+                  <data type="string"/></element>
+                <element name="comp">
+                  <a:documentation>The relative concentration of this nuclide in the basis defined above.</a:documentation>
+                  <data type="double"/></element>
               </interleave>
             </element>
           </oneOrMore>
@@ -209,22 +283,46 @@
 
     <zeroOrMore>
       <element name="package">
+        <a:documentation>A package that defines how bulk quantities are shipped between facilities.</a:documentation>
         <interleave>
-          <element name="name"><text/></element>
-          <optional><element name="fill_min"><data type="double"/></element></optional>
-          <optional><element name="fill_max"><data type="double"/></element></optional>
-          <optional><element name="strategy"><text/></element></optional>
+          <element name="name">
+            <a:documentation>The name of this package.</a:documentation>
+            <text/></element>
+          <optional>
+            <element name="fill_min">
+              <a:documentation>The minimum amount of material that is allowed to be shipped in this package.</a:documentation>
+              <data type="double"/></element></optional>
+          <optional>
+            <element name="fill_max">
+              <a:documentation>The maximums amount of material that is allowed to be shipped in this package.</a:documentation>            
+              <data type="double"/></element></optional>
+          <optional>
+            <element name="strategy">
+              <a:documentation>The strategy for filling a set of packages.</a:documentation>
+              <text/></element></optional>
         </interleave>
       </element>
     </zeroOrMore>
 
     <zeroOrMore>
       <element name="transportunit">
+        <a:documentation>A transport unit that describes how multiple packages may be shipped in some collection.</a:documentation>
         <interleave>
-          <element name="name"><text/></element>
-          <optional><element name="fill_min"><data type="nonNegativeInteger"/></element></optional>
-          <optional><element name="fill_max"><data type="nonNegativeInteger"/></element></optional>
-          <optional><element name="strategy"><text/></element></optional>
+          <element name="name">
+            <a:documentation>The name of this transport unit.</a:documentation>
+            <text/></element>
+          <optional>
+            <element name="fill_min">
+              <a:documentation>The minimum number of packages allowed to be shipped in this transport unit.</a:documentation>
+              <data type="nonNegativeInteger"/></element></optional>
+          <optional>
+            <element name="fill_max">
+              <a:documentation>The maximum number of packages allowed to be shipped in this transport unit.</a:documentation>
+              <data type="nonNegativeInteger"/></element></optional>
+          <optional>
+            <element name="strategy">
+              <a:documentation>The strategy for filling multiple transport units</a:documentation>
+              <text/></element></optional>
         </interleave>
       </element>
     </zeroOrMore>

--- a/share/cyclus.rng.in
+++ b/share/cyclus.rng.in
@@ -1,104 +1,139 @@
 <grammar xmlns="http://relaxng.org/ns/structure/1.0"
-datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  xmlns:a="http://relaxng.org/ns/annotation/1.0"
+  datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
 <start>
 
 <element name="simulation">
-  <optional><element name="schematype"><text/></element></optional>
-<interleave>
+  <a:documentation>A complete Cyclus simulation</a:documentation>
+  <optional><element name="schematype">
+    <text/></element></optional>
 
-  <optional><element name="ui"><text/></element></optional>
-  
-  <element name ="control">
-    <interleave>
-      <optional>
-        <element name="simhandle"> <data type="string"/> </element>
-      </optional>
-      <element name="duration"> <data type="nonNegativeInteger"/> </element>
-      <element name="startmonth"> <data type="nonNegativeInteger"/> </element>
-      <element name="startyear"> <data type="nonNegativeInteger"/> </element>
-      <optional>
-        <element name="decay"> <text/> </element>
-      </optional>
-      <optional> 
-        <element name="dt"><data type="nonNegativeInteger"/></element> 
-      </optional>
-      <optional>
-        <element name="explicit_inventory"> <data type="boolean"/> </element>
-      </optional>
-      <optional>
-        <element name="explicit_inventory_compact"> <data type="boolean"/> </element>
-      </optional>
-      <optional>
-          <element name="tolerance_generic"><data type="double"/></element>
-      </optional>
-      <optional>
-          <element name="tolerance_resource"><data type="double"/></element>
-      </optional>
-      <optional>
-          <element name="seed"><data type="positiveInteger" /></element>
-      </optional>
-      <optional>
-          <element name="stride"><data type="positiveInteger" /></element>
-      </optional>
-      <optional>
-        <element name="solver"> 
-          <interleave>
-            <optional><element name="config">
-            <choice>
-              <element name="greedy">
-                <interleave>
-                  <optional>
-                    <element name="preconditioner"> <text/> </element>
-                  </optional>
-                </interleave>
-              </element>
-              <element name="coin-or">
-                <interleave>
-                  <optional>
-                    <element name="timeout">  <data type="positiveInteger"/>  </element>
-                  </optional>
-                  <optional><element name="verbose"><data type="boolean"/></element></optional>
-                  <optional><element name="mps"><data type="boolean"/></element></optional>
-                </interleave>
-              </element>
-            </choice>
-            </element></optional>
-            <optional>
-              <element name="allow_exclusive_orders">
-                <data type="boolean" />
-              </element>
-            </optional>
-          </interleave>
-        </element>
-      </optional>
-    </interleave>
-  </element>
+  <interleave>
 
-  <zeroOrMore>
-    <element name="commodity">
+    <optional><element name="ui"><text/></element></optional>
+    
+    <element name ="control">
+      <a:documentation>Block to define control parameters of simulation.</a:documentation>
       <interleave>
-        <element name="name"> <text/> </element>
-        <element name="solution_priority"> <data type="double"/> </element>
+        <optional>
+          <element name="simhandle"> <data type="string"/> </element>
+        </optional>
+        <element name="duration"> 
+          <a:documentation>Simulation duration in units of time steps. Default time steps
+            are 1 month. See `dt` to change default time step length.</a:documentation>
+          <data type="nonNegativeInteger"/> </element>
+        <element name="startyear"> 
+          <a:documentation>First year of simulation, e.g. 2015 (integer)</a:documentation>
+          <data type="nonNegativeInteger"/> </element>
+        <element name="startmonth"> 
+          <a:documentation>First month of the simulation, e.g. 3 for March (integer)</a:documentation>
+          <data type="nonNegativeInteger"/> </element>
+        <optional>
+          <element name="decay"> 
+          <a:documentation>Mode for when radioactive decay occurs. Choose from "never", "manual", "lazy".</a:documentation>
+          <text/> </element>
+        </optional>
+        <optional> 
+          <element name="dt">
+            <a:documentation>Length of a time step in seconds. Default: 1 month = 1 year/12.</a:documentation>
+          <data type="nonNegativeInteger"/></element> 
+        </optional>
+        <optional>
+          <element name="explicit_inventory">
+          <a:documentation>A Boolean flag to indicate whether the database should include tables that explicitly
+            record the inventory of each resource buffer in each agent at each time step.</a:documentation>
+          <data type="boolean"/> </element>
+        </optional>
+        <optional>
+          <element name="explicit_inventory_compact"> <data type="boolean"/> </element>
+        </optional>
+        <optional>
+            <element name="tolerance_generic"><data type="double"/></element>
+        </optional>
+        <optional>
+            <element name="tolerance_resource"><data type="double"/></element>
+        </optional>
+        <optional>
+            <element name="seed"><data type="positiveInteger" /></element>
+        </optional>
+        <optional>
+            <element name="stride"><data type="positiveInteger" /></element>
+        </optional>
+        <optional>
+          <element name="solver"> 
+            <interleave>
+              <optional><element name="config">
+              <choice>
+                <element name="greedy">
+                  <interleave>
+                    <optional>
+                      <element name="preconditioner"> <text/> </element>
+                    </optional>
+                  </interleave>
+                </element>
+                <element name="coin-or">
+                  <interleave>
+                    <optional>
+                      <element name="timeout">  <data type="positiveInteger"/>  </element>
+                    </optional>
+                    <optional><element name="verbose"><data type="boolean"/></element></optional>
+                    <optional><element name="mps"><data type="boolean"/></element></optional>
+                  </interleave>
+                </element>
+              </choice>
+              </element></optional>
+              <optional>
+                <element name="allow_exclusive_orders">
+                  <data type="boolean" />
+                </element>
+              </optional>
+            </interleave>
+          </element>
+        </optional>
       </interleave>
     </element>
-  </zeroOrMore>
-    
-  <element name="archetypes"> 
-    <oneOrMore>
-      <element name="spec">
+
+    <zeroOrMore>
+      <element name="commodity">
         <interleave>
-          <optional><element name="path"><text/></element></optional>
-          <optional><element name="lib"><text/></element></optional>
-          <element name="name"><text/></element>
-          <optional><element name="alias"><text/></element></optional>
+          <element name="name"> <text/> </element>
+          <element name="solution_priority"> <data type="double"/> </element>
+        </interleave>
+      </element>
+    </zeroOrMore>
+      
+    <element name="archetypes"> 
+      <oneOrMore>
+        <element name="spec">
+          <interleave>
+            <optional><element name="path"><text/></element></optional>
+            <optional><element name="lib"><text/></element></optional>
+            <element name="name"><text/></element>
+            <optional><element name="alias"><text/></element></optional>
+          </interleave>
+        </element>
+      </oneOrMore>
+    </element>
+
+    <oneOrMore>
+      <element name="facility">
+        <interleave>
+          <element name="name"> <text/> </element>
+          <optional>
+            <element name="lifetime"> <data type="nonNegativeInteger"/> </element>
+          </optional>
+
+          <element name="config">
+            <choice>
+            @Facility_REFS@
+            </choice>
+          </element>
         </interleave>
       </element>
     </oneOrMore>
-  </element>
 
-  <oneOrMore>
-    <element name="facility">
-      <interleave>
+    <oneOrMore>
+      <element name="region"> <interleave>
         <element name="name"> <text/> </element>
         <optional>
           <element name="lifetime"> <data type="nonNegativeInteger"/> </element>
@@ -106,97 +141,81 @@ datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
 
         <element name="config">
           <choice>
-          @Facility_REFS@
+          @Region_REFS@
           </choice>
         </element>
-      </interleave>
-    </element>
-  </oneOrMore>
 
-  <oneOrMore>
-    <element name="region"> <interleave>
-      <element name="name"> <text/> </element>
-      <optional>
-        <element name="lifetime"> <data type="nonNegativeInteger"/> </element>
-      </optional>
-
-      <element name="config">
-        <choice>
-        @Region_REFS@
-        </choice>
-      </element>
-
-      <oneOrMore>
-        <element name="institution"> <interleave>
-          <element name="name"> <text/> </element>
-          <optional>
-            <element name="lifetime"> <data type="nonNegativeInteger"/> </element>
-          </optional>
-
-          <optional>
-            <element name="initialfacilitylist">
-              <oneOrMore>
-                <element name="entry">
-                  <interleave>
-                    <element name="prototype"> <text/> </element>
-                    <element name="number"> <data type="nonNegativeInteger"/> </element>
-                  </interleave>
-                </element>
-              </oneOrMore>
-            </element>
-          </optional>
-
-          <element name="config">
-            <choice>
-            @Inst_REFS@
-            </choice>
-          </element>
-        </interleave> </element>
-      </oneOrMore>
-
-    </interleave> </element>
-  </oneOrMore>
-
-  <zeroOrMore>
-    <element name="recipe">
-      <interleave>
-        <element name="name"><text/></element>
-        <element name="basis"><text/></element>
         <oneOrMore>
-          <element name="nuclide">
-            <interleave>
-              <element name="id"><data type="string"/></element>
-              <element name="comp"><data type="double"/></element>
-            </interleave>
-          </element>
+          <element name="institution"> <interleave>
+            <element name="name"> <text/> </element>
+            <optional>
+              <element name="lifetime"> <data type="nonNegativeInteger"/> </element>
+            </optional>
+
+            <optional>
+              <element name="initialfacilitylist">
+                <oneOrMore>
+                  <element name="entry">
+                    <interleave>
+                      <element name="prototype"> <text/> </element>
+                      <element name="number"> <data type="nonNegativeInteger"/> </element>
+                    </interleave>
+                  </element>
+                </oneOrMore>
+              </element>
+            </optional>
+
+            <element name="config">
+              <choice>
+              @Inst_REFS@
+              </choice>
+            </element>
+          </interleave> </element>
         </oneOrMore>
-      </interleave>
-    </element>
-  </zeroOrMore>
 
-  <zeroOrMore>
-    <element name="package">
-      <interleave>
-        <element name="name"><text/></element>
-        <optional><element name="fill_min"><data type="double"/></element></optional>
-        <optional><element name="fill_max"><data type="double"/></element></optional>
-        <optional><element name="strategy"><text/></element></optional>
-      </interleave>
-    </element>
-  </zeroOrMore>
+      </interleave> </element>
+    </oneOrMore>
 
-  <zeroOrMore>
-    <element name="transportunit">
-      <interleave>
-        <element name="name"><text/></element>
-        <optional><element name="fill_min"><data type="nonNegativeInteger"/></element></optional>
-        <optional><element name="fill_max"><data type="nonNegativeInteger"/></element></optional>
-        <optional><element name="strategy"><text/></element></optional>
-      </interleave>
-    </element>
-  </zeroOrMore>
+    <zeroOrMore>
+      <element name="recipe">
+        <interleave>
+          <element name="name"><text/></element>
+          <element name="basis"><text/></element>
+          <oneOrMore>
+            <element name="nuclide">
+              <interleave>
+                <element name="id"><data type="string"/></element>
+                <element name="comp"><data type="double"/></element>
+              </interleave>
+            </element>
+          </oneOrMore>
+        </interleave>
+      </element>
+    </zeroOrMore>
 
-</interleave> </element>
+    <zeroOrMore>
+      <element name="package">
+        <interleave>
+          <element name="name"><text/></element>
+          <optional><element name="fill_min"><data type="double"/></element></optional>
+          <optional><element name="fill_max"><data type="double"/></element></optional>
+          <optional><element name="strategy"><text/></element></optional>
+        </interleave>
+      </element>
+    </zeroOrMore>
+
+    <zeroOrMore>
+      <element name="transportunit">
+        <interleave>
+          <element name="name"><text/></element>
+          <optional><element name="fill_min"><data type="nonNegativeInteger"/></element></optional>
+          <optional><element name="fill_max"><data type="nonNegativeInteger"/></element></optional>
+          <optional><element name="strategy"><text/></element></optional>
+        </interleave>
+      </element>
+    </zeroOrMore>
+
+  </interleave> </element>
 
 </start>
 

--- a/share/cyclus.rng.in
+++ b/share/cyclus.rng.in
@@ -190,68 +190,69 @@
     </oneOrMore>
 
     <oneOrMore>
-      <element name="region"> <interleave>
+      <element name="region"> 
         <a:documentation>A region that represents a geopolitical division of the world and contains one or more institutions.</a:documentation>
-        <element name="name">
-          <a:documentation>The name of the region</a:documentation>
-          <text/> </element>
-        <optional>
-          <element name="lifetime">
-            <a:documentation>The number of time steps that this region participates in the simulation once it begins.</a:documentation>
-            <data type="nonNegativeInteger"/> </element>
-        </optional>
+        <interleave>
+          <element name="name">
+            <a:documentation>The name of the region</a:documentation>
+            <text/> </element>
+          <optional>
+            <element name="lifetime">
+              <a:documentation>The number of time steps that this region participates in the simulation once it begins.</a:documentation>
+              <data type="nonNegativeInteger"/> </element>
+          </optional>
 
-        <element name="config">
-          <a:documentation>Configuration to specify which archetype is being used for this region, and then 
-            provide parameters to specify a particular prototype.</a:documentation>
-          <choice>
-          @Region_REFS@
-          </choice>
-        </element>
+          <element name="config">
+            <a:documentation>Configuration to specify which archetype is being used for this region, and then 
+              provide parameters to specify a particular prototype.</a:documentation>
+            <choice>
+            @Region_REFS@
+            </choice>
+          </element>
 
-        <oneOrMore>
-          <element name="institution"> 
-            <a:documentation>An institution that represents an entity that can own/operate facilities within a region.</a:documentation>
-            <interleave>
-              <element name="name">
-                <a:documentation>The name of the institution</a:documentation>
-                <text/> </element>
-              <optional>
-                <element name="lifetime"> 
-                  <a:documentation>The number of time steps that this institution participates in the simulation once it begins.</a:documentation>
-                  <data type="nonNegativeInteger"/> </element>
-              </optional>
+          <oneOrMore>
+            <element name="institution"> 
+              <a:documentation>An institution that represents an entity that can own/operate facilities within a region.</a:documentation>
+              <interleave>
+                <element name="name">
+                  <a:documentation>The name of the institution</a:documentation>
+                  <text/> </element>
+                <optional>
+                  <element name="lifetime"> 
+                    <a:documentation>The number of time steps that this institution participates in the simulation once it begins.</a:documentation>
+                    <data type="nonNegativeInteger"/> </element>
+                </optional>
 
-              <optional>
-                <element name="initialfacilitylist">
-                  <a:documentation>A list of facility prototypes that are operating when this institution begins participating in the simulation.</a:documentation>
-                  <oneOrMore>
-                    <element name="entry">
-                      <a:documentation>An entry for each prototype that has some number of initial facilities.</a:documentation>
-                      <interleave>
-                        <element name="prototype"> 
-                          <a:documentation>The name of the prototype that has at least one initial facility.</a:documentation>
-                          <text/> </element>
-                        <element name="number"> 
-                          <a:documentation>The number of this prototype that are operating initially.</a:documentation>
-                          <data type="nonNegativeInteger"/> </element>
-                      </interleave>
-                    </element>
-                  </oneOrMore>
+                <optional>
+                  <element name="initialfacilitylist">
+                    <a:documentation>A list of facility prototypes that are operating when this institution begins participating in the simulation.</a:documentation>
+                    <oneOrMore>
+                      <element name="entry">
+                        <a:documentation>An entry for each prototype that has some number of initial facilities.</a:documentation>
+                        <interleave>
+                          <element name="prototype"> 
+                            <a:documentation>The name of the prototype that has at least one initial facility.</a:documentation>
+                            <text/> </element>
+                          <element name="number"> 
+                            <a:documentation>The number of this prototype that are operating initially.</a:documentation>
+                            <data type="nonNegativeInteger"/> </element>
+                        </interleave>
+                      </element>
+                    </oneOrMore>
+                  </element>
+                </optional>
+
+                <element name="config">
+                  <a:documentation>Configuration to specify which archetype is being used for this institution, and then 
+                    provide parameters to specify a particular prototype.</a:documentation>
+                  <choice>
+                  @Inst_REFS@
+                  </choice>
                 </element>
-              </optional>
+            </interleave> </element>
+          </oneOrMore>
 
-              <element name="config">
-                <a:documentation>Configuration to specify which archetype is being used for this institution, and then 
-                  provide parameters to specify a particular prototype.</a:documentation>
-                <choice>
-                @Inst_REFS@
-                </choice>
-              </element>
-          </interleave> </element>
-        </oneOrMore>
-
-      </interleave> </element>
+        </interleave> </element>
     </oneOrMore>
 
     <zeroOrMore>

--- a/src/xml_file_loader.cc
+++ b/src/xml_file_loader.cc
@@ -13,6 +13,7 @@
 #include "blob.h"
 #include "context.h"
 #include "cyc_std.h"
+#include "discovery.h"
 #include "env.h"
 #include "error.h"
 #include "exchange_solver.h"
@@ -60,6 +61,17 @@ std::string LoadStringFromFile(std::string file, std::string format) {
   return input.str();
 }
 
+std::vector<AgentSpec> ParseSpecs(std::set<std::string> agent_set) {
+
+  std::vector<AgentSpec> specs;
+
+  for (const std::string& spec_str : agent_set) {
+    specs.push_back(AgentSpec(spec_str));
+  }
+
+  return specs;
+}
+
 std::vector<AgentSpec> ParseSpecs(std::string infile, std::string format) {
   std::stringstream input;
   LoadStringstreamFromFile(input, infile, format);
@@ -67,27 +79,25 @@ std::vector<AgentSpec> ParseSpecs(std::string infile, std::string format) {
   parser_.Init(input);
   InfileTree xqe(parser_);
 
-  std::vector<AgentSpec> specs;
   std::set<std::string> unique;
 
   std::string p = "/simulation/archetypes/spec";
   int n = xqe.NMatches(p);
   for (int i = 0; i < n; ++i) {
-    AgentSpec spec(xqe.SubTree(p, i));
-    if (unique.count(spec.str()) == 0) {
-      specs.push_back(spec);
-      unique.insert(spec.str());
-    }
+    unique.insert(xqe.SubTree(p, i)->GetString("name"));
   }
 
-  if (specs.size() == 0) {
+  if (unique.size() == 0) {
     throw ValidationError("failed to parse archetype specs from input file");
   }
+
+  std::vector<AgentSpec> specs = ParseSpecs(unique);
 
   return specs;
 }
 
-std::string BuildMasterSchema(std::string schema_path, std::string infile, std::string format) {
+std::string BuildMasterSchema(std::string schema_path, std::vector<AgentSpec> specs) {
+
   Timer ti;
   Recorder rec;
   Context ctx(&ti, &rec);
@@ -95,8 +105,6 @@ std::string BuildMasterSchema(std::string schema_path, std::string infile, std::
   std::stringstream schema("");
   LoadStringstreamFromFile(schema, schema_path);
   std::string master = schema.str();
-
-  std::vector<AgentSpec> specs = ParseSpecs(infile, format);
 
   std::map<std::string, std::string> subschemas;
 
@@ -124,6 +132,22 @@ std::string BuildMasterSchema(std::string schema_path, std::string infile, std::
   }
 
   return master;
+}
+
+std::string BuildMasterSchema(std::string schema_path) {
+
+  std::vector<AgentSpec> specs = ParseSpecs(cyclus::DiscoverSpecsInCyclusPath());
+
+  return BuildMasterSchema(schema_path, specs);
+
+}
+
+std::string BuildMasterSchema(std::string schema_path, std::string infile, std::string format) {
+
+  std::vector<AgentSpec> specs = ParseSpecs(infile, format);
+
+  return BuildMasterSchema(schema_path, specs);
+
 }
 
 Composition::Ptr ReadRecipe(InfileTree* qe) {

--- a/src/xml_file_loader.cc
+++ b/src/xml_file_loader.cc
@@ -84,7 +84,8 @@ std::vector<AgentSpec> ParseSpecs(std::string infile, std::string format) {
   std::string p = "/simulation/archetypes/spec";
   int n = xqe.NMatches(p);
   for (int i = 0; i < n; ++i) {
-    unique.insert(xqe.SubTree(p, i)->GetString("name"));
+    AgentSpec spec(xqe.SubTree(p, i));
+    unique.insert(spec.str());
   }
 
   if (unique.size() == 0) {

--- a/src/xml_file_loader.h
+++ b/src/xml_file_loader.h
@@ -31,12 +31,25 @@ void LoadStringstreamFromFile(std::stringstream& stream, std::string file,
 std::string LoadStringFromFile(std::string file, std::string format="none");
 
 /// Returns a list of the full module+agent spec for all agents in the given
+/// set of agent names.
+std::vector<AgentSpec> ParseSpecs(std::set<std::string> agent_set);
+
+/// Returns a list of the full module+agent spec for all agents in the given
 /// input file.
 std::vector<AgentSpec> ParseSpecs(std::string infile, std::string format="none");
 
 /// Builds and returns a master cyclus input xml schema that includes the
-/// sub-schemas defined by all installed cyclus modules (e.g. facility agents).
-/// This is used to validate simulation input files.
+/// sub-schemas defined by the provided list of agent specifications.
+/// This is used but other versions of BuildMasterSchema.
+std::string BuildMasterSchema(std::string schema_path, std::vector<AgentSpec> specs);
+
+/// Builds and returns a master cyclus input xml schema that includes the
+/// sub-schemas from all the installed modules.
+std::string BuildMasterSchema(std::string schema_path);
+
+/// Builds and returns a master cyclus input xml schema that includes the
+/// sub-schemas defined by all cyclus modules (e.g. facility agents) referenced
+/// in the input file. This is used to validate simulation input files.
 std::string BuildMasterSchema(std::string schema_path, std::string infile,
                               std::string format="none");
 

--- a/src/xml_flat_loader.cc
+++ b/src/xml_flat_loader.cc
@@ -2,6 +2,7 @@
 
 #include "agent.h"
 #include "context.h"
+#include "discovery.h"
 #include "env.h"
 #include "error.h"
 #include "infile_tree.h"
@@ -11,7 +12,7 @@
 
 namespace cyclus {
 
-std::string BuildFlatMasterSchema(std::string schema_path, std::string infile) {
+std::string BuildFlatMasterSchema(std::string schema_path, std::vector<AgentSpec> specs) {
   Timer ti;
   Recorder rec;
   Context ctx(&ti, &rec);
@@ -20,7 +21,6 @@ std::string BuildFlatMasterSchema(std::string schema_path, std::string infile) {
   LoadStringstreamFromFile(schema, schema_path);
   std::string master = schema.str();
 
-  std::vector<AgentSpec> specs = ParseSpecs(infile);
   std::string subschemas;
   for (int i = 0; i < specs.size(); ++i) {
     Agent* m = DynamicModule::Make(&ctx, specs[i]);
@@ -38,6 +38,22 @@ std::string BuildFlatMasterSchema(std::string schema_path, std::string infile) {
   }
 
   return master;
+}
+
+std::string BuildFlatMasterSchema(std::string schema_path, std::string infile) {
+
+  std::vector<AgentSpec> specs = ParseSpecs(infile);
+
+  return BuildMasterSchema(schema_path, specs);
+
+}
+
+std::string BuildFlatMasterSchema(std::string schema_path) {
+
+  std::vector<AgentSpec> specs = ParseSpecs(cyclus::DiscoverSpecsInCyclusPath());
+
+  return BuildMasterSchema(schema_path, specs);
+
 }
 
 std::string XMLFlatLoader::master_schema() {

--- a/src/xml_flat_loader.cc
+++ b/src/xml_flat_loader.cc
@@ -44,7 +44,7 @@ std::string BuildFlatMasterSchema(std::string schema_path, std::string infile) {
 
   std::vector<AgentSpec> specs = ParseSpecs(infile);
 
-  return BuildMasterSchema(schema_path, specs);
+  return BuildFlatMasterSchema(schema_path, specs);
 
 }
 
@@ -52,7 +52,7 @@ std::string BuildFlatMasterSchema(std::string schema_path) {
 
   std::vector<AgentSpec> specs = ParseSpecs(cyclus::DiscoverSpecsInCyclusPath());
 
-  return BuildMasterSchema(schema_path, specs);
+  return BuildFlatMasterSchema(schema_path, specs);
 
 }
 

--- a/src/xml_flat_loader.h
+++ b/src/xml_flat_loader.h
@@ -7,8 +7,19 @@ namespace cyclus {
 
 /// Builds and returns a master cyclus input xml schema defining a flat
 /// prototype and instance structure that includes the sub-schemas defined by
+/// the vector of specs.
+/// This is used internally by other BuildFlatMasterSchema.
+std::string BuildFlatMasterSchema(std::string schema_path, std::vector<AgentSpec> specs);
+
+/// Builds and returns a master cyclus input xml schema defining a flat
+/// prototype and instance structure that includes the sub-schemas defined by
 /// all installed cyclus modules (e.g. facility agents).  This is used to
-/// validate simulation input files.
+/// share all valid gammar.
+std::string BuildFlatMasterSchema(std::string schema_path);
+
+/// Builds and returns a master cyclus input xml schema defining a flat
+/// prototype and instance structure that includes the sub-schemas defined by
+/// the input file.  This is used to validate simulation input files.
 std::string BuildFlatMasterSchema(std::string schema_path, std::string infile);
 
 /// a class that encapsulates the methods needed to load input to

--- a/tests/agent_tests/agent_tests.cc
+++ b/tests/agent_tests/agent_tests.cc
@@ -28,9 +28,11 @@ TEST_P(AgentTests, Print) {
 
 TEST_P(AgentTests, Schema) {
   std::stringstream schema;
-  schema << ("<element name=\"foo\">\n");
+  schema << "<grammar xmlns:a=\"http://relaxng.org/ns/annotation/1.0\">\n";
+  schema << "<element name=\"foo\">\n";
   schema << agent_->schema();
-  schema << "</element>\n";
+  schema << "</element>\n</grammar>\n";
+  std::cout << schema.str();
   cyclus::XMLParser p;
   EXPECT_NO_THROW(p.Init(schema));
 }


### PR DESCRIPTION
Fixes #1598

Create two ways to build a master schema:
1. using the agent specs included in an input file
2. using all the agent specs that are discoverable on a system

Change the CLI to use the second option above instead of just regurgitating the schema template.

This has been broken since #843 (11 years!!)

Prior to this, when requesting the schema, Cyclus would load and write the "template" that included lines like `@Facility_REFS@` that are meant to be replaced by the list of available facilities.

Now, those template codes have been replaced and include the full list of choices of available archetypes of each type.

Also automatically adds variable documentation as RelaxNG annotations for each variable, and added some annotations to the template.
