### PR TITLE
Position Code Injection Variable Initialization Changes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,7 +40,7 @@ Since last release
 * Package GetFillMass returns vector of masses (#1790, #1813)
 * Modified Doxygen homepage (#1815)
 * Pin ``python<3.13`` in CI workflows (#1826)
-* changed the way Position is added to the archetypes (#1510)
+* Changed the way Position is added to the archetypes (#1510) (#1872)
 
 **Removed:**
 

--- a/src/toolkit/position.cc
+++ b/src/toolkit/position.cc
@@ -28,6 +28,11 @@ double Position::longitude() const {
 void Position::latitude(double lat) {
   if (!ValidLatitude(lat)) {
     latitude_ = kInvalidLatitude;
+    std::stringstream msg;
+    msg << "The provided latitude (" << lat
+        << ") is outside the acceptable range "
+        << "[-90, 90]. Setting to " << kInvalidLatitude;
+    cyclus::Warn<cyclus::VALUE_WARNING>(msg.str());
   } else { 
     latitude_ = SetPrecision(lat * CYCLUS_DECIMAL_SECOND_MULTIPLIER, 1);
   }
@@ -36,6 +41,11 @@ void Position::latitude(double lat) {
 void Position::longitude(double lon) {
   if (!ValidLongitude(lon)) {
     longitude_ = kInvalidLongitude;
+    std::stringstream msg;
+    msg << "The provided longitude (" << lon
+        << ") is outside the acceptable range "
+        << "[-180, 180]. Setting to " << kInvalidLongitude;
+    cyclus::Warn<cyclus::VALUE_WARNING>(msg.str());
   } else {
     longitude_ = SetPrecision(lon * CYCLUS_DECIMAL_SECOND_MULTIPLIER, 1);
   }
@@ -58,11 +68,6 @@ void Position::RecordPosition(Agent* agent) {
 }
 bool Position::ValidLatitude(double lat) {
   if (lat > 90 || lat < -90) {
-    std::stringstream msg;
-    msg << "The provided latitude (" << lat
-        << ") is outside the acceptable range "
-        << "[-90, 90]. Setting to NaN.";
-    cyclus::Warn<cyclus::VALUE_WARNING>(msg.str());
     return false;
   }
   return true;
@@ -70,11 +75,6 @@ bool Position::ValidLatitude(double lat) {
 
 bool Position::ValidLongitude(double lon) {
   if (lon > 180 || lon < -180) {
-    std::stringstream msg;
-    msg << "The provided longitude (" << lon
-        << ") is outside the acceptable range "
-        << "[-180, 180]. Setting to NaN.";
-    cyclus::Warn<cyclus::VALUE_WARNING>(msg.str());
     return false;
   }
   return true;

--- a/src/toolkit/position.cc
+++ b/src/toolkit/position.cc
@@ -60,7 +60,7 @@ void Position::LatCheck(double lat) {
     msg << "The provided latitude (" << lat
         << ") is outside the acceptable range. "
         << "[-90, 90]";
-      cyclus::Warn<cyclus::VALUE_WARNING>(msg.str());
+    cyclus::Warn<cyclus::VALUE_WARNING>(msg.str());
   }
 }
 

--- a/src/toolkit/position.cc
+++ b/src/toolkit/position.cc
@@ -44,7 +44,7 @@ void Position::longitude(double lon) {
     std::stringstream msg;
     msg << "The provided longitude (" << lon
         << ") is outside the acceptable range "
-        << "[-180, 180]. Setting to " << kInvalidLongitude;
+        << "[-180, 180]. Longitude has been set to " << longitude_;
     cyclus::Warn<cyclus::VALUE_WARNING>(msg.str());
   } else {
     longitude_ = SetPrecision(lon * CYCLUS_DECIMAL_SECOND_MULTIPLIER, 1);

--- a/src/toolkit/position.cc
+++ b/src/toolkit/position.cc
@@ -11,10 +11,14 @@ namespace toolkit {
 Position::Position() : latitude_(0), longitude_(0) {}
 
 Position::Position(double decimal_lat, double decimal_lon) {
-  LatCheck(decimal_lat);
-  LonCheck(decimal_lon);
-  latitude_ = SetPrecision(decimal_lat * CYCLUS_DECIMAL_SECOND_MULTIPLIER, 1);
-  longitude_ = SetPrecision(decimal_lon * CYCLUS_DECIMAL_SECOND_MULTIPLIER, 1);
+  if (ValidLatitude(decimal_lat) and ValidLongitude(decimal_lon)) {
+    latitude_ = SetPrecision(decimal_lat * CYCLUS_DECIMAL_SECOND_MULTIPLIER, 1);
+    longitude_ = SetPrecision(decimal_lon * CYCLUS_DECIMAL_SECOND_MULTIPLIER, 1);
+  } else {
+    // Set to some legal value. 0.0 is chosen as the default.
+    latitude_ = 0.0; 
+    longitude_ = 0.0;
+  }
 }
 
 Position::~Position() {}
@@ -28,20 +32,29 @@ double Position::longitude() const {
 }
 
 void Position::latitude(double lat) {
-  LatCheck(lat);
-  latitude_ = SetPrecision(lat * CYCLUS_DECIMAL_SECOND_MULTIPLIER, 1);
+  if (ValidLatitude(lat)) {
+    latitude_ = SetPrecision(lat * CYCLUS_DECIMAL_SECOND_MULTIPLIER, 1);
+  } else { 
+    latitude_ = 0.0;
+  }
 }
 
 void Position::longitude(double lon) {
-  LonCheck(lon);
-  longitude_ = SetPrecision(lon * CYCLUS_DECIMAL_SECOND_MULTIPLIER, 1);
+  if (ValidLongitude(lon)) {
+    longitude_ = SetPrecision(lon * CYCLUS_DECIMAL_SECOND_MULTIPLIER, 1);
+  } else {
+    longitude_ = 0.0;
+  }
 }
 
 void Position::set_position(double lat, double lon) {
-  LatCheck(lat);
-  LonCheck(lon);
-  latitude_ = SetPrecision(lat * CYCLUS_DECIMAL_SECOND_MULTIPLIER, 1);
-  longitude_ = SetPrecision(lon * CYCLUS_DECIMAL_SECOND_MULTIPLIER, 1);
+  if (ValidLatitude(lat) and ValidLongitude(lon)) {
+    latitude_ = SetPrecision(lat * CYCLUS_DECIMAL_SECOND_MULTIPLIER, 1);
+    longitude_ = SetPrecision(lon * CYCLUS_DECIMAL_SECOND_MULTIPLIER, 1);
+  } else {
+    latitude_ = 0.0;
+    longitude_ = 0.0;
+  }
 }
 
 void Position::RecordPosition(Agent* agent) {
@@ -54,24 +67,28 @@ void Position::RecordPosition(Agent* agent) {
       ->AddVal("Longitude", longitude_ / CYCLUS_DECIMAL_SECOND_MULTIPLIER)
       ->Record();
 }
-void Position::LatCheck(double lat) {
+bool Position::ValidLatitude(double lat) {
   if (lat > 90 || lat < -90) {
     std::stringstream msg;
     msg << "The provided latitude (" << lat
         << ") is outside the acceptable range. "
         << "[-90, 90]";
     cyclus::Warn<cyclus::VALUE_WARNING>(msg.str());
+    return false;
   }
+  return true;
 }
 
-void Position::LonCheck(double lon) {
+bool Position::ValidLongitude(double lon) {
   if (lon > 180 || lon < -180) {
     std::stringstream msg;
     msg << "The provided longitude (" << lon
         << ") is outside the acceptable range."
         << "[-180, 180]";
-    cyclus::Warn<cyclus::VALUE_WARNING>(msg.str());;
+    cyclus::Warn<cyclus::VALUE_WARNING>(msg.str());
+    return false;
   }
+  return true;
 }
 
 double Position::Distance(Position target) const {

--- a/src/toolkit/position.cc
+++ b/src/toolkit/position.cc
@@ -31,7 +31,7 @@ void Position::latitude(double lat) {
     std::stringstream msg;
     msg << "The provided latitude (" << lat
         << ") is outside the acceptable range "
-        << "[-90, 90]. Setting to " << kInvalidLatitude;
+        << "[-90, 90]. Latitude has been set to " << latitude_;
     cyclus::Warn<cyclus::VALUE_WARNING>(msg.str());
   } else { 
     latitude_ = SetPrecision(lat * CYCLUS_DECIMAL_SECOND_MULTIPLIER, 1);

--- a/src/toolkit/position.cc
+++ b/src/toolkit/position.cc
@@ -11,14 +11,8 @@ namespace toolkit {
 Position::Position() : latitude_(0), longitude_(0) {}
 
 Position::Position(double decimal_lat, double decimal_lon) {
-  if (ValidLatitude(decimal_lat) and ValidLongitude(decimal_lon)) {
-    latitude_ = SetPrecision(decimal_lat * CYCLUS_DECIMAL_SECOND_MULTIPLIER, 1);
-    longitude_ = SetPrecision(decimal_lon * CYCLUS_DECIMAL_SECOND_MULTIPLIER, 1);
-  } else {
-    // Set to some legal value. 0.0 is chosen as the default.
-    latitude_ = kDefaultLatitude; 
-    longitude_ = kDefaultLongitude;
-  }
+    latitude(decimal_lat);
+    longitude(decimal_lon);
 }
 
 Position::~Position() {}
@@ -32,29 +26,24 @@ double Position::longitude() const {
 }
 
 void Position::latitude(double lat) {
-  if (ValidLatitude(lat)) {
-    latitude_ = SetPrecision(lat * CYCLUS_DECIMAL_SECOND_MULTIPLIER, 1);
+  if (!ValidLatitude(lat)) {
+    latitude_ = kInvalidLatitude;
   } else { 
-    latitude_ = kDefaultLatitude;
+    latitude_ = SetPrecision(lat * CYCLUS_DECIMAL_SECOND_MULTIPLIER, 1);
   }
 }
 
 void Position::longitude(double lon) {
-  if (ValidLongitude(lon)) {
-    longitude_ = SetPrecision(lon * CYCLUS_DECIMAL_SECOND_MULTIPLIER, 1);
+  if (!ValidLongitude(lon)) {
+    longitude_ = kInvalidLongitude;
   } else {
-    longitude_ = 0.0;
+    longitude_ = SetPrecision(lon * CYCLUS_DECIMAL_SECOND_MULTIPLIER, 1);
   }
 }
 
 void Position::set_position(double lat, double lon) {
-  if (ValidLatitude(lat) and ValidLongitude(lon)) {
-    latitude_ = SetPrecision(lat * CYCLUS_DECIMAL_SECOND_MULTIPLIER, 1);
-    longitude_ = SetPrecision(lon * CYCLUS_DECIMAL_SECOND_MULTIPLIER, 1);
-  } else {
-    latitude_ = kDefaultLatitude;
-    longitude_ = kDefaultLongitude;
-  }
+  latitude(lat);
+  longitude(lon);
 }
 
 void Position::RecordPosition(Agent* agent) {
@@ -71,8 +60,8 @@ bool Position::ValidLatitude(double lat) {
   if (lat > 90 || lat < -90) {
     std::stringstream msg;
     msg << "The provided latitude (" << lat
-        << ") is outside the acceptable range. "
-        << "[-90, 90]";
+        << ") is outside the acceptable range "
+        << "[-90, 90]. Setting to NaN.";
     cyclus::Warn<cyclus::VALUE_WARNING>(msg.str());
     return false;
   }
@@ -83,8 +72,8 @@ bool Position::ValidLongitude(double lon) {
   if (lon > 180 || lon < -180) {
     std::stringstream msg;
     msg << "The provided longitude (" << lon
-        << ") is outside the acceptable range."
-        << "[-180, 180]";
+        << ") is outside the acceptable range "
+        << "[-180, 180]. Setting to NaN.";
     cyclus::Warn<cyclus::VALUE_WARNING>(msg.str());
     return false;
   }

--- a/src/toolkit/position.cc
+++ b/src/toolkit/position.cc
@@ -60,7 +60,7 @@ void Position::LatCheck(double lat) {
     msg << "The provided latitude (" << lat
         << ") is outside the acceptable range. "
         << "[-90, 90]";
-    throw ValueError(msg.str());
+      cyclus::Warn<cyclus::VALUE_WARNING>(msg.str());
   }
 }
 
@@ -70,7 +70,7 @@ void Position::LonCheck(double lon) {
     msg << "The provided longitude (" << lon
         << ") is outside the acceptable range."
         << "[-180, 180]";
-    throw ValueError(msg.str());
+    cyclus::Warn<cyclus::VALUE_WARNING>(msg.str());;
   }
 }
 

--- a/src/toolkit/position.cc
+++ b/src/toolkit/position.cc
@@ -16,8 +16,8 @@ Position::Position(double decimal_lat, double decimal_lon) {
     longitude_ = SetPrecision(decimal_lon * CYCLUS_DECIMAL_SECOND_MULTIPLIER, 1);
   } else {
     // Set to some legal value. 0.0 is chosen as the default.
-    latitude_ = 0.0; 
-    longitude_ = 0.0;
+    latitude_ = kDefaultLatitude; 
+    longitude_ = kDefaultLongitude;
   }
 }
 
@@ -35,7 +35,7 @@ void Position::latitude(double lat) {
   if (ValidLatitude(lat)) {
     latitude_ = SetPrecision(lat * CYCLUS_DECIMAL_SECOND_MULTIPLIER, 1);
   } else { 
-    latitude_ = 0.0;
+    latitude_ = kDefaultLatitude;
   }
 }
 
@@ -52,8 +52,8 @@ void Position::set_position(double lat, double lon) {
     latitude_ = SetPrecision(lat * CYCLUS_DECIMAL_SECOND_MULTIPLIER, 1);
     longitude_ = SetPrecision(lon * CYCLUS_DECIMAL_SECOND_MULTIPLIER, 1);
   } else {
-    latitude_ = 0.0;
-    longitude_ = 0.0;
+    latitude_ = kDefaultLatitude;
+    longitude_ = kDefaultLongitude;
   }
 }
 

--- a/src/toolkit/position.cycpp.h
+++ b/src/toolkit/position.cycpp.h
@@ -1,12 +1,12 @@
 // This includes the required header to add geographic coordinates to a
 // archetypes.
-// One only need to:
-// - '#include "toolkit/position.cycpp.h"' in the core of the archetype class (as
+// One only needs to:
+// - '#include "toolkit/position.cycpp.h"' in the header of the archetype class (as
 // private)
-// - and in the EnterNotify() method:
-//   - set the coordinates 'coordinates = cyclus::toolkit::Position(latitude,
-//   longitude);'
-//   - call the record method: 'coordinates.RecordPosititon(this);'
+// - In the EnterNotify() method:
+//   - Call the InitializePosition(); function
+// - In the constructor in the .cc file:
+//   - Add  latitude(0.0), longitude(0.0), to the initialization list
 
 cyclus::toolkit::Position coordinates;
 

--- a/src/toolkit/position.cycpp.h
+++ b/src/toolkit/position.cycpp.h
@@ -26,12 +26,10 @@ double latitude;
 }
 double longitude;
 
-protected:
-
-  void InitializePosition(cyclus::Agent* agent) {
-    coordinates.set_position(latitude, longitude);
-    coordinates.RecordPosition(agent);
-  }
+void InitializePosition(cyclus::Agent* agent) {
+  coordinates.set_position(latitude, longitude);
+  coordinates.RecordPosition(agent);
+}
 
 // required for compilation but not added by the cycpp preprocessor...
 std::vector<int> cycpp_shape_latitude = {0};

--- a/src/toolkit/position.cycpp.h
+++ b/src/toolkit/position.cycpp.h
@@ -26,9 +26,9 @@ double latitude;
 }
 double longitude;
 
-void InitializePosition(cyclus::Agent* agent) {
+void InitializePosition() {
   coordinates.set_position(latitude, longitude);
-  coordinates.RecordPosition(agent);
+  coordinates.RecordPosition(this);
 }
 
 // required for compilation but not added by the cycpp preprocessor...

--- a/src/toolkit/position.cycpp.h
+++ b/src/toolkit/position.cycpp.h
@@ -27,6 +27,7 @@ double latitude;
 }
 double longitude;
 
+// Provided default values to give the option to manually override
 void InitializePosition() {
   coordinates.set_position(latitude, longitude);
   coordinates.RecordPosition(this);

--- a/src/toolkit/position.cycpp.h
+++ b/src/toolkit/position.cycpp.h
@@ -1,4 +1,3 @@
-
 // This includes the required header to add geographic coordinates to a
 // archetypes.
 // One only need to:
@@ -9,7 +8,7 @@
 //   longitude);'
 //   - call the record method: 'coordinates.RecordPosititon(this);'
 
-cyclus::toolkit::Position coordinates(0,0);
+cyclus::toolkit::Position coordinates;
 
 #pragma cyclus var { \
 "default": 0.0, \
@@ -18,8 +17,6 @@ cyclus::toolkit::Position coordinates(0,0);
        "be expressed in degrees as a double." \
 }
 double latitude;
-// required for compilation but not added by the cycpp preprocessor...
-std::vector<int> cycpp_shape_latitude = 0;
 
 #pragma cyclus var { \
 "default": 0.0, \
@@ -28,5 +25,14 @@ std::vector<int> cycpp_shape_latitude = 0;
        "be expressed in degrees as a double." \
 }
 double longitude;
+
+protected:
+
+  void InitializePosition(cyclus::Agent* agent) {
+    coordinates.set_position(latitude, longitude);
+    coordinates.RecordPosition(agent);
+  }
+
 // required for compilation but not added by the cycpp preprocessor...
-std::vector<int> cycpp_shape_longitude = 0;
+std::vector<int> cycpp_shape_latitude = {0};
+std::vector<int> cycpp_shape_longitude = {0};

--- a/src/toolkit/position.cycpp.h
+++ b/src/toolkit/position.cycpp.h
@@ -1,8 +1,9 @@
 // This includes the required header to add geographic coordinates to a
 // archetypes.
 // One only needs to:
-// - '#include "toolkit/position.cycpp.h"' in the header of the archetype class (as
-// private)
+// - '#include "toolkit/position.cycpp.h"' in the header of the archetype class
+//   (it is strongly recommended to inject this snippet as `private:`, but 
+//   archetype developers are free to make other choices)
 // - In the EnterNotify() method:
 //   - Call the InitializePosition(); function
 // - In the constructor in the .cc file:

--- a/src/toolkit/position.h
+++ b/src/toolkit/position.h
@@ -138,6 +138,12 @@ class Position {
   /// Longitude is stored as seconds of degree.
   double longitude_;
 
+  /// @brief Default Latitude
+  static constexpr double kDefaultLatitude = 0.0;
+
+  /// @brief Default Latitude
+  static constexpr double kDefaultLongitude = 0.0;
+
   /// Checks if the decimal degree of longitude is within acceptable range.
   /// The acceptable range is between -180 and 180 (inclusive).
   /// @param lat latitude expressed in decimal degrees.

--- a/src/toolkit/position.h
+++ b/src/toolkit/position.h
@@ -141,12 +141,14 @@ class Position {
   /// Checks if the decimal degree of longitude is within acceptable range.
   /// The acceptable range is between -180 and 180 (inclusive).
   /// @param lat latitude expressed in decimal degrees.
-  void LonCheck(double lon);
-
-  /// Checks if the decimal degree of latitude is within acceptable range.
-  /// The acceptable range is between -90 and 90 (inclusive).
+  /// @return bool (true if valid, false otherwise)
+  bool ValidLongitude(double lon);
+  
+  /// @brief Checks if the decimal degree of latitude is within acceptable
+  /// range. The acceptable range is between -90 and 90 (inclusive).
   /// @param lat latitude expressed in decimal degrees.
-  void LatCheck(double lat);
+  /// @return bool (true if valid, false otherwise)
+  bool ValidLatitude(double lat);
 
   /// Sets the precision for double values.
   /// @param value that requires change of precision

--- a/src/toolkit/position.h
+++ b/src/toolkit/position.h
@@ -3,6 +3,7 @@
 #define CYCLUS_DECIMAL_SECOND_MULTIPLIER 3600
 
 #include <string>
+
 #include "cyclus.h"
 
 namespace cyclus {
@@ -138,18 +139,20 @@ class Position {
   /// Longitude is stored as seconds of degree.
   double longitude_;
 
-  /// @brief Default Latitude
-  static constexpr double kDefaultLatitude = 0.0;
+  /// @brief Catch for Invalid Latitude
+  static constexpr double kInvalidLatitude =
+      std::numeric_limits<double>::quiet_NaN();
 
-  /// @brief Default Latitude
-  static constexpr double kDefaultLongitude = 0.0;
+  /// @brief Catch for Invalid Longitude
+  static constexpr double kInvalidLongitude =
+      std::numeric_limits<double>::quiet_NaN();
 
   /// Checks if the decimal degree of longitude is within acceptable range.
   /// The acceptable range is between -180 and 180 (inclusive).
   /// @param lat latitude expressed in decimal degrees.
   /// @return bool (true if valid, false otherwise)
   bool ValidLongitude(double lon);
-  
+
   /// @brief Checks if the decimal degree of latitude is within acceptable
   /// range. The acceptable range is between -90 and 90 (inclusive).
   /// @param lat latitude expressed in decimal degrees.

--- a/tests/toolkit/position_tests.cc
+++ b/tests/toolkit/position_tests.cc
@@ -6,18 +6,6 @@
 #include "toolkit/position.h"
 using cyclus::toolkit::Position;
 
-std::string CaptureCerr(std::function<void()> f) {
-  std::stringstream buffer;
-
-  // This line grabs/copies the cerr buffer, and stores it in old/buffer so we
-  // can check it, and then restore it later.
-  std::streambuf* old = std::cerr.rdbuf(buffer.rdbuf());
-  f();
-
-  // Restore the old cerr buffer so that it gets back what it expects
-  std::cerr.rdbuf(old);
-  return buffer.str();
-}
 namespace cyclus {
 
 class PositionTest : public ::testing::Test {

--- a/tests/toolkit/position_tests.cc
+++ b/tests/toolkit/position_tests.cc
@@ -128,6 +128,11 @@ TEST_F(PositionTest, Setters) {
   EXPECT_NE(eiffel_out.find("is outside the acceptable range"), std::string::npos);
   EXPECT_NE(sydney_out.find("is outside the acceptable range"), std::string::npos);
   EXPECT_NE(museum_out.find("is outside the acceptable range"), std::string::npos);
+
+  EXPECT_EQ(eiffel_.latitude(), 0.0);
+  EXPECT_EQ(sydney_.latitude(), 0.0);
+  EXPECT_EQ(sydney_.longitude(), 0.0);
+  EXPECT_EQ(museum_.longitude(), 0.0);
 }
 
 }  // namespace cyclus

--- a/tests/toolkit/position_tests.cc
+++ b/tests/toolkit/position_tests.cc
@@ -113,26 +113,12 @@ TEST_F(PositionTest, ToStringDMS) {
 }
 
 TEST_F(PositionTest, Setters) {
-
-  std::string eiffel_out = CaptureCerr([&]() {
-    eiffel_.latitude(1000);
-  });
-
-  std::string sydney_out = CaptureCerr([&]() {
-    sydney_.set_position(-90.1, 0);
-  });
-  std::string museum_out = CaptureCerr([&]() {
-    museum_.longitude(180.1);
-  });
-
-  EXPECT_NE(eiffel_out.find("is outside the acceptable range"), std::string::npos);
-  EXPECT_NE(sydney_out.find("is outside the acceptable range"), std::string::npos);
-  EXPECT_NE(museum_out.find("is outside the acceptable range"), std::string::npos);
-
-  EXPECT_EQ(eiffel_.latitude(), 0.0);
-  EXPECT_EQ(sydney_.latitude(), 0.0);
-  EXPECT_EQ(sydney_.longitude(), 0.0);
-  EXPECT_EQ(museum_.longitude(), 0.0);
+  cyclus::warn_as_error = true;
+  EXPECT_THROW(eiffel_.latitude(1000), cyclus::ValueError);
+  EXPECT_THROW(sydney_.set_position(-90.1, 0), cyclus::ValueError);
+  EXPECT_THROW(museum_.longitude(180.1), cyclus::ValueError);
+  cyclus::warn_as_error = false;
+ 
 }
 
 }  // namespace cyclus


### PR DESCRIPTION
# Summary of Changes
This PR primarily serves to reopen discussion on the "correct" way to do code injection through the .cycpp system, specifically related to the initialization of variables in position. A few minor changes were made to the way @bam241 did things, mostly to bring the code in line with some of the in-person talks @gonuke and I had when talking about cyclus/cycamore#502.

# Related CEPs and Issues

This PR is related to:

- cyclus/cycamore#502
- #1853 
- #1510 
- Closes #1871   

# Associated Developers

@bam241 
@gonuke 

# Design Notes

I attempted to remove all initialization from the constructor (the `latitude(0.0), longitude(0.0), coordinates(0, 0)` bit), but because of limitations with the `#pragma cyclus var` system, it is impossible to inject something like `double latitude = 0.0` (it throws an error). I was able to remove the `coordinates(0, 0)` bit, and to condense the initialization into an injected function, however. 

## TODO:
- [x] Change the documentation in the .cycpp.h file
- [x] Update the changelog (oops)

# Testing and Validation

The code was built locally on my machine. No additional tests were added, but all existing tests passed on my machine. 

# Checklist

 - [x] Read the [Contributing to Cyclus](https://fuelcycle.org/kernel/contributing_to_cyclus.html) guide.
 - [x]  Compile and run locally.
 - [x]  Add or update tests.
 - [x]  Document if needed.
 - [x]  Follow style guidelines.
 - [x]  Update the changelog.
 - [ ]  Address all review comments.
Reviewers, please refer to the Cyclus [Guide for Reviewers](https://fuelcycle.org/kernel/pr_review.html).