### PR TITLE
Change Facility_Cost `CalculateBidPrice()` function to `CalculateUnitPrice()`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Since last release
 **Added:**
 
 * Added clang-format protections to .cycpp.h and query_backend.h files, modified .clang-format file (#1880)
-* Added a function to facility_cost.cycpp.h to calculate price of a DRE bid (#1870 ,#1877, #1884)
+* Added a function to facility_cost.cycpp.h to calculate unit price of a DRE bid (#1870 ,#1877, #1884, #1889)
 * Added code injection for matl_buy/sell_policy (#1866)
 * Added set of basic finance math function to EconomicEntity (#1864)
 * Added Composition functions to get printable material composition information (#1868)

--- a/src/economic_entity.h
+++ b/src/economic_entity.h
@@ -127,7 +127,7 @@ class EconomicEntity {
   }
 
  protected:
-  static constexpr int kDefaultBidCost = 1;
+  static constexpr int kDefaultUnitCost = 1;
 
  private:
   std::unordered_map<std::string, double> financial_data_;

--- a/src/toolkit/facility_cost.cycpp.h
+++ b/src/toolkit/facility_cost.cycpp.h
@@ -84,7 +84,7 @@ std::unordered_map<std::string, double> GenerateParamList() const override {
 }
 
 double CalculateUnitCost(double production_capacity, double units_to_produce,
-                        double input_cost = 0.0) const {
+                         double input_cost = 0.0) const {
   // Check if there's a cost override, and if so, use that
   if (cost_override > 0) {
     return cost_override + input_cost / units_to_produce;
@@ -159,8 +159,8 @@ double CalculateUnitCost(double production_capacity, double units_to_produce,
       PMT(operational_lifetime, return_rate, total_dep - tax_shield, 0);
 
   double unit_production_cost = (annualized_depreciable + total_annual_fixed +
-                      total_annual_variable + property_tax) /
-                     annual_production;
+                                 total_annual_variable + property_tax) /
+                                annual_production;
 
   double unit_cost = unit_production_cost + input_cost / units_to_produce;
 
@@ -169,7 +169,7 @@ double CalculateUnitCost(double production_capacity, double units_to_produce,
 }
 
 double CalculateUnitPrice(double production_capacity, double units_to_produce,
-                         double input_cost = 0.0) const {
+                          double input_cost = 0.0) const {
   // Default implementation
   return CalculateUnitCost(production_capacity, units_to_produce, input_cost);
 }

--- a/src/toolkit/facility_cost.cycpp.h
+++ b/src/toolkit/facility_cost.cycpp.h
@@ -83,11 +83,11 @@ std::unordered_map<std::string, double> GenerateParamList() const override {
   return econ_params;
 }
 
-double CalculateBidCost(double production_capacity, double units_to_produce,
+double CalculateUnitCost(double production_capacity, double units_to_produce,
                         double input_cost = 0.0) const {
   // Check if there's a cost override, and if so, use that
   if (cost_override > 0) {
-    return cost_override * units_to_produce + input_cost;
+    return cost_override + input_cost / units_to_produce;
   }
 
   // Economic Parameters (declared like this because of scoping with try{})
@@ -112,9 +112,9 @@ double CalculateBidCost(double production_capacity, double units_to_produce,
     taxable_lifetime =
         static_cast<int>(GetEconParameter("facility_taxable_lifetime"));
   } catch (const std::exception& e) {
-    LOG(cyclus::LEV_INFO1, "CalculateBidCost")
+    LOG(cyclus::LEV_INFO1, "CalculateUnitCost")
         << prototype() << "failed to get financial_data_: " << e.what();
-    return kDefaultBidCost;
+    return kDefaultUnitCost;
   }
 
   try {
@@ -122,22 +122,22 @@ double CalculateBidCost(double production_capacity, double units_to_produce,
     corporate_tax_rate =
         parent()->GetEconParameter("corporate_income_tax_rate");
   } catch (const std::exception& e) {
-    LOG(cyclus::LEV_INFO1, "CalculateBidCost")
+    LOG(cyclus::LEV_INFO1, "CalculateUnitCost")
         << prototype()
         << "failed to get financial_data_ from: " << parent()->prototype()
         << e.what();
-    return kDefaultBidCost;
+    return kDefaultUnitCost;
   }
 
   try {
     property_tax_rate =
         parent()->parent()->GetEconParameter("property_tax_rate");
   } catch (const std::exception& e) {
-    LOG(cyclus::LEV_INFO1, "CalculateBidCost")
+    LOG(cyclus::LEV_INFO1, "CalculateUnitCost")
         << prototype() << "failed to get financial_data_ from: "
         << parent()->parent()->prototype() << e.what();
 
-    return kDefaultBidCost;
+    return kDefaultUnitCost;
   }
 
   double timesteps_per_year = cyclusYear / context()->dt();
@@ -158,20 +158,20 @@ double CalculateBidCost(double production_capacity, double units_to_produce,
   double annualized_depreciable =
       PMT(operational_lifetime, return_rate, total_dep - tax_shield, 0);
 
-  double unit_cost = (annualized_depreciable + total_annual_fixed +
+  double unit_production_cost = (annualized_depreciable + total_annual_fixed +
                       total_annual_variable + property_tax) /
                      annual_production;
 
-  double bid_cost = unit_cost * units_to_produce + input_cost;
+  double unit_cost = unit_production_cost + input_cost / units_to_produce;
 
-  // Protects against divide by zero in pref = 1/BidCost
-  return bid_cost != 0 ? bid_cost : kDefaultBidCost;
+  // Protects against divide by zero in pref = 1/unit_cost
+  return unit_cost != 0 ? unit_cost : kDefaultUnitCost;
 }
 
-double CalculateBidPrice(double production_capacity, double units_to_produce,
+double CalculateUnitPrice(double production_capacity, double units_to_produce,
                          double input_cost = 0.0) const {
   // Default implementation
-  return CalculateBidCost(production_capacity, units_to_produce, input_cost);
+  return CalculateUnitCost(production_capacity, units_to_produce, input_cost);
 }
 
 // Required for compilation but not added by the cycpp preprocessor. Do not


### PR DESCRIPTION
# Summary of Changes

After our conversation today, @gonuke and I decided that (one of) the reason(s) that cyclus/cycamore#656 was failing tests was because of a misimplementation of the `CalculateBidPrice()` function in `facility_cost.cycpp.h`, and that what we really wanted was to give it the UnitCost directly so that the default behavior of that function would interact correctly with the expected default behavior of the DRE in the regression tests. As a result, the `CalculateBidCost()` function was changed to `CalculateUnitCost()` (with appropriate modifications therein) and cyclus/cycamore#656 was modified to reflect this change. Hopefully those will stop failing tests now, but before they do, this PR needs to be merged.

# Related CEPs and Issues

This PR is related to:

- cyclus/cycamore#656
- Closes #1888 

# Associated Developers

@gonuke 

# Design Notes

Changed the semantics of the functions to match their new purpose.

# Testing and Validation

Built and tested Cyclus on my local machine. This was done with a clean-build.

# Checklist

 - [x] Read the [Contributing to Cyclus](https://fuelcycle.org/kernel/contributing_to_cyclus.html) guide.
 - [x]  Compile and run locally.
 - [ ]  Add or update tests.
 - [x]  Document if needed.
 - [x]  Follow style guidelines.
 - [x]  Update the changelog.
 - [x]   Run clang-format
 - [ ]  Address all review comments.
Reviewers, please refer to the Cyclus [Guide for Reviewers](https://fuelcycle.org/kernel/pr_review.html).