### PR TITLE
Allow Cyclus to Record the Adjusted Preference/Cost of Trades

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,7 +32,9 @@ Since last release
 * Allow multiple archetype blocks to facilitate includes (#1874)
 
 **Changed:**
+
 * Changed Dockerfile to use boost and boost-cpp instead of libboost-devel (#1906)
+* Changed TradeExecutor to use adjusted preferences from ExchangeContext (#1897)
 * Ran clang-format on src directory (#1881, #1893)
 * Changed README.rst installation instructions, tested on fresh Ubuntu-22.04 system with Python3.11 (#1744)
 * Rely on ``python3`` in environment instead of ``python`` (#1747)

--- a/src/exchange_manager.h
+++ b/src/exchange_manager.h
@@ -61,7 +61,7 @@ template <class T> class ExchangeManager {
 
     // execute trades!
     TradeExecutor<T> exec(trades);
-    exec.ExecuteTrades(ctx_);
+    exec.ExecuteTrades(ctx_, &exchng.ex_ctx());
   }
 
  private:

--- a/src/trade_executor.h
+++ b/src/trade_executor.h
@@ -71,7 +71,8 @@ template <class T> class TradeExecutor {
     SendTradeResources(trade_ctx_);
   }
 
-  /// @brief execute all trades with access to exchange context for adjusted preferences
+  /// @brief execute all trades with access to exchange context for adjusted
+  /// preferences
   void ExecuteTrades(Context* ctx, ExchangeContext<T>* ex_ctx) {
     GroupTradesBySupplier(trade_ctx_, trades_);
     GetTradeResponses(trade_ctx_);
@@ -85,15 +86,15 @@ template <class T> class TradeExecutor {
   ///
   /// @param ctx the Context through which communication with backends will
   /// occur
-  void RecordTrades(Context* ctx) {
-    RecordTrades(ctx, NULL);
-  }
+  void RecordTrades(Context* ctx) { RecordTrades(ctx, NULL); }
 
-  /// @brief Record all trades with the appropriate backends, using adjusted preferences
+  /// @brief Record all trades with the appropriate backends, using adjusted
+  /// preferences
   ///
   /// @param ctx the Context through which communication with backends will
   /// occur
-  /// @param ex_ctx the ExchangeContext containing the adjusted preferences used by the solver
+  /// @param ex_ctx the ExchangeContext containing the adjusted preferences used
+  /// by the solver
   void RecordTrades(Context* ctx, ExchangeContext<T>* ex_ctx) {
     // record all trades
     typename std::map<
@@ -111,25 +112,28 @@ template <class T> class TradeExecutor {
         Trade<T>& trade = v_it->first;
         typename T::Ptr rsrc = v_it->second;
         if (rsrc->quantity() > cyclus::eps_rsrc()) {
-          // Calculate the adjusted preference that was actually used by the solver
+          // Calculate the adjusted preference that was actually used by the
+          // solver
           double adjusted_preference = trade.bid->preference();
-          
+
           // If the bid has NaN preference, use the request preference
           if (std::isnan(adjusted_preference)) {
             adjusted_preference = trade.request->preference();
           }
-          
-          // If we have access to the exchange context, use the adjusted preference
-          // that was actually used by the solver
+
+          // If we have access to the exchange context, use the adjusted
+          // preference that was actually used by the solver
           if (ex_ctx != NULL) {
             try {
-              adjusted_preference = ex_ctx->trader_prefs.at(trade.request->requester())[trade.request][trade.bid];
+              adjusted_preference = ex_ctx->trader_prefs.at(
+                  trade.request->requester())[trade.request][trade.bid];
             } catch (const std::out_of_range&) {
-              // If the preference is not found in the exchange context, fall back to the bid preference
-              // This could happen if the trade was not part of the original exchange
+              // If the preference is not found in the exchange context, fall
+              // back to the bid preference This could happen if the trade was
+              // not part of the original exchange
             }
           }
-          
+
           ctx->NewDatum("Transactions")
               ->AddVal("TransactionId", ctx->NextTransactionID())
               ->AddVal("SenderId", supplier->id())

--- a/src/trade_executor.h
+++ b/src/trade_executor.h
@@ -62,21 +62,14 @@ template <class T> class TradeExecutor {
 
   /// @brief execute all trades, collecting responders from bidders and sending
   /// responses to requesters
-  void ExecuteTrades(Context* ctx) {
-    GroupTradesBySupplier(trade_ctx_, trades_);
-    GetTradeResponses(trade_ctx_);
-    if (ctx != NULL) {
-      RecordTrades(ctx);
-    }
-    SendTradeResources(trade_ctx_);
-  }
+  void ExecuteTrades(Context* ctx) { ExecuteTrades(ctx, NULL); }
 
   /// @brief execute all trades with access to exchange context for adjusted
   /// preferences
   void ExecuteTrades(Context* ctx, ExchangeContext<T>* ex_ctx) {
     GroupTradesBySupplier(trade_ctx_, trades_);
     GetTradeResponses(trade_ctx_);
-    if (ctx != NULL) {
+    if (ctx) {
       RecordTrades(ctx, ex_ctx);
     }
     SendTradeResources(trade_ctx_);
@@ -123,7 +116,7 @@ template <class T> class TradeExecutor {
 
           // If we have access to the exchange context, use the adjusted
           // preference that was actually used by the solver
-          if (ex_ctx != NULL) {
+          if (ex_ctx) {
             try {
               adjusted_preference = ex_ctx->trader_prefs.at(
                   trade.request->requester())[trade.request][trade.bid];

--- a/tests/trade_executor_tests.cc
+++ b/tests/trade_executor_tests.cc
@@ -8,6 +8,7 @@
 #include "agent.h"
 #include "bid.h"
 #include "context.h"
+#include "exchange_context.h"
 #include "material.h"
 #include "request.h"
 #include "resource_helpers.h"
@@ -20,6 +21,7 @@
 
 using cyclus::Bid;
 using cyclus::Context;
+using cyclus::ExchangeContext;
 using cyclus::Material;
 using cyclus::Agent;
 using cyclus::Request;
@@ -166,6 +168,237 @@ TEST_F(TradeExecutorTests, NoThrowWriting) {
   TradeExecutor<Material> exec(trades);
   exec.ExecuteTrades();
   EXPECT_NO_THROW(exec.RecordTrades(tc.get()));
+}
+
+
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+TEST(TradeExecutorDatabaseTests, WrapperFunctionAndBasicRecording) {
+  // Set up database backend for testing. NOTE, this approach gives us more
+  // fine grained control over the database than mock_sim, which would not
+  // allow the same kind of targeted function testing that we do here.
+  std::string path = ":memory:";  // In-memory database
+  cyclus::SqliteBack* b = new cyclus::SqliteBack(path);
+  cyclus::Recorder rec;
+  rec.RegisterBackend(b);
+  
+  cyclus::Timer ti;
+  cyclus::Context* ctx = new cyclus::Context(&ti, &rec);
+  
+  // Create test objects
+  TestObjFactory fac;
+  TestTrader* s1 = new TestTrader(ctx, &fac);
+  TestTrader* r1 = new TestTrader(ctx, &fac);
+  
+  double orig_pref = 3.14;
+  double test_trade_amt = 1.0;
+  Request<Material>* req = Request<Material>::Create(fac.mat, r1);
+  Bid<Material>* bid = Bid<Material>::Create(req, fac.mat, s1, false, orig_pref);
+  
+  Trade<Material> trade(req, bid, test_trade_amt);
+  std::vector<Trade<Material>> trades;
+  trades.push_back(trade);
+  
+  TradeExecutor<Material> exec(trades);
+  
+  // Test wrapper function - should not throw (this also records trades automatically)
+  EXPECT_NO_THROW(exec.ExecuteTrades(ctx));  // Single parameter version
+  rec.Flush();
+  
+  // Verify bid object retains original preference
+  EXPECT_DOUBLE_EQ(bid->preference(), orig_pref);
+  
+  // Query database and verify both preferences are the same (no ExchangeContext)
+  cyclus::QueryResult qr = b->Query("Transactions", NULL);
+  EXPECT_EQ(1, qr.rows.size()) << "Expected 1 transaction, got " << qr.rows.size();
+  
+  if (qr.rows.size() > 0) {
+    double recorded_orig_cost = qr.GetVal<double>("BidCost", 0);
+    double recorded_adj_cost = qr.GetVal<double>("AdjustedCost", 0);
+    
+    EXPECT_DOUBLE_EQ(recorded_orig_cost, 1.0 / orig_pref);
+    EXPECT_DOUBLE_EQ(recorded_adj_cost, 1.0 / orig_pref);
+    EXPECT_DOUBLE_EQ(recorded_orig_cost, recorded_adj_cost);
+  }
+  
+  // Cleanup
+  delete bid;
+  delete req;
+  delete r1;
+  delete s1;
+  rec.Close();
+  delete ctx;
+  delete b;
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+TEST(TradeExecutorDatabaseTests, ExchangeContextWithAdjustedPreferences) {
+  // Set up database backend for testing, again, this appproach is used to
+  // give us more fine grained control over the database than mock_sim.
+  std::string path = ":memory:";  // In-memory database
+  cyclus::SqliteBack* b = new cyclus::SqliteBack(path);
+  cyclus::Recorder rec;
+  rec.RegisterBackend(b);
+  
+  cyclus::Timer ti;
+  cyclus::Context* ctx = new cyclus::Context(&ti, &rec);
+  
+  // Create test objects
+  TestObjFactory fac;
+  TestTrader* s1 = new TestTrader(ctx, &fac);
+  TestTrader* s2 = new TestTrader(ctx, &fac);
+  TestTrader* r1 = new TestTrader(ctx, &fac);
+  TestTrader* r2 = new TestTrader(ctx, &fac);
+  
+  // Create multiple trades with different preferences
+  double orig_pref1 = 2.5;
+  double orig_pref2 = 3.7;
+  double orig_pref3 = 1.2;
+
+  double trade_amt1 = 2.0;
+  double trade_amt2 = 1.5;
+  double trade_amt3 = 3.0;
+  
+  Request<Material>* req1 = Request<Material>::Create(fac.mat, r1);
+  Request<Material>* req2 = Request<Material>::Create(fac.mat, r2);
+  
+  Bid<Material>* bid1 = Bid<Material>::Create(req1, fac.mat, s1, false, orig_pref1);
+  Bid<Material>* bid2 = Bid<Material>::Create(req1, fac.mat, s2, false, orig_pref2);
+  Bid<Material>* bid3 = Bid<Material>::Create(req2, fac.mat, s2, false, orig_pref3);
+  
+  std::vector<Trade<Material>> trades;
+  trades.push_back(Trade<Material>(req1, bid1, trade_amt1));
+  trades.push_back(Trade<Material>(req1, bid2, trade_amt2));
+  trades.push_back(Trade<Material>(req2, bid3, trade_amt3));
+  
+  // Create ExchangeContext with adjusted preferences
+  ExchangeContext<Material> ex_ctx;
+  ex_ctx.AddRequest(req1);
+  ex_ctx.AddRequest(req2);
+  ex_ctx.AddBid(bid1);
+  ex_ctx.AddBid(bid2);
+  ex_ctx.AddBid(bid3);
+  
+  // Set different adjusted preferences
+  double adj_pref1 = 4.2;
+  double adj_pref2 = 1.8;
+  double adj_pref3 = 5.1;
+  
+  ex_ctx.trader_prefs[r1][req1][bid1] = adj_pref1;
+  ex_ctx.trader_prefs[r1][req1][bid2] = adj_pref2;
+  ex_ctx.trader_prefs[r2][req2][bid3] = adj_pref3;
+  
+  TradeExecutor<Material> exec(trades);
+  
+  // Test two-parameter version - should not throw (this also records trades automatically)
+  EXPECT_NO_THROW(exec.ExecuteTrades(ctx, &ex_ctx));
+  rec.Flush();
+  
+  // Verify original bid preferences are preserved
+  EXPECT_DOUBLE_EQ(bid1->preference(), orig_pref1);
+  EXPECT_DOUBLE_EQ(bid2->preference(), orig_pref2);
+  EXPECT_DOUBLE_EQ(bid3->preference(), orig_pref3);
+  
+  // Verify adjusted preferences in ExchangeContext
+  EXPECT_DOUBLE_EQ(ex_ctx.trader_prefs[r1][req1][bid1], adj_pref1);
+  EXPECT_DOUBLE_EQ(ex_ctx.trader_prefs[r1][req1][bid2], adj_pref2);
+  EXPECT_DOUBLE_EQ(ex_ctx.trader_prefs[r2][req2][bid3], adj_pref3);
+  
+  // Query database and verify different original vs adjusted preferences
+  cyclus::QueryResult qr = b->Query("Transactions", NULL);
+  EXPECT_EQ(3, qr.rows.size()) << "Expected 3 transactions, got " << qr.rows.size();
+  
+  // Check each transaction's preferences
+  std::vector<double> expected_orig = {orig_pref1, orig_pref2, orig_pref3};
+  std::vector<double> expected_adj = {adj_pref1, adj_pref2, adj_pref3};
+  
+  for (int i = 0; i < qr.rows.size(); i++) {
+    double recorded_orig_cost = qr.GetVal<double>("BidCost", i);
+    double recorded_adj_cost = qr.GetVal<double>("AdjustedCost", i);
+    
+    // Find which expected preference this matches
+    bool found_match = false;
+    for (size_t j = 0; j < expected_orig.size(); j++) {
+      if (std::abs(recorded_orig_cost - 1.0 / expected_orig[j]) < 1e-10) {
+        EXPECT_DOUBLE_EQ(recorded_adj_cost, 1.0 / expected_adj[j]);
+        EXPECT_NE(recorded_orig_cost, recorded_adj_cost);  // Should be different
+        found_match = true;
+        break;
+      }
+    }
+    EXPECT_TRUE(found_match) << "Recorded bid cost " << recorded_orig_cost 
+                             << " doesn't match any expected value";
+  }
+  
+  // Cleanup
+  delete bid3;
+  delete bid2;
+  delete bid1;
+  delete req2;
+  delete req1;
+  delete r2;
+  delete r1;
+  delete s2;
+  delete s1;
+  rec.Close();
+  delete ctx;
+  delete b;
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+TEST(TradeExecutorDatabaseTests, MixedPreferenceScenarios) {
+  // Set up database backend for testing
+  std::string path = ":memory:";  // In-memory database
+  cyclus::SqliteBack* b = new cyclus::SqliteBack(path);
+  cyclus::Recorder rec;
+  rec.RegisterBackend(b);
+  
+  cyclus::Timer ti;
+  cyclus::Context* ctx = new cyclus::Context(&ti, &rec);
+  
+  // Create test objects
+  TestObjFactory fac;
+  TestTrader* s1 = new TestTrader(ctx, &fac);
+  TestTrader* s2 = new TestTrader(ctx, &fac);
+  TestTrader* r1 = new TestTrader(ctx, &fac);
+  
+  double explicit_pref = 2.8;
+  double trade_amt = 1.0;
+  Request<Material>* req = Request<Material>::Create(fac.mat, r1);
+  
+  // One bid with explicit preference, one with NaN (default)
+  Bid<Material>* bid_explicit = Bid<Material>::Create(req, fac.mat, s1, false, explicit_pref);
+  Bid<Material>* bid_nan = Bid<Material>::Create(req, fac.mat, s2);  // Default NaN preference
+  
+  std::vector<Trade<Material>> trades;
+  trades.push_back(Trade<Material>(req, bid_explicit, trade_amt));
+  trades.push_back(Trade<Material>(req, bid_nan, trade_amt));
+  
+  TradeExecutor<Material> exec(trades);
+  
+  // Test wrapper function with mixed preferences - should not throw (this also records trades automatically)
+  EXPECT_NO_THROW(exec.ExecuteTrades(ctx));
+  rec.Flush();
+  
+  // Verify preference preservation
+  EXPECT_DOUBLE_EQ(bid_explicit->preference(), explicit_pref);
+  EXPECT_TRUE(std::isnan(bid_nan->preference()));
+  
+  // Query database
+  cyclus::QueryResult qr = b->Query("Transactions", NULL);
+  EXPECT_EQ(2, qr.rows.size()) << "Expected 2 transactions, got " 
+            << qr.rows.size();
+  
+  // Cleanup
+  delete bid_nan;
+  delete bid_explicit;
+  delete req;
+  delete r1;
+  delete s2;
+  delete s1;
+  rec.Close();
+  delete ctx;
+  delete b;
 }
 
 // This test was a part of a previous iteration of Trade testing, but its not


### PR DESCRIPTION
# Summary of Changes

While playing with something else, I noticed that when I was adjusting the preference of trades the `RecordTrades()` function, which writes to the Transactions table in the database wasn't reflecting the adjusted cost, but was instead simply recording the original bid cost *before* the adjustment. I am not certain that we will necessarily want to represent this cost as "real", but it would be nice to be able to have access to it. For now, I had Cursor go in and give that function access to the exchange context of the DRE so it can see the adjusted cost, and changed "RecordTrades" to record this cost (if it was adjusted, and otherwise just the normal cost). I looked at what it did, and it more or less made sense and didn't seem too wild, so I figured I'd make a PR since this is a pretty limited change.

# Related CEPs and Issues

This PR is related to:

- Closes #1896 

# Associated Developers

Cursor AI

# Design Notes

Again, not totally sure if the desired behavior is to always record this as the "cost", but I found myself personally wanting access to it. Maybe adding a column to the `RecordTrades()` Transactions table to have a "bid" and an "adjusted cost" section would be better? Not totally sure...

# Testing and Validation

Built and tested Cyclus on my local machine.  All CURRENT unit tests pass. 

NO NEW UNIT TESTS HAVE BEEN ADDED (YET)

# Checklist

 - [x] Read the [Contributing to Cyclus](https://fuelcycle.org/kernel/contributing_to_cyclus.html) guide.
 - [x]  Compile and run locally.
 - [x]  Add or update tests.
 - [x]  Document if needed.
 - [x]  Follow style guidelines.
 - [x]  Update the changelog.
 - [x]   Run clang-format
 - [ ]  Address all review comments.
Reviewers, please refer to the Cyclus [Guide for Reviewers](https://fuelcycle.org/kernel/pr_review.html).