### PR TITLE
Add definition of full to resource buffer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,7 @@ Since last release
 * New composition specification based on single nuclide (#1949) 
 * Added ability to calcuate a time shift between the start time and some other time stamp (#1907)
 * Users can specify for random seed to be created for random number generation (#1950)
+* Introduced a definition of "full" for a resource buffer, which is a threshold quantity that can be set by the user (#)
 
 **Changed:**
 * Clarify behavior of `Material::Absorb()` with respect to decay (#1966)

--- a/src/toolkit/res_buf.h
+++ b/src/toolkit/res_buf.h
@@ -63,6 +63,7 @@ template <class T> class ResBuf {
   ResBuf(bool is_bulk = false, bool keep_pkg = false)
       : qty_(0), is_bulk_(is_bulk) {
     capacity(INFINITY);
+    full_threshold(0);
     keep_packaging(keep_pkg);
   }
 
@@ -92,6 +93,30 @@ template <class T> class ResBuf {
     cap_ = cap;
   }
 
+  /// Returns the threhold resource quantity that buffer must hold 
+  /// to be considered full (units based on constituent resource objects' units).
+  /// Never throws.
+  inline double full_threshold() const { return full_threshold_; }
+
+  /// Sets the quantity this buffer must hold to be considered full 
+  // (units based on constituent resource objects' units).
+  ///
+  /// @throws ValueError the new capacity is lower (by eps_rsrc()) than the
+  /// quantity of resources that exist in the buffer.
+  void full_threshold(double full_threshold) {
+    if (full_threshold < 0) {
+      throw ValueError("full threshold must not be negative");
+    }
+
+    if (cap_ - full_threshold < eps_rsrc()) {
+      std::stringstream ss;
+      ss << std::setprecision(17) << "new full threshold " << full_threshold
+         << " higher than capacity " << capacity();
+      throw ValueError(ss.str());
+    }
+    full_threshold_ = full_threshold;
+  }
+
   /// Sets whether the buffer should keep packaged resources
   void keep_packaging(bool keep_packaging) {
     if (is_bulk_ && keep_packaging) {
@@ -119,6 +144,9 @@ template <class T> class ResBuf {
 
   /// Returns true if there are no resources in the buffer.
   inline bool empty() const { return rs_.empty(); }
+
+  /// Returns true if the buffer is full (i.e. quantity >= full_threshold).
+  inline bool full() const { return qty_ >= full_threshold_; }
 
   /// Pops and returns the specified quantity from the buffer as a vector of
   /// resources.
@@ -370,6 +398,9 @@ template <class T> class ResBuf {
 
   /// Maximum quantity of resources this buffer can hold
   double cap_;
+
+  /// Threshold quantity at which the buffer is considered full
+  double full_threshold_;
 
   /// Whether materials should be stored as a single squashed item or as
   /// individual resource objects

--- a/tests/toolkit/res_buf_tests.cc
+++ b/tests/toolkit/res_buf_tests.cc
@@ -49,6 +49,45 @@ TEST_F(ProductBufTest, Getset_capacityEmpty) {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+TEST_F(ProductBufTest, set_full_threshold_ExceptionsEmpty) {
+  EXPECT_THROW(store_.full_threshold(neg_full), ValueError);
+  EXPECT_NO_THROW(store_.full_threshold(zero_full));
+  EXPECT_NO_THROW(store_.full_threshold(full));
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+TEST_F(ProductBufTest, set_full_threshold_ExceptionsFilled) {
+  EXPECT_THROW(filled_store_.full_threshold(hi_full), ValueError);
+  EXPECT_NO_THROW(filled_store_.full_threshold(full));
+}
+
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+TEST_F(ProductBufTest, GetFullThreshold_ExceptionsEmpty) {
+  ASSERT_NO_THROW(store_.full_threshold());
+  store_.full_threshold(zero_full);
+  ASSERT_NO_THROW(store_.full_threshold());
+  store_.full_threshold(zero_full);
+  ASSERT_NO_THROW(store_.full_threshold());
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+TEST_F(ProductBufTest, GetFullThreshold_InitialEmpty) {
+  EXPECT_DOUBLE_EQ(store_.full_threshold(), 0.0);
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+TEST_F(ProductBufTest, Getset_full_thresholdEmpty) {
+  store_.full_threshold(zero_full);
+  EXPECT_DOUBLE_EQ(store_.full_threshold(), zero_full);
+
+  store_.full_threshold(full);
+  EXPECT_DOUBLE_EQ(store_.full_threshold(), full);
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TEST_F(ProductBufTest, GetSpace_Empty) {
   ASSERT_NO_THROW(store_.space());
   EXPECT_DOUBLE_EQ(store_.space(), INFINITY);

--- a/tests/toolkit/res_buf_tests.h
+++ b/tests/toolkit/res_buf_tests.h
@@ -35,6 +35,7 @@ class ProductBufTest : public ::testing::Test {
   ResBuf<Product> filled_store_;
 
   double neg_cap, zero_cap, cap, low_cap;
+  double neg_full, zero_full, full, hi_full;
   double exact_qty;  // mass in filled_store_
   double exact_qty_under;  // mass in filled_store - 0.9*eps_rsrc()
   double exact_qty_over;  // mass in filled_store + 0.9*eps_rsrc()
@@ -57,6 +58,11 @@ class ProductBufTest : public ::testing::Test {
             1;  // should be higher than mat1+mat2 masses
       low_cap = mat1_->quantity() + mat2_->quantity() -
                 1;  // should be lower than mat1_mat2 masses
+
+      neg_full = -1;
+      zero_full = 0;
+      full = cap * 0.5;
+      hi_full = cap * 1.1;
 
       undereps = 0.9 * eps_rsrc();
       overeps = 1.1 * eps_rsrc();


### PR DESCRIPTION
# Summary of Changes
Adding the notion of a threshold that defines when a resource buffer is considered full, different from being filled 100% to capacity.

## Design Notes
The default threshold is 0 so that a resource buffer is considered full if it contains any amount of material.

Check the box if your change does not break any of the following:
- [X] API for Cyclus modules
- [X] Input files
- [X] Output tables for post processing tools


- [X] I have read the [Contributing to Cyclus](https://fuelcycle.org/kernel/contributing_to_cyclus.html) guide
- [X] I have compiled and run the code locally
- [X] I have added or updated relevant tests
- [X] I have added documentation for new or changed features
- [X] This code follows the style guide
- [X] I have updated the changelog

Reviewers, please refer to the Cyclus [Guide for Reviewers](https://fuelcycle.org/kernel/pr_review.html).