### PR TITLE
Fix the Progress Bar Breaking Cycamore Build

### DIFF
--- a/.github/workflows/changelog_test.yml
+++ b/.github/workflows/changelog_test.yml
@@ -15,7 +15,7 @@ jobs:
     name: Is Changelog up-to-date ?
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - run: |
           git config --global --add safe.directory ${GITHUB_WORKSPACE}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Since last release
 ====================
 
 **Added:**
-
+* Added a copy constructor to Timer to allow MockSim to copy it without upsetting the progress bar (#1961)
 * Added progress bar to the simulation loop (#1912)
 * Added a warning for when a facility trades with itself (#1895)
 * Added a new datatype to the backend for tariff region (#1922)

--- a/src/timer.cc
+++ b/src/timer.cc
@@ -19,6 +19,31 @@
 
 namespace cyclus {
 
+Timer::Timer(const Timer& other) {
+  *this = other;
+}
+
+Timer& Timer::operator=(const Timer& other) {
+  if (this != &other) {
+    ctx_ = other.ctx_;
+    time_ = other.time_;
+    si_ = other.si_;
+    want_snapshot_ = other.want_snapshot_;
+    want_kill_ = other.want_kill_;
+    tickers_ = other.tickers_;
+    cpp_tickers_ = other.cpp_tickers_;
+    py_tickers_ = other.py_tickers_;
+    build_queue_ = other.build_queue_;
+    decom_queue_ = other.decom_queue_;
+    progress_bar_.reset();
+    progress_update_frequency_ = other.progress_update_frequency_;
+    progress_origin_ = other.progress_origin_;
+    progress_span_ = other.progress_span_;
+    quiet_ = other.quiet_;
+  }
+  return *this;
+}
+
 void Timer::RunSim() {
   LogLevel saved_level = Logger::ReportLevel();
   if (quiet_) {

--- a/src/timer.h
+++ b/src/timer.h
@@ -25,6 +25,10 @@ class Timer {
   friend class ::SimInitTest;
 
  public:
+  Timer() = default;
+  ~Timer() = default;
+  Timer(const Timer& other);
+  Timer& operator=(const Timer& other);
 
   /// Sets intial time-related parameters for the simulation.
   ///

--- a/tests/timer_tests.cc
+++ b/tests/timer_tests.cc
@@ -344,6 +344,36 @@ TEST_P(TimerTestsFixture, DoubleDecom) {
   cyclus::PyStop();
 }
 
+TEST_P(TimerTestsFixture, Copy) {
+  cyclus::Recorder rec;
+  cyclus::Timer ti;
+  cyclus::Timer ti2;
+  cyclus::Context ctx(&ti, &rec);
+
+
+  ti.Initialize(&ctx, cyclus::SimInfo(13));
+  ti.SetQuiet(true);
+  
+  // Quickly test the = operator first
+  ti2 = ti;
+  EXPECT_EQ(ti.dur(), ti2.dur());
+  EXPECT_EQ(ti.IsQuiet(), ti2.IsQuiet());
+
+  // Copy ti
+  cyclus::Timer ti3(ti);
+
+  // test that the copied ti3 matches ti
+  EXPECT_EQ(ti.dur(), ti3.dur());
+  EXPECT_EQ(ti.time(), ti3.time());
+  EXPECT_EQ(ti.CalcTimeDiff(1998, 1),
+            ti3.CalcTimeDiff(1998, 1));
+  EXPECT_EQ(ti.IsQuiet(), ti3.IsQuiet());
+
+  // Make sure the two are independent wrt member vars
+  ti.SetQuiet(false);
+  EXPECT_TRUE(ti3.IsQuiet());
+}
+
 #if CYCLUS_IS_PARALLEL
 INSTANTIATE_TEST_CASE_P(TimerTestsParallel, TimerTestsFixture, ::testing::Values(1, 2, 3, 4));
 #else


### PR DESCRIPTION
# Summary of Changes
<!--- In one or more sentences, describe the PR you are submitting. -->
Apparently the progress bar was breaking Cycamore's build (I guess I somehow NEVER checked that, which is odd because usually I'm pretty careful about that, but I guess this slipped through the cracks). This PR addresses the root cause of that issue by adding a non-default copy constructor to the Timer class which explicitly avoids copying the Progress Bar, which is of type `std::unique_ptr`, which cannot be copied (the cause of the error)

## Design Notes
<!--- Describe any design decisions or trade-offs you made. -->


The root cause of this one was apparently:

1. MockSim starts up and tries to copy the Timer
2. Timer doesn't have an explicit copy function (I think) so the compiler tries to invent one (this is normal and standard I think, the same thing happened with the constructors when I just deleted them since they were default)
3. The copy made by the constructor is blind to what's actually going on in timer, so it just says "yeah grab everything, copy it, and throw it over there"
4.  the progress_bar_  object is an std::unique_ptr because the one you found online says it has to be
5. std::unique_ptr objects are non-copyable (I don't know the details about this, but apparently this is the fundamental problem)
6. when the compiler-generated constructor tries to copy the progress bar, the error gets thrown because it can't copy.
7. Because the progress bar can't copy, C++ throws the "deleted function" error, since it THINKS that timer should have that constructor (at least I think it was the constructor that threw the error) but it can't use it because the progress bar couldn't be copied and is blocking it. 
8. Broken Cycamore build.


I had Codex draft up what it thought would be a fix (to give Timer a copy constructor that was careful about the progress bar so the compiler didn't invent one) and it basically looks like this:

```
Timer::Timer(const Timer& other) {
  *this = other;
}

Timer& Timer::operator=(const Timer& other) {
  if (this != &other) {
    ctx_ = other.ctx_;
    time_ = other.time_;
    si_ = other.si_;
    want_snapshot_ = other.want_snapshot_;
    want_kill_ = other.want_kill_;
    tickers_ = other.tickers_;
    cpp_tickers_ = other.cpp_tickers_;
    py_tickers_ = other.py_tickers_;
    build_queue_ = other.build_queue_;
    decom_queue_ = other.decom_queue_;
    progress_bar_.reset();
    progress_update_frequency_ = other.progress_update_frequency_;
    progress_origin_ = other.progress_origin_;
    progress_span_ = other.progress_span_;
    quiet_ = other.quiet_;
  }
  return *this;
}
```

Which on a first pass allows Cyclus and Cycamore to build and both sets of tests to pass. When I asked Codex to explain what it had done, it flagged that the two major steps were this:

```
Timer::Timer(const Timer& other) {
  *this = other;
}
```

Which is the "copy constructor" it was talking about. This function literally just makes a new timer object  (`this`) and then points the new (copied) Timer to `other`  (the original timer, I have no idea why they're named like that but I assume it's some standard). HOWEVER, what does `Timer = Timer` mean? Well, we define that here:

```
Timer& Timer::operator=(const Timer& other) {
  if (this != &other) {
    ctx_ = other.ctx_;
    time_ = other.time_;
    si_ = other.si_;
    want_snapshot_ = other.want_snapshot_;
    want_kill_ = other.want_kill_;
    tickers_ = other.tickers_;
    cpp_tickers_ = other.cpp_tickers_;
    py_tickers_ = other.py_tickers_;
    build_queue_ = other.build_queue_;
    decom_queue_ = other.decom_queue_;
    progress_bar_.reset();
    progress_update_frequency_ = other.progress_update_frequency_;
    progress_origin_ = other.progress_origin_;
    progress_span_ = other.progress_span_;
    quiet_ = other.quiet_;
  }
  return *this;
}
```
Which just steps through everything that a timer is and sets it normally EXCEPT when it gets to the progress bar part. There, it says "don't copy the progress bar. Just reset it and make a new one" so the `std::unique_ptr` never gets a copy called on it and doesn't complain.

Check the box if your change does not break any of the following:
- [x] API for Cyclus modules
- [x] Input files
- [x] Output tables for post processing tools

# Related CEPs and Issues
<!--- Reference the issue that this PR closes, any related CEPs, and describe how this PR contributes to or addresses the problem. -->
Fixes #???


# Associated Developers
<!--- Please mention any developers who should be alerted of this PR. -->
Codex 🖥️


# Testing and Validation
<!--- Describe how this change was tested. -->
I clean built cyclus and cycamore and ran BOTH sets of tests with this new fix. 

- [x] I have read the [Contributing to Cyclus](https://fuelcycle.org/kernel/contributing_to_cyclus.html) guide
- [x] I have compiled and run the code locally
- [ ] I have added or updated relevant tests
- [x] I have added documentation for new or changed features
- [x] This code follows the style guide
- [ ] I have updated the changelog

Reviewers, please refer to the Cyclus [Guide for Reviewers](https://fuelcycle.org/kernel/pr_review.html).