### PR TITLE
New composition specification from nuclide 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,7 @@ Since last release
 * Support for OpenMP parallelized simulations (#1709)
 * Command-line option to make a new blank input file referencing a current schema (#1861)
 * Allow multiple archetype blocks to facilitate includes (#1874)
+* New composition specification based on single nuclide (#1949) 
 
 **Changed:**
 * Changed the epsilon (eps) in Material::Decay to 1e-4 allowing 1 day decay of tritium (#1946)

--- a/src/composition.cc
+++ b/src/composition.cc
@@ -40,6 +40,17 @@ int Composition::id() {
   return id_;
 }
 
+Composition::Ptr Composition::CreateFromNuclide(Nuc nuc){
+  if (!pyne::nucname::isnuclide(nuc)) {
+      throw ValueError("invalid nuclide in CompMap");
+    }
+  cyclus::CompMap comp;
+  comp[nuc] = 1.0;
+  Composition::Ptr c(new Composition());
+  c->atom_ = comp;
+  return c;
+}
+
 const CompMap& Composition::atom() {
   if (atom_.size() == 0) {
     CompMap::iterator it;

--- a/src/composition.h
+++ b/src/composition.h
@@ -52,6 +52,9 @@ class Composition {
   /// value.
   static Ptr CreateFromMass(CompMap v);
 
+  //creates a composition from one specificed nuclide 
+  static Ptr CreateFromNuclide(Nuc nuc);
+
   /// Returns a unique id associated with this composition.  Note that multiple
   /// material objects can share the same composition. Also Note that the id is
   /// not the same for two compositions that were separately created from the

--- a/tests/composition_tests.cc
+++ b/tests/composition_tests.cc
@@ -50,6 +50,16 @@ TEST(CompositionTests, create_mass) {
                    2 / pyne::atomic_mass(922350000) * pyne::atomic_mass(922330000));
 }
 
+
+TEST(CompositionTests, create_nuclide) {
+  cyclus::Env::SetNucDataPath();
+  EXPECT_THROW(Composition::CreateFromNuclide(920010000);,cyclus::ValueError);
+
+  Composition::Ptr c2 = Composition::CreateFromNuclide(922350000);
+  CompMap v = c2->atom();
+  EXPECT_DOUBLE_EQ(v[922350000],1.0);
+}
+
 TEST(CompositionTests, lineage) {
   cyclus::Env::SetNucDataPath();
 


### PR DESCRIPTION
<!-- If this PR adds a CEP, do not repeat all of the information in the CEP document in the summary. Instead, provide a short description of the CEP's purpose.  -->

# Summary of Changes
<!--- In one or more sentences, describe the PR you are submitting. -->
Resolves issue #1838 . New function in composition that allows only a single nuclide composition to be passed (using nucname). 

Check the box if your change does not break any of the following:
- [ ] API for Cyclus modules
- [ ] Input files
- [ ] Output tables for post processing tools

# Testing and Validation
<!--- Describe how this change was tested. -->
Added single test for checking valid nuclide input and atom frac. 

- [x] I have read the [Contributing to Cyclus](https://fuelcycle.org/kernel/contributing_to_cyclus.html) guide
- [x] I have compiled and run the code locally
- [x] I have added or updated relevant tests
- [x] I have added documentation for new or changed features
- [x] This code follows the style guide
- [ ] I have updated the changelog

Reviewers, please refer to the Cyclus [Guide for Reviewers](https://fuelcycle.org/kernel/pr_review.html).