### PR TITLE
Fix Conda CI

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,7 +32,7 @@ Since last release
 * Allow multiple archetype blocks to facilitate includes (#1874)
 
 **Changed:**
-
+* Changed Dockerfile to use boost and boost-cpp instead of libboost-devel (#1906)
 * Ran clang-format on src directory (#1881, #1893)
 * Changed README.rst installation instructions, tested on fresh Ubuntu-22.04 system with Python3.11 (#1744)
 * Rely on ``python3`` in environment instead of ``python`` (#1747)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 ARG pkg_mgr=apt
 ARG ubuntu_version=24.04
-# Test
+
 FROM ubuntu:${ubuntu_version} AS common-base
 
 ENV TZ=America/Chicago

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -69,7 +69,8 @@ RUN mamba install -y "python<3.13" --no-pin && \
                liblapack \
                pkg-config \
                coincbc \
-               libboost-devel \
+               boost \
+               boost-cpp \
                hdf5 \
                sqlite \
                pcre \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 ARG pkg_mgr=apt
 ARG ubuntu_version=24.04
-
+# Test
 FROM ubuntu:${ubuntu_version} AS common-base
 
 ENV TZ=America/Chicago


### PR DESCRIPTION
# Summary of Changes
Changes the conda section of the Dockerfile to grab `boost` and `boost-cpp` instead of `libboost-devel`, which changed recently and was causing issues with the CI testing.

# Related CEPs and Issues

This PR is related to:

- Closes #1901 
- Closes #1902 
- Closes #1904 

# Associated Developers

ChatGPT (helped parse error messages)

# Design Notes

Not TOTALLY sure about the root cause, but it does seem like libboost-devel was updated around the time this error started popping up, and the errors were pretty consistently saying boost was the problem, so I went in and changed the way we install boost in conda and it seems like it worked.

<img width="516" height="267" alt="Screenshot 2025-08-25 at 3 49 58 PM" src="https://github.com/user-attachments/assets/a28fc55b-3393-42cb-98bf-2adc2d70587f" />

# Testing and Validation

Made a Test PR to see if this change to the Dockerfile would pass the tests and it did. I cannot get these to compile and run locally, but I can't get ANY of the Dockerfiles to do that, so I'm not certain what I'm doing wrong...

# Checklist

 - [x] Read the [Contributing to Cyclus](https://fuelcycle.org/kernel/contributing_to_cyclus.html) guide.
 - [ ]  Compile and run locally.
 - [ ]  Add or update tests.
 - [ ]  Document if needed.
 - [x]  Follow style guidelines.
 - [x]  Update the changelog.
 - [ ]   Run clang-format
 - [ ]  Address all review comments.
Reviewers, please refer to the Cyclus [Guide for Reviewers](https://fuelcycle.org/kernel/pr_review.html).