### PR TITLE
Random Seed Based on Date-Time

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,7 @@ Since last release
 * Allow multiple archetype blocks to facilitate includes (#1874)
 * New composition specification based on single nuclide (#1949) 
 * Added ability to calcuate a time shift between the start time and some other time stamp (#1907)
+* Users can specify for random seed to be created for random number generation (#1950)
 
 **Changed:**
 * Modified cycpp.py to fix a few whitespace-related bugs, and allow cyclus vars to be initialized (#1954)

--- a/share/cyclus-flat.rng.in
+++ b/share/cyclus-flat.rng.in
@@ -65,7 +65,7 @@
         <optional>
             <element name="seed">
               <a:documentation>Value used for seed in built in random number generator. (Default: 20160212)</a:documentation>              
-              <data type="positiveInteger" /></element>
+              <data type="nonNegativeInteger" /></element>
         </optional>
         <optional>
             <element name="stride">

--- a/share/cyclus.rng.in
+++ b/share/cyclus.rng.in
@@ -66,7 +66,7 @@
         <optional>
             <element name="seed">
               <a:documentation>Value used for seed in built in random number generator. (Default: 20160212)</a:documentation>              
-              <data type="positiveInteger" /></element>
+              <data type="nonNegativeInteger" /></element>
         </optional>
         <optional>
             <element name="stride">

--- a/src/context.cc
+++ b/src/context.cc
@@ -16,7 +16,6 @@
 #include "random_number_generator.h"
 #include "version.h"
 #include <chrono>
-#include <thread>
 
 namespace cyclus {
 
@@ -335,7 +334,6 @@ int Context::random_uniform_int(int low, int high) {
 
 int Context::date_time_int(){
   auto time = std::chrono::steady_clock::now();
-  std::this_thread::sleep_for(std::chrono::milliseconds(5));
   auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(time.time_since_epoch());
   return duration.count();
 }

--- a/src/context.cc
+++ b/src/context.cc
@@ -16,6 +16,7 @@
 #include "random_number_generator.h"
 #include "version.h"
 #include <chrono>
+#include <thread>
 
 namespace cyclus {
 
@@ -333,7 +334,8 @@ int Context::random_uniform_int(int low, int high) {
 }
 
 int Context::date_time_int(){
-  auto time = std::chrono::system_clock::now();
+  auto time = std::chrono::steady_clock::now();
+  std::this_thread::sleep_for(std::chrono::milliseconds(5));
   auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(time.time_since_epoch());
   return duration.count();
 }

--- a/src/context.cc
+++ b/src/context.cc
@@ -15,6 +15,7 @@
 #include "timer.h"
 #include "random_number_generator.h"
 #include "version.h"
+#include <chrono>
 
 namespace cyclus {
 
@@ -329,6 +330,12 @@ double Context::random_01() {
 
 int Context::random_uniform_int(int low, int high) {
   return rng_->random_uniform_int(low, high);
+}
+
+int Context::date_time_int(){
+  auto time = std::chrono::system_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(time.time_since_epoch());
+  return duration.count();
 }
 
 double Context::random_uniform_real(double low, double high) {

--- a/src/context.h
+++ b/src/context.h
@@ -291,6 +291,8 @@ class Context {
   /// Returns a random number from a uniform integer distribution.
   int random_uniform_int(int low, int high);
 
+  int date_time_int();
+
   /// Returns a random number from a uniform real distribution.
   double random_uniform_real(double low, double high);
 

--- a/src/context.h
+++ b/src/context.h
@@ -291,6 +291,7 @@ class Context {
   /// Returns a random number from a uniform integer distribution.
   int random_uniform_int(int low, int high);
 
+  //returns an integer representation of the date-time to seed the simulation
   int date_time_int();
 
   /// Returns a random number from a uniform real distribution.

--- a/src/xml_file_loader.cc
+++ b/src/xml_file_loader.cc
@@ -512,7 +512,8 @@ void XMLFileLoader::LoadControlParams() {
   cy_eps_rsrc = si.eps_rsrc = eps_rsrc_;
 
   // get seed
-  si.seed = OptionalQuery<int>(qe, "seed", kDefaultSeed);
+  int seed_inp = OptionalQuery<int>(qe, "seed", kDefaultSeed);
+  si.seed = (seed_inp == 0) ? ctx_->date_time_int() : seed_inp;
 
   // get stride
   si.stride = OptionalQuery<int>(qe, "stride", kDefaultStride);

--- a/tests/random_tests.cc
+++ b/tests/random_tests.cc
@@ -91,3 +91,12 @@ TEST_F(RandomTest, TestRandomNormalFactory) {
   EXPECT_LE(r, 10);
   EXPECT_NEAR(r, 6.408382, 0.00001);
 }
+
+TEST_F(RandomTest, GetDateTimeSeed) {
+  int seed1 = ctx->date_time_int();
+  int seed2 = ctx->date_time_int();
+  int seed3 = ctx->date_time_int();
+  std::set<int> seeds = {seed1,seed2,seed3};
+  EXPECT_EQ(seeds.size(), 3);
+  EXPECT_GT(*seeds.begin(),0); //bc sets are ordered the first value should be the smallest comparably
+}

--- a/tests/random_tests.cc
+++ b/tests/random_tests.cc
@@ -7,6 +7,7 @@
 #include "sqlite_back.h"
 #include "timer.h"
 #include "random_number_generator.h"
+#include <thread>
 
 // special name to tell sqlite to use in-mem db
 static const char* dbpath = ":memory:";
@@ -94,7 +95,9 @@ TEST_F(RandomTest, TestRandomNormalFactory) {
 
 TEST_F(RandomTest, GetDateTimeSeed) {
   int seed1 = ctx->date_time_int();
+  std::this_thread::sleep_for(std::chrono::milliseconds(5));
   int seed2 = ctx->date_time_int();
+  std::this_thread::sleep_for(std::chrono::milliseconds(5));
   int seed3 = ctx->date_time_int();
   std::set<int> seeds = {seed1,seed2,seed3};
   EXPECT_EQ(seeds.size(), 3);


### PR DESCRIPTION
<!-- If this PR adds a CEP, do not repeat all of the information in the CEP document in the summary. Instead, provide a short description of the CEP's purpose.  -->

# Summary of Changes
<!--- In one or more sentences, describe the PR you are submitting. -->

This is intended to resolve issue #1832. The issue described having the user input (-1) as a parameter to indicate to the simulate to generate a random seed for random numbers in the controls block. 
 
## Design Notes
<!--- Describe any design decisions or trade-offs you made. -->

Currently, the user input would actually be 0 instead of -1. I am not super familiar with the schema validation but maybe there is a workaround for this next part -

- I don't know if the xml validation schema can specify that the user can *only* enter + integers and -1 (not 0 or any other negative values). Hence, I just settled on switching the seed input to non-negative integers (include 0 as the option for "random" seed).
 I thought maybe using the date-time cast as an integer to be the random seed when the user wants a random seed. I don't know if it would make sense to use the date time to seed a generator to generate a random seed to generate random numbers for the simulation run... if that makes any sense. So, I just removed the middle part and opted to use date-time directly. 

I would love some comments/critique! 

Check the box if your change does not break any of the following:
- [ ] API for Cyclus modules
- [ ] Input files
- [ ] Output tables for post processing tools

# Testing and Validation
<!--- Describe how this change was tested. -->


- [x] I have read the [Contributing to Cyclus](https://fuelcycle.org/kernel/contributing_to_cyclus.html) guide
- [x] I have compiled and run the code locally
- [x] I have added or updated relevant tests
- [x] I have added documentation for new or changed features
- [x] This code follows the style guide
- [x] I have updated the changelog

Reviewers, please refer to the Cyclus [Guide for Reviewers](https://fuelcycle.org/kernel/pr_review.html).