### PR TITLE
Update Definition of a Year to be Gaussian (+4s)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Since last release
 * Added set of basic finance math function to EconomicEntity (#1864)
 * Added Composition functions to get printable material composition information (#1868)
 * Added cyclusYear (Gaussian + 4s) and changed kDefaultTimeStepDur to be cyclusYear/12
+* Added cyclusYear (Gaussian + 4s) and changed kDefaultTimeStepDur to be cyclusYear/12 (#1867)
 * Added code injection variables for economic data (#1853)
 * Agent now inherits EconomicEntity to allow limited communication across RIF (#1850)
 * Added TransportUnits (#1750, #1772, #1784)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,6 @@ Since last release
 * Added code injection for matl_buy/sell_policy (#1866)
 * Added set of basic finance math function to EconomicEntity (#1864)
 * Added Composition functions to get printable material composition information (#1868)
-* Added cyclusYear (Gaussian + 4s) and changed kDefaultTimeStepDur to be cyclusYear/12
 * Added cyclusYear (Gaussian + 4s) and changed kDefaultTimeStepDur to be cyclusYear/12 (#1867)
 * Added code injection variables for economic data (#1853)
 * Agent now inherits EconomicEntity to allow limited communication across RIF (#1850)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,10 +6,12 @@ Since last release
 ====================
 
 **Added:**
+
 * Added a function to facility_cost.cycpp.h to calculate cost of a DRE bid (#1870)
 * Added code injection for matl_buy/sell_policy (#1866)
 * Added set of basic finance math function to EconomicEntity (#1864)
 * Added Composition functions to get printable material composition information (#1868)
+* Added cyclusYear (Gaussian + 4s) and changed kDefaultTimeStepDur to be cyclusYear/12
 * Added code injection variables for economic data (#1853)
 * Agent now inherits EconomicEntity to allow limited communication across RIF (#1850)
 * Added TransportUnits (#1750, #1772, #1784)

--- a/src/context.h
+++ b/src/context.h
@@ -20,7 +20,11 @@
 #include "recorder.h"
 #include "package.h"
 
-const uint64_t kDefaultTimeStepDur = 2629846;
+// Defined as 4 seconds longer than a Gaussian year (to make division by 12 
+// a round number)
+const uint64_t cyclusYear = 31558200;
+
+const uint64_t kDefaultTimeStepDur = cyclusYear / 12;
 
 const uint64_t kDefaultSeed = 20160212;
 


### PR DESCRIPTION
# Summary of Changes

A new variable (`cyclusYear`) was added to the Cyclus context such that one `cyclusYear` is four seconds longer than a Gaussian year. This was done in response to something I flagged in #1804 where the old definition of a `kDefaultTimestepDur` wasn't any multiple of a standard year (365.0 days, 1 sidereal year, 1 sidereal month, 1 gaussian year, etc). `kDefaultTimestepDur` was then redefined as 1/12 `cyclusYear`s.  

# Related CEPs and Issues

This PR is related to:

- Closes #1804  

# Associated Developers

None.

# Design Notes

The reason I defined the `cyclusYear` as four seconds longer than a Gaussian year was so that it was roundly divisible by 12, since our default tilmestep is a month. The alternative was to make it 8 seconds shorter, which is the behavior you would get if you made 1 `cyclusYear` exactly 1 Gaussian year (since int division truncates towards zero apparently), but since 4 < 8 I decided to go up to make it closer. I am not married to that, and would be fine with making it exact then having `kDefaultTimestepDur` be "imprecise" in that way. 

# Testing and Validation

The code was built locally on my machine after this update, and all Cyclus and Cycamore tests passed. There may be a need for further testing, but I couldn't think of any great ways to do that. If others do, feel free to suggest and I'll happily add some.

# Checklist

 - [x] Read the [Contributing to Cyclus](https://fuelcycle.org/kernel/contributing_to_cyclus.html) guide.
 - [x]  Compile and run locally.
 - [ ]  Add or update tests.
 - [ ]  Document if needed.
 - [x]  Follow style guidelines.
 - [x]  Update the changelog.
 - [ ]  Address all review comments.
Reviewers, please refer to the Cyclus [Guide for Reviewers](https://fuelcycle.org/kernel/pr_review.html).