### PR TITLE
Decay small amounts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,7 @@ Since last release
 * Allow multiple archetype blocks to facilitate includes (#1874)
 
 **Changed:**
+* Changed the epsilon (eps) in Material::Decay to 1e-4 allowing 1 day decay of tritium (#1946)
 * Changed the schema for recipes to require oneOrMore instead of zeroOrMore (#1940)
 * Made the Unit Tests far less verbose by suppressing log output during RunSim (#1927)
 * Changed Dockerfile to use boost and boost-cpp instead of libboost-devel (#1906)

--- a/src/material.cc
+++ b/src/material.cc
@@ -207,7 +207,11 @@ void Material::Decay(int curr_time) {
     return;
   }
 
-  double eps = 1e-3;
+  // eps_decay defined such that tritium (12.32 yr half life) decays over 1 day
+  // NOTE: If in the future something like support for medical isotopes is
+  // wanted, change this value and the MaterialTest.DecaySmallAmounts test 
+  // accordingly.
+  double eps_decay = 1e-4;
   const CompMap c = comp_->atom();
 
   // If composition has too many nuclides (i.e. > 100), it is cheaper to
@@ -221,8 +225,8 @@ void Material::Decay(int curr_time) {
 
   if (!decay) {
     // Only do the decay calc if one of the nuclides would change in number
-    // density more than fraction eps.
-    // i.e. decay if   (1 - eps) > exp(-lambda*dt)
+    // density more than fraction eps_decay.
+    // i.e. decay if   (1 - eps_decay) > exp(-lambda*dt)
     CompMap::const_reverse_iterator it;
     for (it = c.rbegin(); it != c.rend(); ++it) {
       int nuc = it->first;
@@ -230,7 +234,7 @@ void Material::Decay(int curr_time) {
           pyne::decay_const(nuc) * static_cast<double>(secs_per_timestep);
       double change =
           1.0 - std::exp(-lambda_timesteps * static_cast<double>(dt));
-      if (change >= eps) {
+      if (change >= eps_decay) {
         decay = true;
         break;
       }

--- a/src/material.cc
+++ b/src/material.cc
@@ -208,9 +208,6 @@ void Material::Decay(int curr_time) {
   }
 
   // eps_decay defined such that tritium (12.32 yr half life) decays over 1 day
-  // NOTE: If in the future something like support for medical isotopes is
-  // wanted, change this value and the MaterialTest.DecaySmallAmounts test 
-  // accordingly.
   double eps_decay = 1e-4;
   const CompMap c = comp_->atom();
 

--- a/tests/material_tests.cc
+++ b/tests/material_tests.cc
@@ -338,7 +338,7 @@ TEST_F(MaterialTest, DecayShortcut) {
 
   double sec_per_month = 2629152;
   double u235_lambda = pyne::decay_const(u235) * sec_per_month;  // per month
-  double eps = 1e-3;
+  double eps = 1e-4;
   double threshold = -1 * std::log(1-eps) / u235_lambda;
 
   // If delta t is small w.r.t. composition's decay constants, no decay is

--- a/tests/material_tests.cc
+++ b/tests/material_tests.cc
@@ -440,6 +440,31 @@ TEST_F(MaterialTest, DecayHeatTest) {
   ASSERT_NEAR(3.614E-14 , dec_heat, 0.0005);
 }
 
+TEST_F(MaterialTest, DecaySmallAmount) {
+  // eps_decay is defined such that tritium can decay on a 1 day time step
+  const int tritium_id = 10030000;
+  const double qty = 1; //kg, NOTE: fractional amounts all that matter 
+
+  CompMap v;
+  v[tritium_id] = 1.0;
+  Composition::Ptr tritium_comp = Composition::CreateFromMass(v);
+
+  Material::Ptr tritium = Material::Create(fac_day_timestep, qty, tritium_comp);
+
+  cyclus::toolkit::MatQuery mq(tritium);
+  double start_qty = mq.mass(tritium_id);
+  EXPECT_EQ(qty, start_qty);
+
+  // Decay forward by one day (we use the one day time step facility)
+  tritium->Decay(1);
+  double decayed_qty = mq.mass(tritium_id);
+
+  // NOTE: we've already tested that Decay is decaying the correct amt, so we
+  // can just make sure that any decay happens here and be satisfied that it's
+  // correct.
+  EXPECT_LT(decayed_qty, start_qty); // First entry < second enty
+}
+
 TEST_F(MaterialTest, GetNormalizedCompAtom) {
   double val = 1.5 * units::kg;
   Material::Ptr m1 = Material::CreateUntracked(val, diff_comp_);

--- a/tests/material_tests.h
+++ b/tests/material_tests.h
@@ -32,18 +32,30 @@ class MaterialTest : public ::testing::Test {
   double u235_g_per_mol_;
 
   cyclus::Timer ti;
+  cyclus::Timer ti_day_timestep;
   cyclus::Recorder rec;
   cyclus::Context* ctx;
   TestFacility* fac;
   cyclus::Context* ctx_no_decay;
   TestFacility* fac_no_decay;
+  cyclus::Context* ctx_day_timestep;
+  TestFacility* fac_day_timestep;
   // dur 100, y0 = 2015, m0=1, handle="", d="never"
   SimInfo si;
+  SimInfo si_day_timestep;
 
   virtual void SetUp() {
     PyStart();
     ctx = new cyclus::Context(&ti, &rec);
     fac = new TestFacility(ctx);
+
+    // Set up the one day time step context
+    int one_day = 86400;
+    si_day_timestep = SimInfo(100, 2015, 1, "", "manual");
+    si_day_timestep.dt = one_day;
+    ctx_day_timestep = new cyclus::Context(&ti_day_timestep, &rec);
+    ctx_day_timestep->InitSim(si_day_timestep);
+    fac_day_timestep = new TestFacility(ctx_day_timestep);
 
     si = SimInfo(100, 2015, 1, "", "never");
     ctx_no_decay = new cyclus::Context(&ti, &rec);


### PR DESCRIPTION
# Summary of Changes
<!--- In one or more sentences, describe the PR you are submitting. -->
Changes `eps = 1e-3` in `Material::Decay()` to `eps_decay = 1e-4`, pegging the value to allowing tritium to decay on a one day time step, and adds a test to make sure this works.

## Design Notes
<!--- Describe any design decisions or trade-offs you made. -->
I started by writing the test, which failed until I lowered `eps_decay`. I also decided to rename `eps` --> `eps_decay` to bring it more in line with other `eps` in cyclus (notably `eps_rsrc`).

Check the box if your change does not break any of the following:
- [ x API for Cyclus modules
- [x] Input files
- [x] Output tables for post processing tools

# Related CEPs and Issues
<!--- Reference the issue that this PR closes, any related CEPs, and describe how this PR contributes to or addresses the problem. -->
Closes #1917

# Associated Developers
<!--- Please mention any developers who should be alerted of this PR. -->

None.

# Testing and Validation
<!--- Describe how this change was tested. -->
Added a test to make sure tritium could decay in a simulation with a 1 day time step.

- [x] I have read the [Contributing to Cyclus](https://fuelcycle.org/kernel/contributing_to_cyclus.html) guide
- [x] I have compiled and run the code locally
- [x] I have added or updated relevant tests
- [x] I have added documentation for new or changed features
- [x] This code follows the style guide
- [ ] I have updated the changelog

Reviewers, please refer to the Cyclus [Guide for Reviewers](https://fuelcycle.org/kernel/pr_review.html).