### PR TITLE
Set booleans with `true` and `false`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Since last release
 ====================
 
 **Added:**
+* Added a boolean-specific Query function to infile_tree.h to support archetype bools using true and false (#1970)
 * Added a copy constructor to Timer to allow MockSim to copy it without upsetting the progress bar (#1961)
 * Added progress bar to the simulation loop (#1912)
 * Added a warning for when a facility trades with itself (#1895)

--- a/src/infile_tree.h
+++ b/src/infile_tree.h
@@ -90,6 +90,18 @@ inline std::string Query(InfileTree* tree, std::string query, int index) {
   return tree->GetString(query, index);
 }
 
+template <> inline bool Query(InfileTree* tree, std::string query, int index) {
+  std::string s = tree->GetString(query, index);
+  boost::trim(s);
+  if (s == "true" || s == "1") {
+    return true;
+  }
+  if (s == "false" || s == "0") {
+    return false;
+  }
+  return boost::lexical_cast<bool>(s.c_str());
+}
+
 template <> inline int Query(InfileTree* tree, std::string query, int index) {
   std::string s = tree->GetString(query, index);
   boost::trim(s);

--- a/src/infile_tree.h
+++ b/src/infile_tree.h
@@ -93,10 +93,10 @@ inline std::string Query(InfileTree* tree, std::string query, int index) {
 template <> inline bool Query(InfileTree* tree, std::string query, int index) {
   std::string s = tree->GetString(query, index);
   boost::trim(s);
-  if (s == "true" || s == "1") {
+  if (s == "true") {
     return true;
   }
-  if (s == "false" || s == "0") {
+  if (s == "false") {
     return false;
   }
   return boost::lexical_cast<bool>(s.c_str());

--- a/src/material.cc
+++ b/src/material.cc
@@ -156,7 +156,6 @@ void Material::Absorb(Material::Ptr mat) {
 
 void Material::Transmute(Composition::Ptr c) {
   comp_ = c;
-  tracker_.Modify();
 
   // Presumably the user has chosen the new composition to be accurate for
   // the current simulation time.  The next call to decay should not include
@@ -168,6 +167,9 @@ void Material::Transmute(Composition::Ptr c) {
   if (ctx_ != NULL && ctx_->time() > prev_decay_time_) {
     prev_decay_time_ = ctx_->time();
   }
+
+  // Record the composition and updated decay timestamp together.
+  tracker_.Modify();
 }
 
 Resource::Ptr Material::PackageExtract(double qty,

--- a/tests/infile_tree_tests.cc
+++ b/tests/infile_tree_tests.cc
@@ -152,3 +152,25 @@ TEST_F(InfileTreeTest, optional_queries) {
   EXPECT_EQ(str_val, OptionalQuery<string>(&qe, str_str, str_other));
   EXPECT_EQ(str_other, OptionalQuery<string>(&qe, other, str_other));
 }
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+TEST_F(InfileTreeTest, bool_queries) {
+  using cyclus::Query;
+
+  std::stringstream ss;
+  ss << "<root>"
+     << "<true> true </true>"
+     << "<false>false</false>"
+     << "<one>1</one>"
+     << "<zero>0</zero>"
+     << "</root>";
+
+  cyclus::XMLParser parser;
+  parser.Init(ss);
+  cyclus::InfileTree qe(parser);
+
+  EXPECT_TRUE(Query<bool>(&qe, "true"));
+  EXPECT_FALSE(Query<bool>(&qe, "false"));
+  EXPECT_TRUE(Query<bool>(&qe, "one"));
+  EXPECT_FALSE(Query<bool>(&qe, "zero"));
+}


### PR DESCRIPTION
# Summary of Changes
<!--- In one or more sentences, describe the PR you are submitting. -->
This PR adds a boolean-specific Query function to infile_tree.h which cycpp.py can grab to allow cyclus XML input for booleans to be entered as `true` and `false` instead of just `1` and `0`.

This PR also switches the order of the `prev_decay_time` update and the record inside `Material::Transmute`. This was done here instead of in its own PR so that I could give Amer a branch that worked for him to continue making progress. I figured since it was such a small change it was fine to glob onto this.

## Design Notes
<!--- Describe any design decisions or trade-offs you made. -->
There are maybe (not necessarily "probably") more tests which could be done as a part of a more thorough investigation about how this all works and whether other variables have similar problems, but this PR is meant mostly as a patch to get things working properly quickly to support Amer.

The bug that this fixes was discovered by Cypher use (Cypher tries to insert `true` and `false` not `1` or `0`) and the options were either to change cypher (worse, because 1 and 0 are less obviously booleans in the XML) or to do this in Cyclus.

The issue describes `t` and `f` as possibilities, but some testing during implementation revealed that this broke something else if you tried it, and that was a rabbit hole I did not want to go down, since this is a little time-sensitive.

### NOTE: 
This PR does NOT make it so you can use `True` or `False` or `TRUE` or `FALSE` (or `trUE` or `FaLsE`). It must be `true` or `false` or `1` or `0` and that's an unrelated thing with the way Cyclus handles booleans in general. If we want to fix that we (probably) can, but I would STRONGLY suggest that we do so as a separate issue with a separate PR since that feels like yet another rabbit hole.

Check the box if your change does not break any of the following:
- [X] API for Cyclus modules
- [X] Input files
- [X] Output tables for post processing tools

# Related CEPs and Issues
<!--- Reference the issue that this PR closes, any related CEPs, and describe how this PR contributes to or addresses the problem. -->
Fixes #1969 

# Associated Developers
<!--- Please mention any developers who should be alerted of this PR. -->
Codex


# Testing and Validation
<!--- Describe how this change was tested. -->
Manual testing and unit tests both added. Code compiles and runs on my computer. Tests all pass.

- [X] I have read the [Contributing to Cyclus](https://fuelcycle.org/kernel/contributing_to_cyclus.html) guide
- [X] I have compiled and run the code locally
- [X] I have added or updated relevant tests
- [ ] I have added documentation for new or changed features
- [X] This code follows the style guide
- [x] I have updated the changelog

Reviewers, please refer to the Cyclus [Guide for Reviewers](https://fuelcycle.org/kernel/pr_review.html).