### PR TITLE
Add unit_value to Resource Objects and Children

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Since last release
 
 **Added:**
 
+* Added a unit value to Resource, Material, and Product objects (#1894)
 * Added clang-format protections to .cycpp.h and query_backend.h files, modified .clang-format file (#1880)
 * Added a function to facility_cost.cycpp.h to calculate unit price of a DRE bid (#1870 ,#1877, #1884, #1889)
 * Added code injection for matl_buy/sell_policy (#1866)

--- a/src/material.cc
+++ b/src/material.cc
@@ -17,13 +17,15 @@ Material::~Material() {}
 Material::Ptr Material::Create(Agent* creator, double quantity,
                                Composition::Ptr c, std::string package_name,
                                double unit_value) {
-  Material::Ptr m(new Material(creator->context(), quantity, c, package_name, unit_value));
+  Material::Ptr m(
+      new Material(creator->context(), quantity, c, package_name, unit_value));
   m->tracker_.Create(creator);
   return m;
 }
 
 Material::Ptr Material::CreateUntracked(double quantity, Composition::Ptr c) {
-  Material::Ptr m(new Material(NULL, quantity, c, Package::unpackaged_name(), 0.0));
+  Material::Ptr m(
+      new Material(NULL, quantity, c, Package::unpackaged_name(), 0.0));
   return m;
 }
 
@@ -87,7 +89,8 @@ Material::Ptr Material::ExtractComp(double qty, Composition::Ptr c,
   }
 
   qty_ -= qty;
-  Material::Ptr other(new Material(ctx_, qty, c, Package::unpackaged_name(), UnitValue()));
+  Material::Ptr other(
+      new Material(ctx_, qty, c, Package::unpackaged_name(), UnitValue()));
 
   // Decay called on the extracted material should have the same dt as for
   // this material regardless of composition.
@@ -119,7 +122,8 @@ void Material::Absorb(Material::Ptr mat) {
     prev_decay_time_ = mat->prev_decay_time_;
   }
   double tot_mass = qty_ + mat->quantity();
-  double avg_unit_value = (qty_ * UnitValue() + mat->quantity() * mat->UnitValue()) / tot_mass;
+  double avg_unit_value =
+      (qty_ * UnitValue() + mat->quantity() * mat->UnitValue()) / tot_mass;
   SetUnitValue(avg_unit_value);
   qty_ = tot_mass;
   mat->qty_ = 0;

--- a/src/material.cc
+++ b/src/material.cc
@@ -153,7 +153,8 @@ Resource::Ptr Material::PackageExtract(double qty,
   }
 
   qty_ -= qty;
-  Material::Ptr other(new Material(ctx_, qty, comp_, new_package_name));
+  Material::Ptr other(
+      new Material(ctx_, qty, comp_, new_package_name, UnitValue()));
 
   // Decay called on the extracted material should have the same dt as for
   // this material regardless of composition.

--- a/src/material.cc
+++ b/src/material.cc
@@ -15,14 +15,15 @@ const ResourceType Material::kType = "Material";
 Material::~Material() {}
 
 Material::Ptr Material::Create(Agent* creator, double quantity,
-                               Composition::Ptr c, std::string package_name) {
-  Material::Ptr m(new Material(creator->context(), quantity, c, package_name));
+                               Composition::Ptr c, std::string package_name,
+                               double unit_value) {
+  Material::Ptr m(new Material(creator->context(), quantity, c, package_name, unit_value));
   m->tracker_.Create(creator);
   return m;
 }
 
 Material::Ptr Material::CreateUntracked(double quantity, Composition::Ptr c) {
-  Material::Ptr m(new Material(NULL, quantity, c, Package::unpackaged_name()));
+  Material::Ptr m(new Material(NULL, quantity, c, Package::unpackaged_name(), 0.0));
   return m;
 }
 
@@ -86,7 +87,7 @@ Material::Ptr Material::ExtractComp(double qty, Composition::Ptr c,
   }
 
   qty_ -= qty;
-  Material::Ptr other(new Material(ctx_, qty, c, Package::unpackaged_name()));
+  Material::Ptr other(new Material(ctx_, qty, c, Package::unpackaged_name(), UnitValue()));
 
   // Decay called on the extracted material should have the same dt as for
   // this material regardless of composition.
@@ -265,13 +266,14 @@ Composition::Ptr Material::comp() {
 }
 
 Material::Material(Context* ctx, double quantity, Composition::Ptr c,
-                   std::string package_name)
+                   std::string package_name, double unit_value)
     : qty_(quantity),
       comp_(c),
       tracker_(ctx, this),
       ctx_(ctx),
       prev_decay_time_(0),
       package_name_(package_name) {
+  SetUnitValue(unit_value);
   if (ctx != NULL) {
     prev_decay_time_ = ctx->time();
   } else {

--- a/src/material.cc
+++ b/src/material.cc
@@ -117,8 +117,10 @@ void Material::Absorb(Material::Ptr mat) {
   if (qty_ < mat->qty_) {
     prev_decay_time_ = mat->prev_decay_time_;
   }
-
-  qty_ += mat->qty_;
+  double tot_mass = qty_ + mat->quantity();
+  double avg_unit_value = (qty_ * UnitValue() + mat->quantity() * mat->UnitValue()) / tot_mass;
+  SetUnitValue(avg_unit_value);
+  qty_ = tot_mass;
   mat->qty_ = 0;
   tracker_.Absorb(&mat->tracker_);
 }

--- a/src/material.cc
+++ b/src/material.cc
@@ -23,9 +23,10 @@ Material::Ptr Material::Create(Agent* creator, double quantity,
   return m;
 }
 
-Material::Ptr Material::CreateUntracked(double quantity, Composition::Ptr c) {
+Material::Ptr Material::CreateUntracked(double quantity, Composition::Ptr c,
+                                        double unit_value) {
   Material::Ptr m(
-      new Material(NULL, quantity, c, Package::unpackaged_name(), 0.0));
+      new Material(NULL, quantity, c, Package::unpackaged_name(), unit_value));
   return m;
 }
 

--- a/src/material.h
+++ b/src/material.h
@@ -87,7 +87,8 @@ class Material : public Resource {
 
   /// Creates a new material resource that does not actually exist as part of
   /// the simulation and is untracked.
-  static Ptr CreateUntracked(double quantity, Composition::Ptr c);
+  static Ptr CreateUntracked(double quantity, Composition::Ptr c, 
+                             double unit_value = 0.0);
 
   /// Returns the id of the material's internal nuclide composition.
   virtual int qual_id() const;

--- a/src/material.h
+++ b/src/material.h
@@ -82,7 +82,8 @@ class Material : public Resource {
   /// "this" pointer). All future output data recorded will be done using the
   /// creator's context.
   static Ptr Create(Agent* creator, double quantity, Composition::Ptr c,
-                    std::string package_name = Package::unpackaged_name());
+                    std::string package_name = Package::unpackaged_name(),
+                    double unit_value = 0.0);
 
   /// Creates a new material resource that does not actually exist as part of
   /// the simulation and is untracked.
@@ -168,7 +169,8 @@ class Material : public Resource {
 
  protected:
   Material(Context* ctx, double quantity, Composition::Ptr c,
-           std::string package_name = Package::unpackaged_name());
+           std::string package_name = Package::unpackaged_name(),
+           double unit_value = 0.0);
 
  private:
   Context* ctx_;

--- a/src/material.h
+++ b/src/material.h
@@ -88,7 +88,7 @@ class Material : public Resource {
   /// Creates a new material resource that does not actually exist as part of
   /// the simulation and is untracked.
   static Ptr CreateUntracked(double quantity, Composition::Ptr c, 
-                             double unit_value = 0.0);
+                             double unit_value = kUnsetUnitValue);
 
   /// Returns the id of the material's internal nuclide composition.
   virtual int qual_id() const;

--- a/src/material.h
+++ b/src/material.h
@@ -83,11 +83,11 @@ class Material : public Resource {
   /// creator's context.
   static Ptr Create(Agent* creator, double quantity, Composition::Ptr c,
                     std::string package_name = Package::unpackaged_name(),
-                    double unit_value = 0.0);
+                    double unit_value = kUnsetUnitValue);
 
   /// Creates a new material resource that does not actually exist as part of
   /// the simulation and is untracked.
-  static Ptr CreateUntracked(double quantity, Composition::Ptr c, 
+  static Ptr CreateUntracked(double quantity, Composition::Ptr c,
                              double unit_value = kUnsetUnitValue);
 
   /// Returns the id of the material's internal nuclide composition.
@@ -171,7 +171,7 @@ class Material : public Resource {
  protected:
   Material(Context* ctx, double quantity, Composition::Ptr c,
            std::string package_name = Package::unpackaged_name(),
-           double unit_value = 0.0);
+           double unit_value = kUnsetUnitValue);
 
  private:
   Context* ctx_;

--- a/src/product.cc
+++ b/src/product.cc
@@ -50,7 +50,10 @@ void Product::Absorb(Product::Ptr other) {
   if (other->quality() != quality()) {
     throw ValueError("incompatible resource types.");
   }
-  quantity_ += other->quantity();
+  double tot_qty = quantity_ + other->quantity();
+  double avg_unit_value = (quantity_ * UnitValue() + other->quantity() * other->UnitValue()) / tot_qty;
+  SetUnitValue(avg_unit_value);
+  quantity_ = tot_qty;
   other->quantity_ = 0;
 
   tracker_.Absorb(&other->tracker_);

--- a/src/product.cc
+++ b/src/product.cc
@@ -13,7 +13,8 @@ int Product::next_qualid_ = 1;
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Product::Ptr Product::Create(Agent* creator, double quantity,
-                             std::string quality, std::string package_name) {
+                             std::string quality, std::string package_name, 
+                             double unit_value) {
   if (qualids_.count(quality) == 0) {
     qualids_[quality] = next_qualid_++;
     creator->context()
@@ -25,14 +26,14 @@ Product::Ptr Product::Create(Agent* creator, double quantity,
 
   // the next lines must come after qual id setting
   Product::Ptr r(
-      new Product(creator->context(), quantity, quality, package_name));
+      new Product(creator->context(), quantity, quality, package_name, unit_value));
   r->tracker_.Create(creator);
   return r;
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Product::Ptr Product::CreateUntracked(double quantity, std::string quality) {
-  Product::Ptr r(new Product(NULL, quantity, quality));
+  Product::Ptr r(new Product(NULL, quantity, quality, Package::unpackaged_name(), 0.0));
   r->tracker_.DontTrack();
   return r;
 }
@@ -67,7 +68,7 @@ Product::Ptr Product::Extract(double quantity) {
 
   quantity_ -= quantity;
 
-  Product::Ptr other(new Product(ctx_, quantity, quality_, package_name_));
+  Product::Ptr other(new Product(ctx_, quantity, quality_, package_name_, UnitValue()));
   tracker_.Extract(&other->tracker_);
   return other;
 }
@@ -81,6 +82,7 @@ std::string Product::package_name() {
   return package_name_;
 }
 
+// Not sure what to do here with the unit value and packaging...
 Resource::Ptr Product::PackageExtract(double qty,
                                       std::string new_package_name) {
   if (qty > quantity_) {
@@ -122,11 +124,13 @@ void Product::ChangePackage(std::string new_package_name) {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Product::Product(Context* ctx, double quantity, std::string quality,
-                 std::string package_name)
+                 std::string package_name, double unit_value)
     : quality_(quality),
       quantity_(quantity),
       tracker_(ctx, this),
       ctx_(ctx),
-      package_name_(package_name) {}
+      package_name_(package_name) {
+  SetUnitValue(unit_value);
+}
 
 }  // namespace cyclus

--- a/src/product.cc
+++ b/src/product.cc
@@ -13,7 +13,7 @@ int Product::next_qualid_ = 1;
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Product::Ptr Product::Create(Agent* creator, double quantity,
-                             std::string quality, std::string package_name, 
+                             std::string quality, std::string package_name,
                              double unit_value) {
   if (qualids_.count(quality) == 0) {
     qualids_[quality] = next_qualid_++;
@@ -25,15 +25,16 @@ Product::Ptr Product::Create(Agent* creator, double quantity,
   }
 
   // the next lines must come after qual id setting
-  Product::Ptr r(
-      new Product(creator->context(), quantity, quality, package_name, unit_value));
+  Product::Ptr r(new Product(creator->context(), quantity, quality,
+                             package_name, unit_value));
   r->tracker_.Create(creator);
   return r;
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Product::Ptr Product::CreateUntracked(double quantity, std::string quality) {
-  Product::Ptr r(new Product(NULL, quantity, quality, Package::unpackaged_name(), 0.0));
+  Product::Ptr r(
+      new Product(NULL, quantity, quality, Package::unpackaged_name(), 0.0));
   r->tracker_.DontTrack();
   return r;
 }
@@ -52,7 +53,9 @@ void Product::Absorb(Product::Ptr other) {
     throw ValueError("incompatible resource types.");
   }
   double tot_qty = quantity_ + other->quantity();
-  double avg_unit_value = (quantity_ * UnitValue() + other->quantity() * other->UnitValue()) / tot_qty;
+  double avg_unit_value =
+      (quantity_ * UnitValue() + other->quantity() * other->UnitValue()) /
+      tot_qty;
   SetUnitValue(avg_unit_value);
   quantity_ = tot_qty;
   other->quantity_ = 0;
@@ -68,7 +71,8 @@ Product::Ptr Product::Extract(double quantity) {
 
   quantity_ -= quantity;
 
-  Product::Ptr other(new Product(ctx_, quantity, quality_, package_name_, UnitValue()));
+  Product::Ptr other(
+      new Product(ctx_, quantity, quality_, package_name_, UnitValue()));
   tracker_.Extract(&other->tracker_);
   return other;
 }

--- a/src/product.cc
+++ b/src/product.cc
@@ -94,7 +94,8 @@ Resource::Ptr Product::PackageExtract(double qty,
   }
 
   quantity_ -= qty;
-  Product::Ptr other(new Product(ctx_, qty, quality_, new_package_name));
+  Product::Ptr other(
+      new Product(ctx_, qty, quality_, new_package_name, UnitValue()));
 
   // this call to res_tracker must come first before the parent resource
   // state id gets modified

--- a/src/product.cc
+++ b/src/product.cc
@@ -34,7 +34,7 @@ Product::Ptr Product::Create(Agent* creator, double quantity,
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Product::Ptr Product::CreateUntracked(double quantity, std::string quality) {
   Product::Ptr r(
-      new Product(NULL, quantity, quality, Package::unpackaged_name(), 0.0));
+      new Product(NULL, quantity, quality, Package::unpackaged_name(), kUnsetUnitValue));
   r->tracker_.DontTrack();
   return r;
 }

--- a/src/product.cc
+++ b/src/product.cc
@@ -33,8 +33,8 @@ Product::Ptr Product::Create(Agent* creator, double quantity,
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Product::Ptr Product::CreateUntracked(double quantity, std::string quality) {
-  Product::Ptr r(
-      new Product(NULL, quantity, quality, Package::unpackaged_name(), kUnsetUnitValue));
+  Product::Ptr r(new Product(NULL, quantity, quality,
+                             Package::unpackaged_name(), kUnsetUnitValue));
   r->tracker_.DontTrack();
   return r;
 }

--- a/src/product.h
+++ b/src/product.h
@@ -28,7 +28,8 @@ class Product : public Resource {
   /// "this" pointer). All future output data recorded will be done using the
   /// creator's context.
   static Ptr Create(Agent* creator, double quantity, std::string quality,
-                    std::string package_name = Package::unpackaged_name());
+                    std::string package_name = Package::unpackaged_name(),
+                    double unit_value = 0.0);
 
   /// Creates a new product that does not actually exist as part of
   /// the simulation and is untracked.
@@ -79,7 +80,8 @@ class Product : public Resource {
   /// @param quantity is a double indicating the quantity
   /// @param quality the resource quality
   Product(Context* ctx, double quantity, std::string quality,
-          std::string package_name = Package::unpackaged_name());
+          std::string package_name = Package::unpackaged_name(),
+          double unit_value = 0.0);
 
   // map<quality, quality_id>
   static std::map<std::string, int> qualids_;

--- a/src/product.h
+++ b/src/product.h
@@ -29,7 +29,7 @@ class Product : public Resource {
   /// creator's context.
   static Ptr Create(Agent* creator, double quantity, std::string quality,
                     std::string package_name = Package::unpackaged_name(),
-                    double unit_value = 0.0);
+                    double unit_value = kUnsetUnitValue);
 
   /// Creates a new product that does not actually exist as part of
   /// the simulation and is untracked.
@@ -81,7 +81,7 @@ class Product : public Resource {
   /// @param quality the resource quality
   Product(Context* ctx, double quantity, std::string quality,
           std::string package_name = Package::unpackaged_name(),
-          double unit_value = 0.0);
+          double unit_value = kUnsetUnitValue);
 
   // map<quality, quality_id>
   static std::map<std::string, int> qualids_;

--- a/src/res_tracker.cc
+++ b/src/res_tracker.cc
@@ -104,6 +104,7 @@ void ResTracker::Record(bool bumpId) {
       ->AddVal("TimeCreated", ctx_->time())
       ->AddVal("Quantity", res_->quantity())
       ->AddVal("Units", res_->units())
+      ->AddVal("UnitValue", res_->UnitValue())
       ->AddVal("QualId", res_->qual_id())
       ->AddVal("PackageName", res_->package_name())
       ->AddVal("Parent1", parent1_)

--- a/src/resource.h
+++ b/src/resource.h
@@ -26,7 +26,7 @@ class Resource {
  public:
   typedef boost::shared_ptr<Resource> Ptr;
 
-  Resource() : state_id_(nextstate_id_++), obj_id_(nextobj_id_++) {}
+  Resource() : state_id_(nextstate_id_++), unit_value_(0.0), obj_id_(nextobj_id_++) {}
 
   virtual ~Resource() {}
 
@@ -34,6 +34,12 @@ class Resource {
   /// to track and/or associate other information with this resource object.
   /// You should NOT track resources by pointer.
   const int obj_id() const { return obj_id_; }
+
+  /// Returns the unit value of this resource.
+  double UnitValue() const { return unit_value_; }
+
+  /// Sets the unit value of this resource.
+  void SetUnitValue(double unit_value) { unit_value_ = unit_value; }
 
   /// Returns the unique id corresponding to this resource and its current
   /// state.  All resource id's are unique - even across different resource
@@ -112,6 +118,8 @@ class Resource {
   static int nextstate_id_;
   static int nextobj_id_;
   int state_id_;
+  // Unit value of the resource.
+  double unit_value_;
   // Setting the state id should only be done when extracting one resource
   void state_id(int st_id) { state_id_ = st_id; }
 

--- a/src/resource.h
+++ b/src/resource.h
@@ -26,7 +26,8 @@ class Resource {
  public:
   typedef boost::shared_ptr<Resource> Ptr;
 
-  Resource() : state_id_(nextstate_id_++), unit_value_(0.0), obj_id_(nextobj_id_++) {}
+  Resource()
+      : state_id_(nextstate_id_++), unit_value_(0.0), obj_id_(nextobj_id_++) {}
 
   virtual ~Resource() {}
 

--- a/src/resource.h
+++ b/src/resource.h
@@ -116,7 +116,8 @@ class Resource {
   template <class T> std::vector<typename T::Ptr> Package(Package::Ptr pkg);
 
  protected:
-  constexpr static double kUnsetUnitValue = std::numeric_limits<double>::quiet_NaN();
+  constexpr static double kUnsetUnitValue =
+      std::numeric_limits<double>::quiet_NaN();
 
  private:
   double unit_value_;

--- a/src/resource.h
+++ b/src/resource.h
@@ -115,6 +115,9 @@ class Resource {
   /// restrictions, the remainder is left in the resource object.
   template <class T> std::vector<typename T::Ptr> Package(Package::Ptr pkg);
 
+ protected:
+  constexpr static double kUnsetUnitValue = std::numeric_limits<double>::quiet_NaN();
+
  private:
   double unit_value_;
   static int nextstate_id_;

--- a/src/resource.h
+++ b/src/resource.h
@@ -116,11 +116,10 @@ class Resource {
   template <class T> std::vector<typename T::Ptr> Package(Package::Ptr pkg);
 
  private:
+  double unit_value_;
   static int nextstate_id_;
   static int nextobj_id_;
   int state_id_;
-  // Unit value of the resource.
-  double unit_value_;
   // Setting the state id should only be done when extracting one resource
   void state_id(int st_id) { state_id_ = st_id; }
 

--- a/tests/resource_tests.cc
+++ b/tests/resource_tests.cc
@@ -76,17 +76,17 @@ TEST_F(ResourceTest, MaterialAbsorbGraphid) {
 
 TEST_F(ResourceTest, MaterialExtractTrackid) {
   int obj_id = m1->obj_id();
-  Material::Ptr m4 = m1->ExtractQty(2);
+  Material::Ptr lm1 = m1->ExtractQty(2);
   EXPECT_EQ(obj_id, m1->obj_id());
-  EXPECT_LT(obj_id, m4->obj_id());
+  EXPECT_LT(obj_id, lm1->obj_id());
 }
 
 TEST_F(ResourceTest, MaterialExtractGraphid) {
   int state_id = m1->state_id();
-  Material::Ptr m4 = m1->ExtractQty(2);
+  Material::Ptr lm1 = m1->ExtractQty(2);
   EXPECT_LT(state_id, m1->state_id());
-  EXPECT_LT(state_id, m4->state_id());
-  EXPECT_NE(m1->state_id(), m4->state_id());
+  EXPECT_LT(state_id, lm1->state_id());
+  EXPECT_NE(m1->state_id(), lm1->state_id());
 }
 
 TEST_F(ResourceTest, MaterialUnitValue) {
@@ -95,10 +95,10 @@ TEST_F(ResourceTest, MaterialUnitValue) {
   m1->Absorb(m2);
   EXPECT_EQ(m1->UnitValue(), 17);
   EXPECT_EQ(m3->UnitValue(), 0.0);
-  Material::Ptr m4 = boost::dynamic_pointer_cast<Material>(m1->Clone());
-  EXPECT_EQ(m4->UnitValue(), 17);
-  Material::Ptr m5 = m1->ExtractQty(1);
-  EXPECT_EQ(m5->UnitValue(), 17);
+  Material::Ptr lm1 = boost::dynamic_pointer_cast<Material>(m1->Clone());
+  EXPECT_EQ(lm1->UnitValue(), 17);
+  Material::Ptr lm2 = m1->ExtractQty(1);
+  EXPECT_EQ(lm2->UnitValue(), 17);
 }
 
 TEST_F(ResourceTest, ProductAbsorbTrackid) {
@@ -115,17 +115,17 @@ TEST_F(ResourceTest, ProductAbsorbGraphid) {
 
 TEST_F(ResourceTest, ProductExtractTrackid) {
   int obj_id = p1->obj_id();
-  Product::Ptr p4 = p1->Extract(2);
+  Product::Ptr lp1 = p1->Extract(2);
   EXPECT_EQ(obj_id, p1->obj_id());
-  EXPECT_LT(obj_id, p4->obj_id());
+  EXPECT_LT(obj_id, lp1->obj_id());
 }
 
 TEST_F(ResourceTest, ProductExtractGraphid) {
   int state_id = p1->state_id();
-  Product::Ptr p4 = p1->Extract(2);
+  Product::Ptr lp1 = p1->Extract(2);
   EXPECT_LT(state_id, p1->state_id());
-  EXPECT_LT(state_id, p4->state_id());
-  EXPECT_NE(p1->state_id(), p4->state_id());
+  EXPECT_LT(state_id, lp1->state_id());
+  EXPECT_NE(p1->state_id(), lp1->state_id());
 }
 
 TEST_F(ResourceTest, ProductUnitValue) {
@@ -134,10 +134,10 @@ TEST_F(ResourceTest, ProductUnitValue) {
   p1->Absorb(p2);
   EXPECT_EQ(p1->UnitValue(), 17);
   EXPECT_EQ(p3->UnitValue(), 0.0);
-  Product::Ptr p4 = boost::dynamic_pointer_cast<Product>(p1->Clone());
-  EXPECT_EQ(p4->UnitValue(), 17);
-  Product::Ptr p5 = p1->Extract(1);
-  EXPECT_EQ(p5->UnitValue(), 17);
+  Product::Ptr lp1 = boost::dynamic_pointer_cast<Product>(p1->Clone());
+  EXPECT_EQ(lp1->UnitValue(), 17);
+  Product::Ptr lp2 = p1->Extract(1);
+  EXPECT_EQ(lp2->UnitValue(), 17);
 }
 
 TEST_F(ResourceTest, DefaultPackageId) {
@@ -146,8 +146,8 @@ TEST_F(ResourceTest, DefaultPackageId) {
   EXPECT_EQ(p1->package_name(), Package::unpackaged_name());
   EXPECT_EQ(p2->package_name(), Package::unpackaged_name());
 
-  Product::Ptr p4 = p1->Extract(2);
-  EXPECT_EQ(p4->package_name(), Package::unpackaged_name());
+  Product::Ptr lp1 = p1->Extract(2);
+  EXPECT_EQ(lp1->package_name(), Package::unpackaged_name());
 }
 
 TEST_F(ResourceTest, ChangePackage) {
@@ -155,9 +155,9 @@ TEST_F(ResourceTest, ChangePackage) {
   Package::Ptr pkg = ctx->GetPackage("foo");
   std::string pkg_name = pkg->name();
 
-  Product::Ptr p4 = p1->Extract(2);
-  p4->ChangePackage(pkg_name);
-  EXPECT_EQ(p4->package_name(), pkg_name);
+  Product::Ptr lp1 = p1->Extract(2);
+  lp1->ChangePackage(pkg_name);
+  EXPECT_EQ(lp1->package_name(), pkg_name);
   EXPECT_EQ(p1->package_name(), Package::unpackaged_name());
 
   m1->ChangePackage(pkg_name);
@@ -170,12 +170,12 @@ TEST_F(ResourceTest, PackageResource) {
   std::string pkg_name = pkg->name();
 
   // nothing packaged
-  Product::Ptr p4 = p1->Extract(0.5);
-  std::vector<Product::Ptr> p4_pkgd = p4->Package<Product>(pkg);
+  Product::Ptr lp1 = p1->Extract(0.5);
+  std::vector<Product::Ptr> lp1_pkgd = lp1->Package<Product>(pkg);
 
   // everything stays in old product, with same (default) package id
-  EXPECT_EQ(p4->package_name(), Package::unpackaged_name());
-  EXPECT_EQ(p4->quantity(), 0.5);
+  EXPECT_EQ(lp1->package_name(), Package::unpackaged_name());
+  EXPECT_EQ(lp1->quantity(), 0.5);
 
   // all packaged
   std::vector<Product::Ptr> p1_pkgd = p1->Package<Product>(pkg);
@@ -192,13 +192,13 @@ TEST_F(ResourceTest, PackageResource) {
   EXPECT_EQ(p2_pkgd[0]->package_name(), pkg_name);
   EXPECT_EQ(p2_pkgd[1]->package_name(), pkg_name);
 
-  Material::Ptr m4 = m2->ExtractQty(5.5);
-  std::vector<Material::Ptr> m4_pkgd = m4->Package<Material>(pkg);
-  EXPECT_EQ(m4->package_name(), Package::unpackaged_name());
-  EXPECT_EQ(m4->quantity(), 0.5);
-  EXPECT_EQ(m4_pkgd.size(), 1);
-  EXPECT_EQ(m4_pkgd[0]->package_name(), pkg_name);
-  EXPECT_EQ(m4_pkgd[0]->quantity(), 5);
+  Material::Ptr lm1 = m2->ExtractQty(5.5);
+  std::vector<Material::Ptr> lm1_pkgd = lm1->Package<Material>(pkg);
+  EXPECT_EQ(lm1->package_name(), Package::unpackaged_name());
+  EXPECT_EQ(lm1->quantity(), 0.5);
+  EXPECT_EQ(lm1_pkgd.size(), 1);
+  EXPECT_EQ(lm1_pkgd[0]->package_name(), pkg_name);
+  EXPECT_EQ(lm1_pkgd[0]->quantity(), 5);
 }
 
 TEST_F(ResourceTest, RepackageLimit) {

--- a/tests/resource_tests.cc
+++ b/tests/resource_tests.cc
@@ -94,7 +94,7 @@ TEST_F(ResourceTest, MaterialUnitValue) {
   EXPECT_EQ(m2->UnitValue(), 20);
   m1->Absorb(m2);
   EXPECT_EQ(m1->UnitValue(), 17);
-  EXPECT_EQ(m3->UnitValue(), 0.0);
+  EXPECT_TRUE(std::isnan(m3->UnitValue()));
   Material::Ptr lm1 = boost::dynamic_pointer_cast<Material>(m1->Clone());
   EXPECT_EQ(lm1->UnitValue(), 17);
   Material::Ptr lm2 = m1->ExtractQty(1);
@@ -133,7 +133,7 @@ TEST_F(ResourceTest, ProductUnitValue) {
   EXPECT_EQ(p2->UnitValue(), 20);
   p1->Absorb(p2);
   EXPECT_EQ(p1->UnitValue(), 17);
-  EXPECT_EQ(p3->UnitValue(), 0.0);
+  EXPECT_TRUE(std::isnan(p3->UnitValue()));
   Product::Ptr lp1 = boost::dynamic_pointer_cast<Product>(p1->Clone());
   EXPECT_EQ(lp1->UnitValue(), 17);
   Product::Ptr lp2 = p1->Extract(1);


### PR DESCRIPTION
# Summary of Changes

A member variable "unit_value_" has been added to all resource-type objects (`Resource`, `Product`, and `Material`) and appropriate functions (`Absorb`, `Clone`, `Extract`) have been updated to have reasonable behavior concerning the new `unit_value_` member.

# Related CEPs and Issues

This PR is related to:

- Closes #1885 

# Associated Developers

# Design Notes

Wasn't sure how to handle packaging. May need to discuss in person, or here, either works.

# Testing and Validation

Built and tested Cyclus on my local machine. Added unit tests. Clean Build Cyclus and Cycamore, all tests for both passing.

# Checklist

 - [x] Read the [Contributing to Cyclus](https://fuelcycle.org/kernel/contributing_to_cyclus.html) guide.
 - [x]  Compile and run locally.
 - [x]  Add or update tests.
 - [x]  Document if needed.
 - [x]  Follow style guidelines.
 - [x]  Update the changelog.
 - [x]   Run clang-format
 - [ ]  Address all review comments.
Reviewers, please refer to the Cyclus [Guide for Reviewers](https://fuelcycle.org/kernel/pr_review.html).