### PR TITLE
Allow XML to have multiple `archetype` elements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Since last release
 * Table for recording active/dormant cycle periods (#1830)
 * Support for OpenMP parallelized simulations (#1709)
 * Command-line option to make a new blank input file referencing a current schema (#1861)
+* Allow multiple archetype blocks to facilitate includes ()
 
 **Changed:**
 

--- a/share/cyclus-flat.rng.in
+++ b/share/cyclus-flat.rng.in
@@ -136,31 +136,33 @@
       </element>
     </zeroOrMore>
 
-    <element name="archetypes"> 
-      <a:documentation>A list of archetypes that will be dynamically loaded for use in agent Prototypes.</a:documentation>
-      <oneOrMore>
-        <element name="spec">
-          <a:documentation>A complete archetype specification</a:documentation>
-          <interleave>
-            <optional>
-              <element name="path">
-                <a:documentation>An optional path to find this archetype; only needed if not discoverable in the standard locations.</a:documentation>
-                <text/></element></optional>
-            <optional>
-              <element name="lib">
-                <a:documentation>An optional name for the library that contains this archetype.</a:documentation>
-                <text/></element></optional>
-            <element name="name">
-              <a:documentation>The name that will be used to refer to this archetype.</a:documentation>
-              <text/></element>
-            <optional>
-              <element name="alias">
-                <a:documentation>An optional alias to refer to this archetype by a different name.</a:documentation>
-                <text/></element></optional>
-          </interleave>
-        </element>
-      </oneOrMore>
-    </element>
+    <oneOrMore>
+      <element name="archetypes"> 
+        <a:documentation>A list of archetypes that will be dynamically loaded for use in agent Prototypes.</a:documentation>
+        <oneOrMore>
+          <element name="spec">
+            <a:documentation>A complete archetype specification</a:documentation>
+            <interleave>
+              <optional>
+                <element name="path">
+                  <a:documentation>An optional path to find this archetype; only needed if not discoverable in the standard locations.</a:documentation>
+                  <text/></element></optional>
+              <optional>
+                <element name="lib">
+                  <a:documentation>An optional name for the library that contains this archetype.</a:documentation>
+                  <text/></element></optional>
+              <element name="name">
+                <a:documentation>The name that will be used to refer to this archetype.</a:documentation>
+                <text/></element>
+              <optional>
+                <element name="alias">
+                  <a:documentation>An optional alias to refer to this archetype by a different name.</a:documentation>
+                  <text/></element></optional>
+            </interleave>
+          </element>
+        </oneOrMore>
+      </element>
+    </oneOrMore>
 
     <oneOrMore>
       <element name="prototype">

--- a/share/cyclus.rng.in
+++ b/share/cyclus.rng.in
@@ -136,32 +136,34 @@
         </interleave>
       </element>
     </zeroOrMore>
-      
-    <element name="archetypes"> 
-      <a:documentation>A list of archetypes that will be dynamically loaded for use in Regions, Insitutions, and Facilities.</a:documentation>
-      <oneOrMore>
-        <element name="spec">
-          <a:documentation>A complete archetype specification</a:documentation>
-          <interleave>
-            <optional>
-              <element name="path">
-                <a:documentation>An optional path to find this archetype; only needed if not discoverable in the standard locations.</a:documentation>
-                <text/></element></optional>
-            <optional>
-              <element name="lib">
-                <a:documentation>An optional name for the library that contains this archetype.</a:documentation>
-                <text/></element></optional>
-            <element name="name">
-              <a:documentation>The name that will be used to refer to this archetype.</a:documentation>
-              <text/></element>
-            <optional>
-              <element name="alias">
-                <a:documentation>An optional alias to refer to this archetype by a different name.</a:documentation>
-                <text/></element></optional>
-          </interleave>
-        </element>
-      </oneOrMore>
-    </element>
+
+    <oneOrMore>  
+      <element name="archetypes"> 
+        <a:documentation>A list of archetypes that will be dynamically loaded for use in Regions, Insitutions, and Facilities.</a:documentation>
+        <oneOrMore>
+          <element name="spec">
+            <a:documentation>A complete archetype specification</a:documentation>
+            <interleave>
+              <optional>
+                <element name="path">
+                  <a:documentation>An optional path to find this archetype; only needed if not discoverable in the standard locations.</a:documentation>
+                  <text/></element></optional>
+              <optional>
+                <element name="lib">
+                  <a:documentation>An optional name for the library that contains this archetype.</a:documentation>
+                  <text/></element></optional>
+              <element name="name">
+                <a:documentation>The name that will be used to refer to this archetype.</a:documentation>
+                <text/></element>
+              <optional>
+                <element name="alias">
+                  <a:documentation>An optional alias to refer to this archetype by a different name.</a:documentation>
+                  <text/></element></optional>
+            </interleave>
+          </element>
+        </oneOrMore>
+      </element>
+    </oneOrMore>
 
     <oneOrMore>
       <element name="facility">

--- a/tests/input/include_source_w_archetype.xml
+++ b/tests/input/include_source_w_archetype.xml
@@ -1,0 +1,59 @@
+<!-- 1 Source, 1 Sink -->
+
+<simulation xmlns:xi="http://www.w3.org/2001/XInclude">
+  <control>
+    <duration>100</duration>
+    <startmonth>1</startmonth>
+    <startyear>2000</startyear>
+    <solver><config><coin-or><timeout>3599</timeout></coin-or></config></solver>
+  </control>
+
+  <archetypes>
+    <spec><lib>agents</lib><name>Sink</name></spec>
+    <spec><lib>agents</lib><name>NullRegion</name></spec>
+    <spec><lib>agents</lib><name>NullInst</name></spec>
+  </archetypes>
+
+  <facility>
+    <name>Sink</name>
+    <config>
+      <Sink>
+        <in_commods>
+          <val>commodity</val>
+        </in_commods>
+        <capacity>   1.00 </capacity>
+      </Sink>
+    </config>
+  </facility>
+
+  <xi:include href="input/source_w_archetype.xml" xpointer="xpointer(//source_w_archetype/*)"/>
+
+  <region>
+    <name>SingleRegion</name>
+    <config> <NullRegion/> </config>
+    <institution>
+      <name>SingleInstitution</name>
+      <initialfacilitylist>
+        <entry>
+          <prototype>Source</prototype>
+          <number>1</number>
+        </entry>
+        <entry>
+          <prototype>Sink</prototype>
+          <number>1</number>
+        </entry>
+      </initialfacilitylist>
+      <config> <NullInst/> </config>
+    </institution>
+  </region>
+
+  <recipe>
+    <name>commod_recipe</name>
+    <basis>mass</basis>
+    <nuclide>
+      <id>H1</id>
+      <comp>1</comp>
+    </nuclide>
+  </recipe>
+
+</simulation>

--- a/tests/input/source_w_archetype.xml
+++ b/tests/input/source_w_archetype.xml
@@ -1,0 +1,16 @@
+<source_w_archetype>
+  <archetypes>
+    <spec><lib>agents</lib><name>Source</name></spec>
+  </archetypes>
+
+  <facility>
+    <name>Source</name>
+    <config>
+      <Source>
+        <commod>commodity</commod>
+        <recipe_name>commod_recipe</recipe_name>
+        <capacity>1.00</capacity>
+      </Source>
+    </config>
+  </facility>
+</source_w_archetype>

--- a/tests/test_include_xml.py
+++ b/tests/test_include_xml.py
@@ -23,3 +23,19 @@ def test_include_recipe(thread_count):
     if rtn != 0:
         return  # don't execute further commands
     clean_outs()
+
+
+def test_include_source_w_archetype(thread_count):
+    """Testing for including of other XML files.
+    """
+    clean_outs()
+    # Cyclus simulation input for recipe including
+    sim_input = os.path.join(INPUT, "include_source_w_archetype.xml")
+    holdsrtn = [1]  # needed because nose does not send() to test generator
+    outfile = which_outfile(thread_count)
+    cmd = ["cyclus", "-j", thread_count, "-o", outfile, "--input-file", sim_input]
+    check_cmd(cmd, CWD, holdsrtn)
+    rtn = holdsrtn[0]
+    if rtn != 0:
+        return  # don't execute further commands
+    clean_outs()


### PR DESCRIPTION
The previous XML schema only allowed a single `archetype` block to exist.  This change allows multiple `archetype` blocks, as long as there is at least one.

A motivating use case for this is to facilitate including XML snippets that contain long lists of facility prototypes that may be useful in many simulations.  Without this change, the top level input file must include all the archetype specs for the archetypes that are used in those facilities.  With this change, the archetype specs that are used in that included file can be included there to make sure they are available.

Fortunately, this required no code changes and only a change in our XML schema.  We already processed archetypes in a way that didn't care how many blocks there were, nor cared if there were duplicates of the same archetype.

A test has been added that demonstrates how to use this kind of inclusion, which requires the `xpointer` metadata in the include line.