### PR TITLE
Fixes failing macOS CI tests 

### DIFF
--- a/.github/workflows/macos_build_test.yml
+++ b/.github/workflows/macos_build_test.yml
@@ -30,7 +30,6 @@ jobs:
       fail-fast: false
       matrix:
         macos_versions: [
-            macos-13,
             macos-14,
         ]
         parallel_flag : [

--- a/.github/workflows/macos_build_test.yml
+++ b/.github/workflows/macos_build_test.yml
@@ -31,6 +31,8 @@ jobs:
       matrix:
         macos_versions: [
             macos-14,
+            macos-15-intel,
+            macos-latest, #macos 15 arm64
         ]
         parallel_flag : [
           "",

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -61,6 +61,7 @@ Since last release
 
 **Fixed:**
 
+* Removed retired macos-13 runner for CI tests and added macos-15-intel and macos-latest (#1938)
 * Removed unnecessary records being added to the Resource database by packaging process (#1761)
 * Removed GTest source code from code coverage reports (#1759)
 * Extended new GTest handling to Institutions and Facilities as they were done in Regions (#1836)


### PR DESCRIPTION
<!-- If this PR adds a CEP, do not repeat all of the information in the CEP document in the summary. Instead, provide a short description of the CEP's purpose.  -->

# Summary of Changes
This removes the retired macos-13 runner from Mac CI testing that causes failed tests. It also adds runners for macos-15-intel and macos-latest, which is currently macos 15 arm64. These runners were suggested in [this github actions issue](https://github.com/actions/runner-images/issues/13046).


## Design Notes
I chose to use the macos-latest runner, but macos-15 could be used instead to explicitly define macos 15 arm64.


Check the box if your change does not break any of the following:
- [x] API for Cyclus modules
- [x] Input files
- [x] Output tables for post processing tools

# Related CEPs and Issues
<!--- Reference the issue that this PR closes, any related CEPs, and describe how this PR contributes to or addresses the problem. -->
Fixes #1934 


# Associated Developers
<!--- Please mention any developers who should be alerted of this PR. -->



# Testing and Validation
CI tests for macos-14, macos-15-intel, and macos-latest all pass.


- [x] I have read the [Contributing to Cyclus](https://fuelcycle.org/kernel/contributing_to_cyclus.html) guide
- [ ] I have compiled and run the code locally
- [ ] I have added or updated relevant tests
- [ ] I have added documentation for new or changed features
- [ ] This code follows the style guide
- [ ] I have updated the changelog

Reviewers, please refer to the Cyclus [Guide for Reviewers](https://fuelcycle.org/kernel/pr_review.html).