### PR TITLE
Fix CompMath test memory access

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -153,6 +153,7 @@ v1.6.0
 * Fix how Env::GetInstallPath() finds the location of the cyclus installation (#1689)
 * Fix Debian package generation (#1676)
 * Fixed ResBuf.Decay() and added test (#1825)
+* Fixed questionable memory access ()
 
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -153,7 +153,7 @@ v1.6.0
 * Fix how Env::GetInstallPath() finds the location of the cyclus installation (#1689)
 * Fix Debian package generation (#1676)
 * Fixed ResBuf.Decay() and added test (#1825)
-* Fixed questionable memory access ()
+* Fixed questionable memory access (#1965)
 
 
 

--- a/tests/comp_math_tests.cc
+++ b/tests/comp_math_tests.cc
@@ -147,10 +147,9 @@ TEST(CompMathTests, ApplyThresholdMedium) {
   v[3] = 3.0;
 
   // if the threshold is in a reasonable range, it should zero small vals
-  CompMap::iterator it;
-  for (it = v.begin(); it != v.end(); ++it) {
-    EXPECT_NO_THROW(cm::ApplyThreshold(&v, it->second));
-    EXPECT_FLOAT_EQ(0, v[it->first]);
+  for (int key = 1; key <= 3; key++) {
+      EXPECT_NO_THROW(cm::ApplyThreshold(&v, v[key]));
+      EXPECT_FLOAT_EQ(0, v[key]);
   }
 }
 


### PR DESCRIPTION
<!-- If this PR adds a CEP, do not repeat all of the information in the CEP document in the summary. Instead, provide a short description of the CEP's purpose.  -->

# Summary of Changes
`CompMath` tests were throwing sporadical errors in MacOS CI.  Using Valgrind, we tracked it down to questionable memory access in a test and replaced that with a more robust algorithm.


Check the box if your change does not break any of the following:
- [X] API for Cyclus modules
- [X] Input files
- [X] Output tables for post processing tools



- [X] I have read the [Contributing to Cyclus](https://fuelcycle.org/kernel/contributing_to_cyclus.html) guide
- [X] I have compiled and run the code locally
- [N/A] I have added or updated relevant tests
- [N/A] I have added documentation for new or changed features
- [X] This code follows the style guide
- [X] I have updated the changelog

Reviewers, please refer to the Cyclus [Guide for Reviewers](https://fuelcycle.org/kernel/pr_review.html).