### PR TITLE
Calculate Unit Price

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Since last release
 
 **Added:**
 
+* Added a function to facility_cost.cycpp.h to calculate price of a DRE bid (#1877)
 * Added a function to facility_cost.cycpp.h to calculate cost of a DRE bid (#1870)
 * Added code injection for matl_buy/sell_policy (#1866)
 * Added set of basic finance math function to EconomicEntity (#1864)

--- a/src/toolkit/facility_cost.cycpp.h
+++ b/src/toolkit/facility_cost.cycpp.h
@@ -140,8 +140,7 @@ double CalculateBidCost(double production_capacity, double units_to_produce,
         return kDefaultBidCost;
     }
 
-    // Once that other time-step related PR gets merged this can be cyclusYear
-    double timesteps_per_year = kDefaultTimeStepDur * 12 / context()->dt();
+    double timesteps_per_year = cyclusYear / context()->dt();
     double annual_production = production_capacity * timesteps_per_year;
 
     // This is my way of keeping the categories. New costs can be added to these
@@ -168,6 +167,13 @@ double CalculateBidCost(double production_capacity, double units_to_produce,
     return bid_cost != 0 ? bid_cost : kDefaultBidCost;
 
     
+}
+
+double CalculateBidPrice(double production_capacity, double units_to_produce, 
+    double input_cost) const {
+
+    // Default implementation
+    return CalculateBidCost(production_capacity, units_to_produce, input_cost);
 }
 
 // Required for compilation but not added by the cycpp preprocessor. Do not


### PR DESCRIPTION
# Summary of Changes

This very simple PR does two things:

1. Add a CalcUnitPrice() function to distinguish between a cost and a price for a bid (currently implements "default" behavior of just returning the cost)
2. Changes the bit in CalcUnitCost() where `kDefaultTimestepDur * 12` was used for the length of a year to just use `cyclusYear` now that #1867 has been merged. 

# Related CEPs and Issues

This PR is related to:

- Closes #1876
- #1867 
- #1870   

# Associated Developers

None.

# Design Notes

I made CalcBidPrice() take the same arguments as CalcBidCost() because it seemed like the easiest thing to do. If anyone can think of a better way to do this let me know and I'm happy to change that.

# Testing and Validation

The code was built locally on my machine. No tests have been added.

# Checklist

 - [x] Read the [Contributing to Cyclus](https://fuelcycle.org/kernel/contributing_to_cyclus.html) guide.
 - [x]  Compile and run locally.
 - [ ]  Add or update tests.
 - [x]  Document if needed.
 - [x]  Follow style guidelines.
 - [x]  Update the changelog.
 - [ ]  Address all review comments.
Reviewers, please refer to the Cyclus [Guide for Reviewers](https://fuelcycle.org/kernel/pr_review.html).