### PR TITLE
Changes to cycpp.py to make it less finicky

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,7 @@ Since last release
 * New composition specification based on single nuclide (#1949) 
 
 **Changed:**
+* Modified cycpp.py to fix a few whitespace-related bugs, and allow cyclus vars to be initialized (#1954)
 * Changed the epsilon (eps) in Material::Decay to 1e-4 allowing 1 day decay of tritium (#1946)
 * Changed the schema for recipes to require oneOrMore instead of zeroOrMore (#1940)
 * Made the Unit Tests far less verbose by suppressing log output during RunSim (#1927)

--- a/cli/cycpp.py
+++ b/cli/cycpp.py
@@ -397,7 +397,10 @@ class PragmaCyclusErrorFilter(Filter):
     """Filter for handling invalid #pragma cyclus. This should be the last filter."""
     regex = re.compile(r'\s*#\s*pragma\s+cyclus(.*)')
 
-    directives = frozenset(['var', 'note', 'exec', 'decl', 'def', 'impl'])
+    directives = frozenset(['var', 'note', 'exec', 'decl', 'def', 'impl',
+                            'clone', 'initfromcopy', 'initfromdb',
+                            'infiletodb', 'schema', 'annotations',
+                            'initinv', 'snapshotinv', 'snapshot'])
 
     def isvalid(self, statement):
         """Checks if a statement is valid for this fliter."""
@@ -407,7 +410,8 @@ class PragmaCyclusErrorFilter(Filter):
         g1 = m.group(1).strip()
         if len(g1) == 0:
             return False
-        s0 = g1.split(None, 1)[0]
+        m0 = re.match(r'(\w+)', g1)
+        s0 = m0.group(1) if m0 is not None else ''
         return s0 not in self.directives
 
     def transform(self, statement, sep):
@@ -472,7 +476,7 @@ class VarDecorationFilter(DecorationFilter):
     This evals the contents of dict and puts them in state.var_annotations, to be
     consumed by the next match with VarDeclarationFilter.
     """
-    regex = re.compile(r"\s*#\s*pragma\s+cyclus\s+var\s+(.*)")
+    regex = re.compile(r"\s*#\s*pragma\s+cyclus\s+var\s*(.+)")
 
     def transform(self, statement, sep):
         state = self.machine
@@ -485,7 +489,19 @@ class VarDeclarationFilter(Filter):
     """State varible declaration.  Only operates if state.var_annotations is
     not None. Access for member variable must be public.
     """
-    regex = re.compile(r"(.*\w+.*?)\s+(\w+)")
+    regex = re.compile(r"\s*(.+?)\s+(\w+)\s*(?:=.*)?$")
+
+    def isvalid(self, statement):
+        state = self.machine
+        if state.var_annotations is None:
+            self.match = None
+            return False
+        stripped = statement.lstrip()
+        if (stripped.startswith('#') or stripped.startswith('//') or
+                stripped.startswith('/*')):
+            self.match = None
+            return False
+        return super(VarDeclarationFilter, self).isvalid(statement)
 
     def transform_pass2(self, statement, sep):
         state = self.machine

--- a/cli/cycpp.py
+++ b/cli/cycpp.py
@@ -203,7 +203,7 @@ class Filter(object):
         self.match = None
 
     def isvalid(self, statement):
-        """Checks if a statement is valid for this fliter."""
+        """Checks if a statement is valid for this filter."""
         self.match = m = self.regex.match(statement)
         return m is not None
 
@@ -288,7 +288,7 @@ class TypedefFilter(AliasFilter):
         state.aliases |= {(depth, typ, a) for a in g0[-1:] + g[1:]}
 
 class UsingFilter(AliasFilter):
-    """Filter for accumumating using aliases."""
+    """Filter for accumulating using aliases."""
     regex = re.compile(r"\s*using\s+(?!namespace\s+)([\w:]+)\s*")
 
     def transform(self, statement, sep):
@@ -298,7 +298,7 @@ class UsingFilter(AliasFilter):
             state.aliases.add((state.depth, name, name.rsplit('::', 1)[1]))
 
 class NamespaceFilter(Filter):
-    """Filter for accumumating namespace encapsulations."""
+    """Filter for accumulating namespace encapsulations."""
     # handles anonymous namespaces as group(1) is None
     regex = re.compile(r"\s*namespace(\s+\w*)?\s*[^=]*", re.DOTALL)
 
@@ -318,7 +318,7 @@ class NamespaceFilter(Filter):
             del state.namespaces[-1]
 
 class UsingNamespaceFilter(Filter):
-    """Filter for accumumating using namespace statement."""
+    """Filter for accumulating using namespace statement."""
     regex = re.compile(r"\s*using\s+namespace\s+([\w:]*)\s*")
 
     def transform(self, statement, sep):
@@ -337,7 +337,7 @@ class UsingNamespaceFilter(Filter):
                                    if d_ns[0] > depth}
 
 class NamespaceAliasFilter(AliasFilter):
-    """Filter for accumumating namespace renames."""
+    """Filter for accumulating namespace renames."""
     regex = re.compile(r"\s*namespace\s+(\w+)\s*=\s*([\w:]+)\s*")
 
     def transform(self, statement, sep):
@@ -380,7 +380,7 @@ class ClassAndSuperclassFilter(ClassFilter):
             for sup in superclasses:
                 trysup = state.canonize_class(sup)
                 if trysup is None:
-                    # We cannot raise an error here becuase there are too many
+                    # We cannot raise an error here because there are too many
                     # corner cases we do not and should not support in C++
                     continue
                 sc.add(trysup)
@@ -403,7 +403,7 @@ class PragmaCyclusErrorFilter(Filter):
                             'initinv', 'snapshotinv', 'snapshot'])
 
     def isvalid(self, statement):
-        """Checks if a statement is valid for this fliter."""
+        """Checks if a statement is valid for this filter."""
         self.match = m = self.regex.match(statement)
         if m is None:
             return False
@@ -486,7 +486,7 @@ class VarDecorationFilter(DecorationFilter):
         state.var_annotations = self._eval()
 
 class VarDeclarationFilter(Filter):
-    """State varible declaration.  Only operates if state.var_annotations is
+    """State variable declaration.  Only operates if state.var_annotations is
     not None. Access for member variable must be public.
     """
     regex = re.compile(r"\s*(.+?)\s+(\w+)\s*(?:=.*)?$")
@@ -727,7 +727,7 @@ class StateAccumulator(object):
             self.context[classname]['vars'] = OrderedDict()
 
     def accumulate(self, statement, sep):
-        """Modify the existing state by incoprorating the statement, which is
+        """Modify the existing state by incorporating the statement, which is
         partitioned from the next statement by sep.
         """
         self.nlines_since_linemarker += statement.count('\n') + sep.count('\n')
@@ -792,7 +792,7 @@ class StateAccumulator(object):
                 return self._canonize_targs(talias, targs)
             for d, nsa in sorted(self.using_namespaces, reverse=True):
                 if len(tname.split(scopz)) > len(nsa.split(scopz)):
-                    # fixed point of reccursion when type would be more scoped than
+                    # fixed point of recursion when type would be more scoped than
                     # the alias - which is impossible.
                     continue
                 try:
@@ -823,7 +823,7 @@ class StateAccumulator(object):
                 return self.canonize_type(talias, name)
             for d, nsa in sorted(self.using_namespaces, reverse=True):
                 if len(t.split(scopz)) > len(nsa.split(scopz)):
-                    # fixed point of reccursion when type would be more scoped than
+                    # fixed point of recursion when type would be more scoped than
                     # the alias - which is impossible.
                     continue
                 try:
@@ -963,7 +963,7 @@ class CodeGeneratorFilter(Filter):
         classname = groups[1] if len(groups) > 1 else None
         if classname is None:
             if len(cg.classes) == 0:
-                TypeError("{0}Classname could not determined".format(
+                TypeError("{0}Classname could not be determined".format(
                         cg.includeloc()))
             classname = cg.classname()
         classname = classname.strip().replace('.', '::')
@@ -1414,7 +1414,7 @@ class InfileToDbFilter(CodeGeneratorFilter):
         else:
             val = alias[1][0]
 
-        # the extra assignment (bub, sub) is because we want the intial sub
+        # the extra assignment (bub, sub) is because we want the initial sub
         # rhs to be from outer scope - otherwise the newly defined sub will be
         # in scope causing segfaults
         tree_idx = idx or '0'
@@ -1448,7 +1448,7 @@ class InfileToDbFilter(CodeGeneratorFilter):
             val = alias[1]
         else:
             val = alias[1][0]
-        # the extra assignment (bub, sub) is because we want the intial sub
+        # the extra assignment (bub, sub) is because we want the initial sub
         # rhs to be from outer scope - otherwise the newly defined sub will be
         # in scope causing segfaults
         tree_idx = idx or '0'
@@ -1480,7 +1480,7 @@ class InfileToDbFilter(CodeGeneratorFilter):
             val = alias[1]
         else:
             val = alias[1][0]
-        # the extra assignment (bub, sub) is because we want the intial sub
+        # the extra assignment (bub, sub) is because we want the initial sub
         # rhs to be from outer scope - otherwise the newly defined sub will be
         # in scope causing segfaults
         tree_idx = idx or '0'
@@ -1509,7 +1509,7 @@ class InfileToDbFilter(CodeGeneratorFilter):
             alias[1] = 'first'
         if alias[2] is None:
             alias[2] = 'second'
-        # the extra assignment (bub, sub) is because we want the intial sub
+        # the extra assignment (bub, sub) is because we want the initial sub
         # rhs to be from outer scope - otherwise the newly defined sub will be
         # in scope causing segfaults
         tree_idx = idx or '0'
@@ -1536,7 +1536,7 @@ class InfileToDbFilter(CodeGeneratorFilter):
             alias[1] = 'key'
         if alias[2] is None:
             alias[2] = 'val'
-        # the extra assignment (bub, sub) is because we want the intial sub
+        # the extra assignment (bub, sub) is because we want the initial sub
         # rhs to be from outer scope - otherwise the newly defined sub will be
         # in scope causing segfaults
         # subtree must be specified if in recursive level
@@ -2131,7 +2131,7 @@ class CodeGenerator(object):
         return s + "\n"
 
     def generate(self, statement, sep):
-        """Modify the existing statements list by incoprorating, modifying, or
+        """Modify the existing statements list by incorporating, modifying, or
         ignoring this statement, which is partitioned from the next statement by
         sep.
         """
@@ -2226,7 +2226,7 @@ class Proxy(MutableMapping):
         return key in self.__dict__['_d']
 
 def outter_split(s, open_brace='(', close_brace=')', separator=','):
-    """Takes a string and only split the outter most level."""
+    """Takes a string and only split the outermost level."""
     outter = []
     ns = s.split(separator)
     count = 0

--- a/src/toolkit/position.cycpp.h
+++ b/src/toolkit/position.cycpp.h
@@ -18,7 +18,7 @@ cyclus::toolkit::Position coordinates;
        "doc": "Latitude of the agent's geographical position. The value should " \
        "be expressed in degrees as a double." \
 }
-double latitude;
+double latitude = 0.0;
 
 #pragma cyclus var { \
        "default": 0.0, \
@@ -26,7 +26,7 @@ double latitude;
        "doc": "Longitude of the agent's geographical position. The value should " \
               "be expressed in degrees as a double." \
 }
-double longitude;
+double longitude = 0.0;
 // clang-format on
 
 // Provided default values to give the option to manually override

--- a/tests/cycpp_test.py
+++ b/tests/cycpp_test.py
@@ -168,10 +168,13 @@ def test_synerror():
     m = MockMachine()
     f = PragmaCyclusErrorFilter(m)
     assert not f.isvalid("#pragma cyclus var {}")
+    assert not f.isvalid("#pragma cyclus var{}")
     assert not f.isvalid("#pragma cyclus")
+    assert not f.isvalid("#pragma cyclus clone")
+    assert not f.isvalid("#pragma cyclus annotations")
+    assert not f.isvalid("#pragma cyclus snapshotinv")
 
-    assert  f.isvalid('#pragma cyclus nooooo')
-    statement, sep = "#pragma cyclus var{}", "\n"
+    statement, sep = "#pragma cyclus nooooo", "\n"
     assert  f.isvalid(statement)
     with pytest.raises(SyntaxError):
         f.transform(statement, sep)
@@ -190,6 +193,11 @@ def test_vdecorfilter():
     f.transform(statement, sep)
     assert m.var_annotations == {'name': 'James Bond'}
 
+    statement, sep = "#pragma cyclus var{'name': 'Moneypenny'} ", "\n"
+    assert  f.isvalid(statement)
+    f.transform(statement, sep)
+    assert m.var_annotations == {'name': 'Moneypenny'}
+
 def test_vdeclarfilter():
     """Test VarDeclarationFilter"""
     m = MockMachine()
@@ -197,12 +205,38 @@ def test_vdeclarfilter():
     assert not f.isvalid("one ")
 
     statement, sep = "one two", "\n"
+    m.var_annotations = {}
     assert  f.isvalid(statement)
     m.classes = [(0, "trader")]
     m.access = {"trader": "public"}
     # m.var_annotations = {'name': 'James Bond'}
+    m.var_annotations = None
     f.transform(statement, sep)
     assert m.var_annotations == None
+
+def test_vdeclarfilter_initialized_member():
+    """Test VarDeclarationFilter with a C++ default member initializer"""
+    m = MockMachine()
+    m.var_annotations = {}
+    f = VarDeclarationFilter(m)
+
+    statement = "double latitude = 0.0"
+    assert f.isvalid(statement)
+    assert f.match.groups() == ("double", "latitude")
+
+    statement = "int foo = 7"
+    assert f.isvalid(statement)
+    assert f.match.groups() == ("int", "foo")
+
+def test_vdeclarfilter_skips_pragmas_and_comments():
+    """Test VarDeclarationFilter leaves non-declarations for later filters"""
+    m = MockMachine()
+    m.var_annotations = {}
+    f = VarDeclarationFilter(m)
+
+    assert not f.isvalid("#pragma cyclus")
+    assert not f.isvalid("// a comment")
+    assert not f.isvalid("/* a comment */")
 
 def test_vdeclarfilter_canonize_alias():
     m = MockMachine()
@@ -1189,4 +1223,3 @@ def test_integration():
         cmd = 'cycpp.py {} -o {} --cpp-path `which g++`'.format(inf, outf.name)
     p = Popen(cmd, shell=True, stdin=PIPE, stdout=PIPE, stderr=STDOUT, close_fds=True)
     assert '' ==  p.stdout.read().decode()
-

--- a/tests/cycpp_test.py
+++ b/tests/cycpp_test.py
@@ -203,16 +203,28 @@ def test_vdeclarfilter():
     m = MockMachine()
     f = VarDeclarationFilter(m)
     assert not f.isvalid("one ")
+    assert not f.isvalid("one two")
 
     statement, sep = "one two", "\n"
     m.var_annotations = {}
     assert  f.isvalid(statement)
+
+
+def test_vdeclarfilter_consumes_pending_annotation():
+    """Test VarDeclarationFilter consumes a pending state var annotation"""
+    m = StateAccumulator()
     m.classes = [(0, "trader")]
-    m.access = {"trader": "public"}
-    # m.var_annotations = {'name': 'James Bond'}
-    m.var_annotations = None
+    m.superclasses["trader"] = set()
+    m.access = {tuple(m.classes): "public"}
+    m.var_annotations = {'doc': 'some state variable'}
+    f = VarDeclarationFilter(m)
+
+    statement, sep = "double foo", "\n"
+    assert f.isvalid(statement)
     f.transform(statement, sep)
-    assert m.var_annotations == None
+    assert m.var_annotations is None
+    assert m.context["trader"]["vars"]["foo"]["type"] == "double"
+    assert m.context["trader"]["vars"]["foo"]["doc"] == "some state variable"
 
 def test_vdeclarfilter_initialized_member():
     """Test VarDeclarationFilter with a C++ default member initializer"""


### PR DESCRIPTION
# Important Note from Dean
I have, recently, been trying to rely less on using AI to write code, for a variety of reasons. However, the cycpp.py file is so arcane and long that I felt it was appropriate to sick OpenAI's Codex (not Cursor, trying it out) on this particular problem. Not only do I think it fixed the issue I set out to have it fix, I think it ALSO fixed two other bugs with the cycpp.py file, including the one that caused me to have to go in and do `// clang-format off/on` 1,000,000 times in Cycamore (haven't tested this yet to be certain, but I have a hunch). I will still be doing my best to flex my own coding muscles going forward, but this one felt like such a massive time/effort save that it was hard not to just let the superhuman AI do it.

Also, I had Codex write the PR report, since it did 100% of the code writing/exploring/debugging/test writing, etc.

Reviewers: I think this should be fairly straightforward to review, I took a look at what Codex did before making this PR, but please feel free to leave general comments about Codex and the work it did. That will be good feedback.

# Summary of Changes
This PR updates `cycpp.py` so annotated Cyclus state variables can use C++ default member initializers, e.g. `double latitude = 0.0;`. This allows injected cycpp snippets such as `position.cycpp.h` to provide real construction-time defaults instead of requiring every consuming archetype to remember constructor initializer-list entries.

The PR also makes cycpp parsing a little more tolerant of existing pragma forms encountered during downstream Cycamore builds, including explicit code-generation pragmas such as `#pragma cyclus clone` during pass 2 and `#pragma cyclus var{...}` without a space before the annotation dictionary.

# Related CEPs and Issues

This PR is related to:

- Closes #1898 

# Design Notes
The main parser change is intentionally narrow: `VarDeclarationFilter` now only attempts to parse a declaration when a preceding `#pragma cyclus var` annotation is pending. This prevents it from accidentally consuming unrelated pragmas or comments while still allowing initialized declarations like `double latitude = 0.0`.

The generic pragma error filter was updated to recognize cycpp’s explicit code-generation pragmas and no-space `var{...}` syntax as valid forms. This keeps existing Cycamore/cycpp usage working without requiring formatting-only edits in downstream projects.

Check the box if your change does not break any of the following:
- [x] API for Cyclus modules
- [x] Input files
- [x] Output tables for post processing tools

# Associated Developers
@dean-krueger

# Testing and Validation
This change was tested with the cycpp unit tests, excluding the existing integration test that assumes a Unix-style `cycpp.py` executable on `PATH` and use of `which` from a Windows shell. The relevant parser tests pass locally, including added coverage for initialized state variable declarations, explicit code-generation pragmas, comments/pragmas near state variable parsing, and `#pragma cyclus var{...}` syntax.

Additional validation was performed by rebuilding Cyclus and running its unit tests locally. The installed cycpp was then used while building Cycamore, which exercised the downstream pragma forms that motivated the compatibility fixes.

# Checklist
- [x] I have read the [Contributing to Cyclus](https://fuelcycle.org/kernel/contributing_to_cyclus.html) guide
- [x] I have compiled and run the code locally
- [x] I have added or updated relevant tests
- [ ] I have added documentation for new or changed features
- [x] This code follows the style guide
- [x] I have updated the changelog

Reviewers, please refer to the Cyclus [Guide for Reviewers](https://fuelcycle.org/kernel/pr_review.html).