### PR TITLE
Add clang-format protections to Cyclus

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,13 +1,12 @@
----
 Language:        Cpp
-BasedOnStyle:  Google
-# only allow single line functions if they are inlined in class def'n
+BasedOnStyle:    Google
+# Only allow single-line functions if they are inlined in class definition
 AllowShortFunctionsOnASingleLine: Inline
-# do not force new line after template declarations
+# Do not force new line after template declarations
 AlwaysBreakTemplateDeclarations: false
-# Automatically detect whether a given fuction's arguments are one-per-line
+# Automatically detect whether a given function's arguments are one-per-line
 ExperimentalAutoDetectBinPacking: true
 # Use C++11 standard
-Standard:        Cpp11
-...
-
+Standard: Cpp11
+# Prevent automatic include sorting
+SortIncludes: Never

--- a/src/query_backend.h
+++ b/src/query_backend.h
@@ -1,3 +1,4 @@
+// clang-format off
 #ifndef CYCLUS_SRC_QUERY_BACKEND_H_
 #define CYCLUS_SRC_QUERY_BACKEND_H_
 
@@ -1044,3 +1045,4 @@ class Sha1 {
 }  // namespace cyclus
 
 #endif  // CYCLUS_SRC_QUERY_BACKEND_H_
+// clang-format on

--- a/src/toolkit/facility_cost.cycpp.h
+++ b/src/toolkit/facility_cost.cycpp.h
@@ -15,6 +15,7 @@
 ///    file with the other ones, reaplcing <param_name> with the name you put
 ///    in the econ_params array (again, must match exactly).
 
+// clang-format off
 #pragma cyclus var {"default" : 0.0,                                       \
                    "uilabel" : "Capital cost required to build facility", \
                    "doc" : "Capital cost required to build facility",     \
@@ -67,7 +68,7 @@ double annual_labor_cost;
     "units": "Dimensionless" \
     }
 double cost_override;
-
+// clang-format on
 
 // Must be done in a function so that we can access the user-defined values
 std::unordered_map<std::string, double> GenerateParamList() const override {

--- a/src/toolkit/institution_cost.cycpp.h
+++ b/src/toolkit/institution_cost.cycpp.h
@@ -15,6 +15,7 @@
 ///    file with the other ones, reaplcing <param_name> with the name you put
 ///    in the econ_params array (again, must match exactly).
 
+// clang-format off
 #pragma cyclus var { \
     "default": 0.0, \
     "uilabel": "Minimum acceptable rate of return", \
@@ -23,7 +24,8 @@
     "units": "Dimensionless" \
     }
 double minimum_acceptable_return_rate;
-    
+// clang-format on    
+
 // Must be done in a function so that we can access the user-defined values
 std::unordered_map<std::string, double> GenerateParamList() const {
     std::unordered_map<std::string, double> econ_params {

--- a/src/toolkit/matl_buy_policy.cycpp.h
+++ b/src/toolkit/matl_buy_policy.cycpp.h
@@ -165,6 +165,7 @@ inline void InitBuyPolicyParameters() {
     throw cyclus::ValueError("Invalid buying size type");}
 }
 
+// clang-format off
 #pragma cyclus var {"default": "Fixed",\
                     "tooltip": "Type of active buying frequency",\
                     "doc": "Options: Fixed, Uniform, Normal, Binomial, FixedWithDisruption. "\
@@ -428,6 +429,7 @@ double reorder_quantity;
                     "The per-time step demand is unchanged except the cycle cap is almost reached.",\
                     "uilabel": "Cumulative Cap"}
 double cumulative_cap;
+// clang-format on
 
 //// A policy for requesting material
 cyclus::toolkit::MatlBuyPolicy buy_policy;

--- a/src/toolkit/matl_sell_policy.cycpp.h
+++ b/src/toolkit/matl_sell_policy.cycpp.h
@@ -16,6 +16,7 @@
 /// sell_quantity restricts selling to only integer multiples of this value
 /// @}
 
+// clang-format off
 #pragma cyclus var {"default": 0,\
                     "tooltip":"sell quantity (kg)",\
                     "doc":"material will be sold in integer multiples of this quantity. If"\
@@ -26,6 +27,7 @@
                     "range": [0.0, CY_LARGE_DOUBLE], \
                     "units": "kg"}
 double sell_quantity;
+// clang-format on
 
 //// A policy for sending material
 cyclus::toolkit::MatlSellPolicy sell_policy;

--- a/src/toolkit/position.cycpp.h
+++ b/src/toolkit/position.cycpp.h
@@ -11,21 +11,23 @@
 
 cyclus::toolkit::Position coordinates;
 
+// clang-format off
 #pragma cyclus var { \
-"default": 0.0, \
-"uilabel": "Geographical latitude in degrees as a double", \
-"doc": "Latitude of the agent's geographical position. The value should " \
+       "default": 0.0, \
+       "uilabel": "Geographical latitude in degrees as a double", \
+       "doc": "Latitude of the agent's geographical position. The value should " \
        "be expressed in degrees as a double." \
 }
 double latitude;
 
 #pragma cyclus var { \
-"default": 0.0, \
-"uilabel": "Geographical longitude in degrees as a double", \
-"doc": "Longitude of the agent's geographical position. The value should " \
-       "be expressed in degrees as a double." \
+       "default": 0.0, \
+       "uilabel": "Geographical longitude in degrees as a double", \
+       "doc": "Longitude of the agent's geographical position. The value should " \
+              "be expressed in degrees as a double." \
 }
 double longitude;
+// clang-format on
 
 // Provided default values to give the option to manually override
 void InitializePosition() {

--- a/src/toolkit/region_cost.cycpp.h
+++ b/src/toolkit/region_cost.cycpp.h
@@ -15,6 +15,7 @@
 ///    file with the other ones, reaplcing <param_name> with the name you put
 ///    in the econ_params array (again, must match exactly).
 
+// clang-format off
 #pragma cyclus var { \
     "default": 0.0, \
     "uilabel": "Corporate Income Tax Rate as decimal", \
@@ -23,7 +24,7 @@
     "units": "Dimensionless" \
     }
 double corporate_income_tax_rate;
-    
+// clang-format on
     
 // Must be done in a function so that we can access the user-defined values
 std::unordered_map<std::string, double> GenerateParamList() const {


### PR DESCRIPTION
# Summary of Changes

In preparation for #1674 some protections against clang-format need to be added to Cyclus. Specifically, the `#pragma` blocks in all the .cycpp.h files needed to be protected with `//clang-format off/on` guards, and an extra line needed to be added to the .clang-format file to make it not reorder the `#include` statements, since some of them depend on each other.

# Related CEPs and Issues

This PR is related to:

- #1674 
- Closes #1878 
- #1879  

# Associated Developers

[ahnaf-tahmid-chowdhury](https://github.com/ahnaf-tahmid-chowdhury)

# Design Notes

Besides the .cycpp.h files, the `query_backend.h` file needed to be protected in its entirety, since a python script reads it and looks for some very specific formatting that doesn't play nicely with clang-format. 

# Testing and Validation

Built and tested Cyclus and Cycamore on my local machine with Clean Builds. No additional unit testing added. clang-format was run on all files in src and then a clean-build was performed, which succeeded without error.

# Checklist

 - [x] Read the [Contributing to Cyclus](https://fuelcycle.org/kernel/contributing_to_cyclus.html) guide.
 - [x]  Compile and run locally.
 - [x]  Add or update tests.
 - [ ]  Document if needed.
 - [x]  Follow style guidelines.
 - [x]  Update the changelog.
 - [ ]  Address all review comments.
Reviewers, please refer to the Cyclus [Guide for Reviewers](https://fuelcycle.org/kernel/pr_review.html).