### PR TITLE
Timeshift

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,7 @@ Since last release
 * Command-line option to make a new blank input file referencing a current schema (#1861)
 * Allow multiple archetype blocks to facilitate includes (#1874)
 * New composition specification based on single nuclide (#1949) 
+* Added ability to calcuate a time shift between the start time and some other time stamp ()
 
 **Changed:**
 * Changed the epsilon (eps) in Material::Decay to 1e-4 allowing 1 day decay of tritium (#1946)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,7 +33,7 @@ Since last release
 * Command-line option to make a new blank input file referencing a current schema (#1861)
 * Allow multiple archetype blocks to facilitate includes (#1874)
 * New composition specification based on single nuclide (#1949) 
-* Added ability to calcuate a time shift between the start time and some other time stamp ()
+* Added ability to calcuate a time shift between the start time and some other time stamp (#1907)
 
 **Changed:**
 * Changed the epsilon (eps) in Material::Decay to 1e-4 allowing 1 day decay of tritium (#1946)

--- a/src/context.cc
+++ b/src/context.cc
@@ -315,6 +315,10 @@ int Context::time() {
   return ti_->time();
 }
 
+int Context::timeshift(int year, int month) {
+  return ti_->timeshift(year, month);
+}
+
 int Context::random() {
   return rng_->random();
 }

--- a/src/context.cc
+++ b/src/context.cc
@@ -315,8 +315,8 @@ int Context::time() {
   return ti_->time();
 }
 
-int Context::timeshift(int year, int month) {
-  return ti_->timeshift(year, month);
+int Context::CalcTimeDiff(int year, int month) {
+  return ti_->CalcTimeDiff(year, month);
 }
 
 int Context::random() {

--- a/src/context.cc
+++ b/src/context.cc
@@ -50,21 +50,6 @@ SimInfo::SimInfo(int dur, int y0, int m0, std::string handle)
       seed(kDefaultSeed),
       stride(kDefaultStride) {}
 
-SimInfo::SimInfo(int dur, int y0, int m0, std::string handle, int timestep)
-    : duration(dur),
-      y0(y0),
-      m0(m0),
-      dt(timestep),
-      decay("manual"),
-      branch_time(-1),
-      handle(handle),
-      explicit_inventory(false),
-      explicit_inventory_compact(false),
-      parent_sim(boost::uuids::nil_uuid()),
-      parent_type("init"),
-      seed(kDefaultSeed),
-      stride(kDefaultStride) {}
-
 SimInfo::SimInfo(int dur, int y0, int m0, std::string handle, std::string d)
     : duration(dur),
       y0(y0),

--- a/src/context.cc
+++ b/src/context.cc
@@ -50,6 +50,21 @@ SimInfo::SimInfo(int dur, int y0, int m0, std::string handle)
       seed(kDefaultSeed),
       stride(kDefaultStride) {}
 
+SimInfo::SimInfo(int dur, int y0, int m0, std::string handle, int timestep)
+    : duration(dur),
+      y0(y0),
+      m0(m0),
+      dt(timestep),
+      decay("manual"),
+      branch_time(-1),
+      handle(handle),
+      explicit_inventory(false),
+      explicit_inventory_compact(false),
+      parent_sim(boost::uuids::nil_uuid()),
+      parent_type("init"),
+      seed(kDefaultSeed),
+      stride(kDefaultStride) {}
+
 SimInfo::SimInfo(int dur, int y0, int m0, std::string handle, std::string d)
     : duration(dur),
       y0(y0),

--- a/src/context.h
+++ b/src/context.h
@@ -24,7 +24,9 @@
 // a round number)
 const uint64_t cyclusYear = 31558200;
 
-const uint64_t kDefaultTimeStepDur = cyclusYear / 12;
+const uint64_t kMonthsPerYear = 12;
+
+const uint64_t kDefaultTimeStepDur = cyclusYear / kMonthsPerYear;
 
 const uint64_t kDefaultSeed = 20160212;
 
@@ -249,6 +251,9 @@ class Context {
 
   /// Returns the current simulation timestep.
   virtual int time();
+
+  /// Returns a time shift between the simulation start time and another time stamp
+  int timeshift(int year, int month);
 
   /// Adds a package type to a simulation-wide accessible list.
   /// Agents should NOT add their own packages.

--- a/src/context.h
+++ b/src/context.h
@@ -253,7 +253,7 @@ class Context {
   virtual int time();
 
   /// Returns a time shift between the simulation start time and another time stamp
-  int timeshift(int year, int month);
+  int CalcTimeDiff(int year, int month);
 
   /// Adds a package type to a simulation-wide accessible list.
   /// Agents should NOT add their own packages.

--- a/src/context.h
+++ b/src/context.h
@@ -62,6 +62,16 @@ class SimInfo {
   /// @return a SimInfo instance
   SimInfo(int dur, int y0 = 2010, int m0 = 1, std::string handle = "");
 
+  /// @brief constructs a SimInfo instance using some default variables
+  /// @param dur simulation duration in number of timesteps
+  /// @param y0 start year for the simulation
+  /// @param m0 start month for the simulation
+  /// @param handle is this simulation's unique simulation handle
+  /// @param timestep is the length of the timestep in seconds
+  /// @return a SimInfo instance
+  SimInfo(int dur, int y0, int m0, std::string handle, 
+          int timestep = kDefaultTimeStepDur);
+
   /// @brief constructs a SimInfo instance using no default variables
   /// @param dur simulation duration in number of timesteps
   /// @param y0 start year for the simulation

--- a/src/context.h
+++ b/src/context.h
@@ -26,6 +26,8 @@ const uint64_t cyclusYear = 31558200;
 
 const uint64_t kMonthsPerYear = 12;
 
+const uint64_t cyclusMonth = cyclusYear/kMonthsPerYear;
+
 const uint64_t kDefaultTimeStepDur = cyclusYear / kMonthsPerYear;
 
 const uint64_t kDefaultSeed = 20160212;

--- a/src/context.h
+++ b/src/context.h
@@ -26,9 +26,9 @@ const uint64_t cyclusYear = 31558200;
 
 const uint64_t kMonthsPerYear = 12;
 
-const uint64_t cyclusMonth = cyclusYear/kMonthsPerYear;
+const uint64_t cyclusMonth = cyclusYear / kMonthsPerYear;
 
-const uint64_t kDefaultTimeStepDur = cyclusYear / kMonthsPerYear;
+const uint64_t kDefaultTimeStepDur = cyclusMonth;
 
 const uint64_t kDefaultSeed = 20160212;
 
@@ -63,16 +63,6 @@ class SimInfo {
   /// @param handle is this simulation's unique simulation handle
   /// @return a SimInfo instance
   SimInfo(int dur, int y0 = 2010, int m0 = 1, std::string handle = "");
-
-  /// @brief constructs a SimInfo instance using some default variables
-  /// @param dur simulation duration in number of timesteps
-  /// @param y0 start year for the simulation
-  /// @param m0 start month for the simulation
-  /// @param handle is this simulation's unique simulation handle
-  /// @param timestep is the length of the timestep in seconds
-  /// @return a SimInfo instance
-  SimInfo(int dur, int y0, int m0, std::string handle, 
-          int timestep = kDefaultTimeStepDur);
 
   /// @brief constructs a SimInfo instance using no default variables
   /// @param dur simulation duration in number of timesteps

--- a/src/timer.cc
+++ b/src/timer.cc
@@ -295,11 +295,11 @@ int Timer::CalcTimeDiff(int year, int month) {
 
   int timediff_ = 0;
   if (year >= 0) {
-    timediff_ += (year - si_.y0) * kMonthsPerYear;
+    timediff_ += (year - si_.y0) * cyclusYear;
   }
   
   if (month >= 0) {
-    timediff_ += month - si_.m0;
+    timediff_ += (month - si_.m0) * cyclusYear / kMonthsPerYear;
   }
 
   return timediff_;

--- a/src/timer.cc
+++ b/src/timer.cc
@@ -299,7 +299,7 @@ int Timer::CalcTimeDiff(int year, int month) {
   }
   
   if (month >= 0) {
-    timediff_ += (month - si_.m0) * cyclusYear / kMonthsPerYear;
+    timediff_ += (month - si_.m0) * cyclusMonth;
   }
 
   // Casting because ctx_->dt() is uint64_t and so negatives don't play nice

--- a/src/timer.cc
+++ b/src/timer.cc
@@ -294,22 +294,12 @@ int Timer::dur() {
 int Timer::timeshift(int year, int month) {
 
   int timeshift_ = 0;
-  if (year > si_.y0) {
+  if (year >= 0) {
     timeshift_ += (year - si_.y0) * kMonthsPerYear;
   }
   
-  if (month >=0) {
+  if (month >= 0) {
     timeshift_ += si_.m0 - month;
-  }
-
-  if (timeshift_ < 0) {
-    Warn<VALUE_WARNING>(
-      "Timeshifting is only allowed for alternate timestamps "
-      "that occur after the simulation start time.  This call "
-      "resulted in a negative time shift.  Returning 0 timeshift "
-      "instead."
-    )
-    timeshift_ = 0;
   }
 
   return timeshift_;

--- a/src/timer.cc
+++ b/src/timer.cc
@@ -291,6 +291,22 @@ int Timer::dur() {
   return si_.duration;
 }
 
+int Timer::timeshift(int year, int month) {
+
+  int timeshift = 0;
+  if (year > si_.y0) {
+    timeshift += (year - si_.y0) * kMonthsPerYear;
+  }
+  
+  if (month >=0) {
+    timeshift += si_.m0 - month;
+  }
+
+  return timeshift;
+
+}
+
+
 Timer::Timer() : time_(0), si_(0), want_snapshot_(false), want_kill_(false) {}
 
 }  // namespace cyclus

--- a/src/timer.cc
+++ b/src/timer.cc
@@ -294,7 +294,15 @@ int Timer::dur() {
 int Timer::CalcTimeDiff(int year, int month) {
 
   int start_time = si_.y0 * cyclusYear + si_.m0 * cyclusMonth;
-  int time = year * cyclusYear + month * cyclusMonth;
+  int time = std::min(year,0) * cyclusYear + std::min(month,0) * cyclusMonth;
+
+  // if time is 0, then invalid combination of year and month were given
+  if time == 0 {
+    CLOG(LEV_WARN) << "Invalid year and month combination given to Timer::CalcTimeDiff. Returning 0. "
+                   "Year: " << year << " Month: " << month;
+
+    return 0;
+  } 
 
   // Casting because ctx_->dt() is uint64_t and so negatives don't play nice
   return (time - start_time) / static_cast<int>(ctx_->dt());

--- a/src/timer.cc
+++ b/src/timer.cc
@@ -293,16 +293,26 @@ int Timer::dur() {
 
 int Timer::timeshift(int year, int month) {
 
-  int timeshift = 0;
+  int timeshift_ = 0;
   if (year > si_.y0) {
-    timeshift += (year - si_.y0) * kMonthsPerYear;
+    timeshift_ += (year - si_.y0) * kMonthsPerYear;
   }
   
   if (month >=0) {
-    timeshift += si_.m0 - month;
+    timeshift_ += si_.m0 - month;
   }
 
-  return timeshift;
+  if (timeshift_ < 0) {
+    Warn<VALUE_WARNING>(
+      "Timeshifting is only allowed for alternate timestamps "
+      "that occur after the simulation start time.  This call "
+      "resulted in a negative time shift.  Returning 0 timeshift "
+      "instead."
+    )
+    timeshift_ = 0;
+  }
+
+  return timeshift_;
 
 }
 

--- a/src/timer.cc
+++ b/src/timer.cc
@@ -303,7 +303,7 @@ int Timer::CalcTimeDiff(int year, int month) {
   }
 
   // Casting because ctx_->dt() is uint64_t and so negatives don't play nice
-  return static_cast<int>(timediff_ / static_cast<int64_t>(ctx_->dt()));
+  return timediff_ / static_cast<int>(ctx_->dt());
 
 }
 

--- a/src/timer.cc
+++ b/src/timer.cc
@@ -299,7 +299,7 @@ int Timer::CalcTimeDiff(int year, int month) {
   }
   
   if (month >= 0) {
-    timediff_ += si_.m0 - month;
+    timediff_ += month - si_.m0;
   }
 
   return timediff_;

--- a/src/timer.cc
+++ b/src/timer.cc
@@ -294,10 +294,10 @@ int Timer::dur() {
 int Timer::CalcTimeDiff(int year, int month) {
 
   int start_time = si_.y0 * cyclusYear + si_.m0 * cyclusMonth;
-  int time = std::min(year,0) * cyclusYear + std::min(month,0) * cyclusMonth;
+  int time = std::max(year,0) * cyclusYear + std::max(month,0) * cyclusMonth;
 
   // if time is 0, then invalid combination of year and month were given
-  if (time == 0) {
+  if (time == 0 ) {
     CLOG(LEV_WARN) << "Invalid year and month combination given to Timer::CalcTimeDiff. Returning 0. "
                    "Year: " << year << " Month: " << month;
 

--- a/src/timer.cc
+++ b/src/timer.cc
@@ -297,7 +297,7 @@ int Timer::CalcTimeDiff(int year, int month) {
   int time = std::min(year,0) * cyclusYear + std::min(month,0) * cyclusMonth;
 
   // if time is 0, then invalid combination of year and month were given
-  if time == 0 {
+  if (time == 0) {
     CLOG(LEV_WARN) << "Invalid year and month combination given to Timer::CalcTimeDiff. Returning 0. "
                    "Year: " << year << " Month: " << month;
 

--- a/src/timer.cc
+++ b/src/timer.cc
@@ -291,18 +291,18 @@ int Timer::dur() {
   return si_.duration;
 }
 
-int Timer::timeshift(int year, int month) {
+int Timer::CalcTimeDiff(int year, int month) {
 
-  int timeshift_ = 0;
+  int timediff_ = 0;
   if (year >= 0) {
-    timeshift_ += (year - si_.y0) * kMonthsPerYear;
+    timediff_ += (year - si_.y0) * kMonthsPerYear;
   }
   
   if (month >= 0) {
-    timeshift_ += si_.m0 - month;
+    timediff_ += si_.m0 - month;
   }
 
-  return timeshift_;
+  return timediff_;
 
 }
 

--- a/src/timer.cc
+++ b/src/timer.cc
@@ -293,17 +293,11 @@ int Timer::dur() {
 
 int Timer::CalcTimeDiff(int year, int month) {
 
-  int timediff_ = 0;
-  if (year >= 0) {
-    timediff_ += (year - si_.y0) * cyclusYear;
-  }
-  
-  if (month >= 0) {
-    timediff_ += (month - si_.m0) * cyclusMonth;
-  }
+  int start_time = si_.y0 * cyclusYear + si_.m0 * cyclusMonth;
+  int time = year * cyclusYear + month * cyclusMonth;
 
   // Casting because ctx_->dt() is uint64_t and so negatives don't play nice
-  return timediff_ / static_cast<int>(ctx_->dt());
+  return (time - start_time) / static_cast<int>(ctx_->dt());
 
 }
 

--- a/src/timer.cc
+++ b/src/timer.cc
@@ -302,7 +302,8 @@ int Timer::CalcTimeDiff(int year, int month) {
     timediff_ += (month - si_.m0) * cyclusYear / kMonthsPerYear;
   }
 
-  return timediff_;
+  // Casting because ctx_->dt() is uint64_t and so negatives don't play nice
+  return static_cast<int>(timediff_ / static_cast<int64_t>(ctx_->dt()));
 
 }
 

--- a/src/timer.h
+++ b/src/timer.h
@@ -76,12 +76,13 @@ class Timer {
   int dur();
 
   /// Returns the number of months between the simulation start
-  /// time and another time stamp
+  /// time and another time stamp.  
   ///
   /// @param year of alternate time stamp
   /// @param month of alternate time stamp
   ///
   /// @return the timeshift between two times, in months
+  /// @warning Only valid for times that occur after the simulation start time.
   int timeshift(int year, int month);
 
  private:

--- a/src/timer.h
+++ b/src/timer.h
@@ -75,14 +75,13 @@ class Timer {
   /// @return the duration, in months
   int dur();
 
-  /// Returns the number of months between the simulation start
+  /// Returns the number of time steps between the simulation start
   /// time and another time stamp.  
   ///
-  /// @param year of alternate time stamp
-  /// @param month of alternate time stamp
+  /// @param year of alternate time stamp (must be greater than 0)
+  /// @param month of alternate time stamp (must be greater than 0)
   ///
   /// @return the difference between the simulation start time and another time
-  /// @warning Only valid for times that occur after the simulation start time.
   int CalcTimeDiff(int year, int month);
 
  private:

--- a/src/timer.h
+++ b/src/timer.h
@@ -81,9 +81,9 @@ class Timer {
   /// @param year of alternate time stamp
   /// @param month of alternate time stamp
   ///
-  /// @return the timeshift between two times, in months
+  /// @return the difference between the simulation start time and another time
   /// @warning Only valid for times that occur after the simulation start time.
-  int timeshift(int year, int month);
+  int CalcTimeDiff(int year, int month);
 
  private:
   /// builds all agents queued for the current timestep.

--- a/src/timer.h
+++ b/src/timer.h
@@ -75,6 +75,15 @@ class Timer {
   /// @return the duration, in months
   int dur();
 
+  /// Returns the number of months between the simulation start
+  /// time and another time stamp
+  ///
+  /// @param year of alternate time stamp
+  /// @param month of alternate time stamp
+  ///
+  /// @return the timeshift between two times, in months
+  int timeshift(int year, int month);
+
  private:
   /// builds all agents queued for the current timestep.
   void DoBuild();

--- a/tests/timer_tests.cc
+++ b/tests/timer_tests.cc
@@ -124,34 +124,34 @@ TEST_P(TimerTestsFixture, TimeShiftTest) {
 
   ti.Initialize(&ctx, cyclus::SimInfo(5));
 
-  int obs = ti.timeshift(-1,-1);
+  int obs = ti.CalcTimeDiff(-1,-1);
   int exp = 0;
   EXPECT_EQ(exp, obs);
 
-  obs = ti.timeshift(0,0);
+  obs = ti.CalcTimeDiff(0,0);
   EXPECT_EQ(exp, obs);
 
-  obs = ti.timeshift(2010, 2);
+  obs = ti.CalcTimeDiff(2010, 2);
   exp = 1;
   EXPECT_EQ(exp, obs);
 
-  obs = ti.timeshift(2011,1);
+  obs = ti.CalcTimeDiff(2011,1);
   exp = 12;
   EXPECT_EQ(exp, obs);
 
-  obs = ti.timeshift(2011,5);
+  obs = ti.CalcTimeDiff(2011,5);
   exp = 16;
   EXPECT_EQ(exp, obs);
 
-  obs = ti.timeshift(2009,1);
+  obs = ti.CalcTimeDiff(2009,1);
   exp = -12;
   EXPECT_EQ(exp, obs);
 
-  obs = ti.timeshift(2009,11);
+  obs = ti.CalcTimeDiff(2009,11);
   exp = -2;
   EXPECT_EQ(exp, obs);
 
-  obs = ti.timeshift(2008,6);
+  obs = ti.CalcTimeDiff(2008,6);
   exp = -19;
   EXPECT_EQ(exp, obs);
 

--- a/tests/timer_tests.cc
+++ b/tests/timer_tests.cc
@@ -128,9 +128,6 @@ TEST_P(TimerTestsFixture, TimeShiftTest) {
   int exp = 0;
   EXPECT_EQ(exp, obs);
 
-  obs = ti.CalcTimeDiff(0,0);
-  EXPECT_EQ(exp, obs);
-
   obs = ti.CalcTimeDiff(2010, 2);
   exp = 1;
   EXPECT_EQ(exp, obs);

--- a/tests/timer_tests.cc
+++ b/tests/timer_tests.cc
@@ -115,6 +115,48 @@ class TimerTestsFixture : public ::testing::TestWithParam<int> {
     #endif // CYCLUS_IS_PARALLEL
 };
 
+
+TEST_P(TimerTestsFixture, TimeShiftTest) {
+  cyclus::PyStart();
+  cyclus::Recorder rec;
+  cyclus::Timer ti;
+  cyclus::Context ctx(&ti, &rec);
+
+  ti.Initialize(&ctx, cyclus::SimInfo(5));
+
+  int obs = ti.timeshift(-1,-1);
+  int exp = 0;
+  EXPECT_EQ(exp, obs);
+
+  obs = ti.timeshift(0,0);
+  EXPECT_EQ(exp, obs);
+
+  obs = ti.timeshift(2010, 2);
+  exp = 1;
+  EXPECT_EQ(exp, obs);
+
+  obs = ti.timeshift(2011,1);
+  exp = 12;
+  EXPECT_EQ(exp, obs);
+
+  obs = ti.timeshift(2011,5);
+  exp = 16;
+  EXPECT_EQ(exp, obs);
+
+  obs = ti.timeshift(2009,1);
+  exp = -12;
+  EXPECT_EQ(exp, obs);
+
+  obs = ti.timeshift(2009,11);
+  exp = -2;
+  EXPECT_EQ(exp, obs);
+
+  obs = ti.timeshift(2008,6);
+  exp = -19;
+  EXPECT_EQ(exp, obs);
+
+}
+
 TEST_P(TimerTestsFixture, BareSim) {
   cyclus::PyStart();
   cyclus::Recorder rec;

--- a/tests/timer_tests.cc
+++ b/tests/timer_tests.cc
@@ -156,21 +156,25 @@ TEST_P(TimerTestsFixture, TimeShiftTest) {
   // Create and initialize a new timer with a non-default timestep
   cyclus::Timer non_default_ti;
   cyclus::Context ctx2(&non_default_ti, &rec);
+  cyclus::SimInfo short_timestep(5);
+  short_timestep.dt = 1;
 
-  non_default_ti.Initialize(&ctx2, cyclus::SimInfo(5, 2010, 1, "", 1));
+  non_default_ti.Initialize(&ctx2, short_timestep);
 
   obs = non_default_ti.CalcTimeDiff(2010, 8);
-  exp = 7 * kDefaultTimeStepDur / ctx2.dt();
+  exp = 7 * cyclusMonth / ctx2.dt();
   EXPECT_EQ(exp, obs);
 
     // Create and initialize a new timer with a weird non-default timestep
   cyclus::Timer weird_non_default_ti;
   cyclus::Context ctx3(&weird_non_default_ti, &rec);
+  cyclus::SimInfo weird_timestep(5);
+  weird_timestep.dt = 13;
 
-  non_default_ti.Initialize(&ctx3, cyclus::SimInfo(5, 2010, 1, "", 13));
+  weird_non_default_ti.Initialize(&ctx3, weird_timestep);
 
-  obs = non_default_ti.CalcTimeDiff(2010, 8);
-  exp = 7 * kDefaultTimeStepDur / ctx3.dt();
+  obs = weird_non_default_ti.CalcTimeDiff(2010, 8);
+  exp = 7 * cyclusMonth / ctx3.dt();
   EXPECT_EQ(exp, obs);
 
 }

--- a/tests/timer_tests.cc
+++ b/tests/timer_tests.cc
@@ -129,27 +129,48 @@ TEST_P(TimerTestsFixture, TimeShiftTest) {
   EXPECT_EQ(exp, obs);
 
   obs = ti.CalcTimeDiff(2010, 2);
-  exp = 1 * kDefaultTimeStepDur;
+  exp = 1;
   EXPECT_EQ(exp, obs);
 
   obs = ti.CalcTimeDiff(2011,1);
-  exp = 12 * kDefaultTimeStepDur;
+  exp = 12;
   EXPECT_EQ(exp, obs);
 
   obs = ti.CalcTimeDiff(2011,5);
-  exp = 16 * kDefaultTimeStepDur;
+  exp = 16;
   EXPECT_EQ(exp, obs);
 
   obs = ti.CalcTimeDiff(2009,1);
-  exp = -12 * kDefaultTimeStepDur;
+  exp = -12;
   EXPECT_EQ(exp, obs);
 
   obs = ti.CalcTimeDiff(2009,11);
-  exp = -2 * kDefaultTimeStepDur;
+  exp = -2;
   EXPECT_EQ(exp, obs);
 
   obs = ti.CalcTimeDiff(2008,6);
-  exp = -19 * kDefaultTimeStepDur;
+  exp = -19;
+  EXPECT_EQ(exp, obs);
+
+
+  // Create and initialize a new timer with a non-default timestep
+  cyclus::Timer non_default_ti;
+  cyclus::Context ctx2(&non_default_ti, &rec);
+
+  non_default_ti.Initialize(&ctx2, cyclus::SimInfo(5, 2010, 1, "", 1));
+
+  obs = non_default_ti.CalcTimeDiff(2010, 8);
+  exp = 7 * kDefaultTimeStepDur / ctx2.dt();
+  EXPECT_EQ(exp, obs);
+
+    // Create and initialize a new timer with a weird non-default timestep
+  cyclus::Timer weird_non_default_ti;
+  cyclus::Context ctx3(&weird_non_default_ti, &rec);
+
+  non_default_ti.Initialize(&ctx3, cyclus::SimInfo(5, 2010, 1, "", 13));
+
+  obs = non_default_ti.CalcTimeDiff(2010, 8);
+  exp = 7 * kDefaultTimeStepDur / ctx3.dt();
   EXPECT_EQ(exp, obs);
 
 }

--- a/tests/timer_tests.cc
+++ b/tests/timer_tests.cc
@@ -129,27 +129,27 @@ TEST_P(TimerTestsFixture, TimeShiftTest) {
   EXPECT_EQ(exp, obs);
 
   obs = ti.CalcTimeDiff(2010, 2);
-  exp = 1;
+  exp = 1 * kDefaultTimeStepDur;
   EXPECT_EQ(exp, obs);
 
   obs = ti.CalcTimeDiff(2011,1);
-  exp = 12;
+  exp = 12 * kDefaultTimeStepDur;
   EXPECT_EQ(exp, obs);
 
   obs = ti.CalcTimeDiff(2011,5);
-  exp = 16;
+  exp = 16 * kDefaultTimeStepDur;
   EXPECT_EQ(exp, obs);
 
   obs = ti.CalcTimeDiff(2009,1);
-  exp = -12;
+  exp = -12 * kDefaultTimeStepDur;
   EXPECT_EQ(exp, obs);
 
   obs = ti.CalcTimeDiff(2009,11);
-  exp = -2;
+  exp = -2 * kDefaultTimeStepDur;
   EXPECT_EQ(exp, obs);
 
   obs = ti.CalcTimeDiff(2008,6);
-  exp = -19;
+  exp = -19 * kDefaultTimeStepDur;
   EXPECT_EQ(exp, obs);
 
 }

--- a/tests/timer_tests.cc
+++ b/tests/timer_tests.cc
@@ -122,6 +122,7 @@ TEST_P(TimerTestsFixture, TimeShiftTest) {
   cyclus::Timer ti;
   cyclus::Context ctx(&ti, &rec);
 
+  // Default SimInfo starts in January 2010: year=2010, month=1
   ti.Initialize(&ctx, cyclus::SimInfo(5));
 
   int obs = ti.CalcTimeDiff(-1,-1);
@@ -165,7 +166,7 @@ TEST_P(TimerTestsFixture, TimeShiftTest) {
   exp = 7 * cyclusMonth / ctx2.dt();
   EXPECT_EQ(exp, obs);
 
-    // Create and initialize a new timer with a weird non-default timestep
+  // Create and initialize a new timer with a weird non-default timestep
   cyclus::Timer weird_non_default_ti;
   cyclus::Context ctx3(&weird_non_default_ti, &rec);
   cyclus::SimInfo weird_timestep(5);


### PR DESCRIPTION
Allow archetype developers to calculate a shift in time between the simulation start time and some arbitrary time stamp specified as a year and month.